### PR TITLE
Support custom sharding (not just logstash)

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,13 @@
 ## Changelog
 
-### Future
+### 0.4.0
+
+- allow sharding with custom format (shard, shard_format, shard_prefix, shard_dateformat)
+- allow insertion of custom timstamp key with a custom format (time_key, time_format)
+- move utc_index out of logstash handler
+- treat logstash_format as a shorthand for existing configuration keys
+
+### 0.3.1
 
 - do not generate @timestamp if already part of message (#35)
 
@@ -30,7 +37,6 @@
 ### 0.1.1
 
 - fix timezone in logstash key
-
 
 ### 0.1.0
 

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = 'fluent-plugin-elasticsearch'
-  s.version       = '0.3.1'
+  s.version       = '0.4.0'
   s.authors       = ['diogo', 'pitr']
   s.email         = ['team@uken.com']
   s.description   = %q{ElasticSearch output plugin for Fluent event collector}

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = 'fluent-plugin-elasticsearch'
-  s.version       = '0.3.0'
+  s.version       = '0.3.1'
   s.authors       = ['diogo', 'pitr']
   s.email         = ['team@uken.com']
   s.description   = %q{ElasticSearch output plugin for Fluent event collector}

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -8,15 +8,25 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
 
   config_param :host, :string,  :default => 'localhost'
   config_param :port, :integer, :default => 9200
-  config_param :logstash_format, :bool, :default => false
-  config_param :logstash_prefix, :string, :default => "logstash"
-  config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
-  config_param :utc_index, :bool, :default => true
+  config_param :time_key, :string, :default => nil
+  config_param :time_format, :string, :default => nil
   config_param :type_name, :string, :default => "fluentd"
   config_param :index_name, :string, :default => "fluentd"
   config_param :id_key, :string, :default => nil
   config_param :parent_key, :string, :default => nil
   config_param :hosts, :string, :default => nil
+
+  # Allow automatic sharding of indexes
+  config_param :shard, :bool, :default => false
+  config_param :shard_format, :string, :default => "%{prefix}-%{date}"
+  config_param :shard_prefix, :string, :default => nil
+  config_param :shard_dateformat, :string, :default => "%Y.%m.%d"
+  config_param :utc_index, :bool, :default => true
+
+  # Logstash-specific commands to create pre-defined behavior
+  config_param :logstash_format, :bool, :default => false
+  config_param :logstash_prefix, :string, :default => "logstash"
+  config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
 
   include Fluent::SetTagKeyMixin
   config_set_default :include_tag_key, false
@@ -67,19 +77,51 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     bulk_message = []
 
     chunk.msgpack_each do |tag, time, record|
+      target_index = @index_name
+
+      # Pre-defined logstash compatibility
       if @logstash_format
-        record.merge!({"@timestamp" => Time.at(time).to_datetime.to_s}) unless record.has_key?("@timestamp")
-        if @utc_index
-          target_index = "#{@logstash_prefix}-#{Time.at(time).getutc.strftime("#{@logstash_dateformat}")}"
-        else
-          target_index = "#{@logstash_prefix}-#{Time.at(time).strftime("#{@logstash_dateformat}")}"
-        end
-      else
-        target_index = @index_name
+        @time_key = "@timestamp"
+        @time_format = nil
+        @shard = true
+        @shard_prefix = @logstash_prefix
+        @shard_dateformat = @logstash_dateformat
+        @shard_format = "%{prefix}-%{date}"
       end
 
+      # Merge in time key if required
+      if @time_key
+        if @time_format
+          record.merge!({@time_key => Time.at(time).strftime("#{@time_format}")}) unless record.has_key?(@time_key)
+        else
+          record.merge!({@time_key => Time.at(time).to_datetime.to_s}) unless record.has_key?(@time_key)
+        end
+      end
+
+      # Merge in tag key if required
       if @include_tag_key
         record.merge!(@tag_key => tag)
+      end
+
+      # Shard index key if required
+      if @shard
+        shard_time = Time.at(time)
+        if @utc_index
+          shard_time!.getutc
+        end
+
+        # If shard_prefix is nil, we inherit the index_name
+        if @shard_prefix.nil?
+          @shard_prefix = @index_name
+        end
+
+        shard_index_context = {
+            prefix: @shard_prefix,
+            date: shard_time.strftime("#{@shard_dateformat}"),
+            index: @index_name,
+            type: @type_name
+        }
+        target_index = @shard_format % shard_index_context
       end
 
       meta = { "index" => {"_index" => target_index, "_type" => type_name} }

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -107,7 +107,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       if @shard
         shard_time = Time.at(time)
         if @utc_index
-          shard_time!.getutc
+          shard_time.getutc!
         end
 
         # If shard_prefix is nil, we inherit the index_name

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -107,7 +107,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       if @shard
         shard_time = Time.at(time)
         if @utc_index
-          shard_time.getutc!
+          shard_time.utc
         end
 
         # If shard_prefix is nil, we inherit the index_name

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -158,8 +158,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   def test_writes_with_sharding
-    driver.configure("index_name myindex\n")
-    driver.configure("shard true\n")
+    driver.configure("index_name myindex
+                      shard true")
     time = Time.parse Date.today.to_s
     shard_index = "myindex-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic_ping
@@ -170,8 +170,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   def test_writes_with_sharding_with_specified_prefix
-    driver.configure("shard true\n")
-    driver.configure("shard_prefix myprefix\n")
+    driver.configure("shard true
+                      shard_prefix myprefix")
     time = Time.parse Date.today.to_s
     shard_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic_ping


### PR DESCRIPTION
0.3.1 allows index sharding by date, but the method is named for logstash which seems incorrect and restrictive. This PR generalizes the code but still allows quick logstash configuration in the same way as before, while leaving the door open for other pre-configurations as well (flume?).