### PR TITLE
add type_key config

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -13,6 +13,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
   config_param :utc_index, :bool, :default => true
   config_param :type_name, :string, :default => "fluentd"
+  config_param :type_key, :string, :default => nil
   config_param :index_name, :string, :default => "fluentd"
   config_param :id_key, :string, :default => nil
   config_param :parent_key, :string, :default => nil
@@ -74,7 +75,10 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
         record.merge!(@tag_key => tag)
       end
 
-      meta = { "index" => {"_index" => target_index, "_type" => type_name} }
+      if @type_key && record[@type_key]
+        type_name = record[@type_key]
+      end
+      meta = { "index" => {"_index" => target_index, "_type" => type_name } }
       if @id_key && record[@id_key]
         meta['index']['_id'] = record[@id_key]
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -325,4 +325,13 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run
     }
   end
+
+  def test_use_type_key_when_configured
+    driver.configure("type_key parent_id\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert_equal(index_cmds[0]['index']['_type'], 'parent')
+  end
 end


### PR DESCRIPTION
I propose new config param, type_key.
It is useful to divide types according to record's value.

```
<match my.logs>
  type elasticsearch
  include_tag_key true
  tag_key _tag
  type_key _tag
</match>
```
