### PR TITLE
add logstash_dateformat option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ logstash_prefix mylogs # defaults to "logstash"
 
 By default, the records inserted into index `logstash-YYMMDD`. This option allows to insert into specified index like `mylogs-YYMMDD`.
 
+```
+logstash_dateformat %Y.%m. # defaults to "%Y.%m.%d"
+```
+
+By default, the records inserted into index `logstash-YYMMDD`. This option allows to insert into specified index like `logstash-YYYYMM` for a monthly index.
+
 ---
 
 ```

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -9,6 +9,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :port, :integer, :default => 9200
   config_param :logstash_format, :bool, :default => false
   config_param :logstash_prefix, :string, :default => "logstash"
+  config_param :logstash_dateformat, :string, :default => "%Y.%m.%d" 
   config_param :type_name, :string, :default => "fluentd"
   config_param :index_name, :string, :default => "fluentd"
   config_param :id_key, :string, :default => nil
@@ -42,7 +43,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     chunk.msgpack_each do |tag, time, record|
       if @logstash_format
         record.merge!({"@timestamp" => Time.at(time).to_datetime.to_s})
-        target_index = "#{@logstash_prefix}-#{Time.at(time).getutc.strftime("%Y.%m.%d")}"
+        target_index = "#{@logstash_prefix}-#{Time.at(time).getutc.strftime("#{@logstash_dateformat}")}"
       else
         target_index = @index_name
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -122,6 +122,29 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
+  
+    def test_writes_to_logstash_index_with_specified_dateformat
+    driver.configure("logstash_format true\n")
+    driver.configure("logstash_dateformat %Y.%m\n")
+    time = Time.parse Date.today.to_s
+    logstash_index = "logstash-#{time.getutc.strftime("%Y.%m")}"
+    stub_elastic
+    driver.emit(sample_record, time)
+    driver.run
+    assert_equal(logstash_index, index_cmds.first['index']['_index'])
+  end
+
+  def test_writes_to_logstash_index_with_specified_prefix_and_dateformat
+    driver.configure("logstash_format true\n")
+    driver.configure("logstash_prefix myprefix\n")
+    driver.configure("logstash_dateformat %Y.%m\n")
+    time = Time.parse Date.today.to_s
+    logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m")}"
+    stub_elastic
+    driver.emit(sample_record, time)
+    driver.run
+    assert_equal(logstash_index, index_cmds.first['index']['_index'])
+  end
 
   def test_doesnt_add_logstash_timestamp_by_default
     stub_elastic


### PR DESCRIPTION
Add option to define dateformat for logstash index if weekly or monthly index is needed.
