### PR TITLE
added support for parent relations

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -13,6 +13,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :type_name, :string, :default => "fluentd"
   config_param :index_name, :string, :default => "fluentd"
   config_param :id_key, :string, :default => nil
+  config_param :parent_key, :string, :default => nil
 
   include Fluent::SetTagKeyMixin
   config_set_default :include_tag_key, false
@@ -56,6 +57,10 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       if @id_key && record[@id_key]
         meta['index']['_id'] = record[@id_key]
       end
+      if @parent_key && record[@parent_key]
+        meta['index']['_parent'] = record[@parent_key]
+      end
+
       bulk_message << Yajl::Encoder.encode(meta)
       bulk_message << Yajl::Encoder.encode(record)
     end


### PR DESCRIPTION
Our logs use [relations](http://www.elasticsearch.org/blog/managing-relations-inside-elasticsearch/) to manage hierarchical logging types. This requires us to use the `_parent` field of the bulk post api.

I have modified the plugin to allow a configurable parent field. It is used identically to the id_key config param. I was able to re-use the test cases for id_key as they are identical to the behaviour of parent_key. 
