### PR TITLE
Add '@' symbol before key values

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -41,6 +41,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
 
     chunk.msgpack_each do |tag, time, record|
       if @logstash_format
+        record.keys.each { |k| record['@'+k]=record[k]; record.delete(k) }
         record.merge!({"@timestamp" => Time.at(time).to_datetime.to_s})
         target_index = "#{@logstash_prefix}-#{Time.at(time).getutc.strftime("%Y.%m.%d")}"
       else


### PR DESCRIPTION
This is more compatible with the native behavior of logstash when exporting into elasticsearch. Also, some other utilities (like Kibana) expect keys to normally be proceeded by an @ symbol. 
