### PR TITLE
@message must contain unparsed event

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -8,6 +8,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :host, :string,  :default => 'localhost'
   config_param :port, :integer, :default => 9200
   config_param :logstash_format, :bool, :default => false
+  config_param :logstash_include_message, :bool, :default => false
   config_param :type_name, :string, :default => "fluentd"
   config_param :index_name, :string, :default => "fluentd"
 
@@ -40,7 +41,9 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     chunk.msgpack_each do |tag, time, record|
       if @logstash_format
         record.merge!({"@timestamp" => Time.at(time).to_datetime.to_s})
-        record.merge!({"@message" => record.dup})
+        if @logstash_include_message
+          record.merge!({"@message" => record.dup.to_s})
+        end
         target_index = "logstash-#{Time.at(time).getutc.strftime("%Y.%m.%d")}"
       else
         target_index = @index_name

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -115,6 +115,14 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_nil(index_cmds[1]['@timestamp'])
   end
 
+  def test_doesnt_add_logstash_message_by_default
+    driver.configure("logstash_format true\n")
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert_nil(index_cmds[1]['@message'])
+  end
+
   def test_adds_logstash_timestamp_when_configured
     driver.configure("logstash_format true\n")
     stub_elastic
@@ -126,13 +134,13 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   def test_adds_logstash_message_when_configured
-    driver.configure("logstash_format true\n")
+    driver.configure("logstash_format true\nlogstash_include_message  true")
     stub_elastic
     ts = DateTime.now.to_s
     driver.emit(sample_record)
     driver.run
     assert(index_cmds[1].has_key? '@message')
-    assert_equal(index_cmds[1]['@message'], sample_record.merge!({'@timestamp' => ts}))
+    assert_equal(index_cmds[1]['@message'], sample_record.merge!({'@timestamp' => ts}).to_s)
   end
 
   def test_doesnt_add_tag_key_by_default


### PR DESCRIPTION
Normally, Kibana will show you Logstash's @message field, since @message contains your unparsed event.
