### PR TITLE
Add auth + all other ElasticSearch options including URI hosts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,27 @@ This plugin creates ElasticSearch indices by merely writing to them. Consider us
 hosts host1:port1,host2:port2,host3:port3
 ```
 
+or
+
+```
+hosts https://customhost.com:443/path,https://username:password@host-failover.com:443
+```
+
 You can specify multiple elasticsearch hosts with separator ",".
 
-If you specify multiple hosts, plugin writes to elasticsearch with load balanced. (it's elasticsearch-ruby's feature, default is round-robin.)
+If you specify multiple hosts, this plugin will load balance updates to elasticsearch. This is an [elasticsearch-ruby](https://github.com/elasticsearch/elasticsearch-ruby) feature, the default strategy is round-robin.
 
 If you specify this option, host and port options are ignored.
 
 ```
 user demo
 password secret
+path /elastic_search/
+scheme https
 ```
 
-You can specify user and password for HTTP basic auth. This is also compatible with `hosts` key above, which you can specify in the following form:
+You can specify user and password for HTTP basic auth. If used in conjunction with a hosts list, then these options will be used by default i.e. if you do not provide any of these options within the hosts listed.
 
-```
-hosts host1:port1:user1:password1,host2:port2,host3:port3
-```
-
-`user` and `password` would be used by default, if they are not provided in a host definition string.
-
-*Note:* it is not possible to have a host-specific password with either `,` or `:` charcters in it.
 
 ```
 logstash_format true # defaults to false

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -2,6 +2,7 @@
 require 'date'
 require 'patron'
 require 'elasticsearch'
+require 'uri'
 
 class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   Fluent::Plugin.register_output('elasticsearch', self)
@@ -10,6 +11,9 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :port, :integer, :default => 9200
   config_param :user, :string, :default => nil
   config_param :password, :string, :default => nil
+  config_param :path, :string, :default => nil
+  config_param :scheme, :string, :default => 'http'
+  config_param :hosts, :string, :default => nil
   config_param :logstash_format, :bool, :default => false
   config_param :logstash_prefix, :string, :default => "logstash"
   config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
@@ -18,7 +22,6 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :index_name, :string, :default => "fluentd"
   config_param :id_key, :string, :default => nil
   config_param :parent_key, :string, :default => nil
-  config_param :hosts, :string, :default => nil
   config_param :request_timeout, :time, :default => 5
 
   include Fluent::SetTagKeyMixin
@@ -39,39 +42,51 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   def client
     @_es ||= begin
       adapter_conf = lambda {|f| f.adapter :patron }
-      transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new({ hosts: get_hosts,
-                                                                           options: {
-                                                                             reload_connections: true,
-                                                                             retry_on_failure: 5,
-                                                                             transport_options: {
-                                                                               request: { timeout: @request_timeout }
-                                                                             }
-                                                                          }}, &adapter_conf)
+      transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(get_connection_options.merge(
+                                                                          options: {
+                                                                            reload_connections: true,
+                                                                            retry_on_failure: 5,
+                                                                            transport_options: {
+                                                                              request: { timeout: @request_timeout }
+                                                                            }
+                                                                          }), &adapter_conf)
       Elasticsearch::Client.new transport: transport
     end
-    raise "Can not reach Elasticsearch cluster (#{@host}:#{@port})!" unless @_es.ping
+    raise "Can not reach Elasticsearch cluster (#{get_connection_options.inspect})!" unless @_es.ping
     @_es
   end
 
-  def get_hosts
-    if @hosts
-        @hosts.split(',').map do |x|
-          hp = x.split(':')
+  def get_connection_options
+    raise "`password` must be present if `user` is present" if @user && !@password
+
+    hosts = if @hosts
+      @hosts.split(',').map do |host_str|
+        # Support legacy hosts format host:port,host:port,host:port...
+        if host_str.match(%r{^[^:]+\:\d+$})
           {
-            host: hp[0],
-            port: hp[1]     || @port,
-            user: hp[2]     || @user,
-            password: hp[3] || @password
+            host:   host_str.split(':')[0],
+            port:   (host_str.split(':')[1] || @port).to_i,
+            scheme: @scheme
           }
-        end.compact
+        else
+          # New hosts format expects URLs such as http://logs.foo.com,https://john:pass@logs2.foo.com/elastic
+          uri = URI(host_str)
+          %w(user password path).inject(host: uri.host, port: uri.port, scheme: uri.scheme) do |hash, key|
+            hash[key.to_sym] = uri.public_send(key) unless uri.public_send(key).nil? || uri.public_send(key) == ''
+            hash
+          end
+        end
+      end.compact
     else
-      if @user
-        raise "`password` must be present if `user` is present" unless @password
-        [{host: @host, port: @port, user: @user, password: @password }]
-      else
-        [{host: @host, port: @port }]
-      end
+      [{host: @host, port: @port, scheme: @scheme}]
+    end.each do |host|
+      host.merge!(user: @user, password: @password) if !host[:user] && @user
+      host.merge!(path: @path) if !host[:path] && @path
     end
+
+    {
+      hosts: hosts
+    }
   end
 
   def format(tag, time, record)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -6,10 +6,10 @@ require 'fluent/plugin/out_elasticsearch'
 require 'webmock/test_unit'
 require 'date'
 
-require 'helper'
-
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("../..", __FILE__)
 $:.push File.dirname(__FILE__)
+
+require 'helper'
 
 WebMock.disable_net_connect!
 
@@ -53,6 +53,87 @@ class ElasticsearchOutput < Test::Unit::TestCase
       index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
       @index_command_counts[url] += index_cmds.size
     end
+  end
+
+  def test_configure
+    config = %{
+      host     logs.google.com
+      port     777
+      scheme   https
+      path     /es/
+      user     john
+      password doe
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 'logs.google.com', instance.host
+    assert_equal 777, instance.port
+    assert_equal 'https', instance.scheme
+    assert_equal '/es/', instance.path
+    assert_equal 'john', instance.user
+    assert_equal 'doe', instance.password
+  end
+
+  def test_legacy_hosts_list
+    config = %{
+      hosts    host1:50,host2:100
+      scheme   https
+      path     /es/
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 2, instance.get_connection_options[:hosts].length
+    host1, host2 = instance.get_connection_options[:hosts]
+
+    assert_equal 'host1', host1[:host]
+    assert_equal 50, host1[:port]
+    assert_equal 'https', host1[:scheme]
+    assert_equal '/es/', host2[:path]
+  end
+
+  def test_hosts_list
+    config = %{
+      hosts    https://john:password@host1:443/elastic/,http://host2
+      path     /default_path
+      user     default_user
+      password default_password
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 2, instance.get_connection_options[:hosts].length
+    host1, host2 = instance.get_connection_options[:hosts]
+
+    assert_equal 'host1', host1[:host]
+    assert_equal 443, host1[:port]
+    assert_equal 'https', host1[:scheme]
+    assert_equal 'john', host1[:user]
+    assert_equal 'password', host1[:password]
+    assert_equal '/elastic/', host1[:path]
+
+    assert_equal 'host2', host2[:host]
+    assert_equal 'http', host2[:scheme]
+    assert_equal 'default_user', host2[:user]
+    assert_equal 'default_password', host2[:password]
+    assert_equal '/default_path', host2[:path]
+  end
+
+  def test_single_host_params_and_defaults
+    config = %{
+      host     logs.google.com
+      user     john
+      password doe
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 1, instance.get_connection_options[:hosts].length
+    host1 = instance.get_connection_options[:hosts][0]
+
+    assert_equal 'logs.google.com', host1[:host]
+    assert_equal 9200, host1[:port]
+    assert_equal 'http', host1[:scheme]
+    assert_equal 'john', host1[:user]
+    assert_equal 'doe', host1[:password]
+    assert_equal nil, host1[:path]
   end
 
   def test_writes_to_default_index


### PR DESCRIPTION
This PR builds on [the auth PR](https://github.com/uken/fluent-plugin-elasticsearch/pull/56) of @farcaller, but completes the functionality required to support all possible ES connection options.  You will also notice I abandoned the hosts support using three consecutive colons to delimit the fields as I do not think it's a very scalable solution, so have instead opted for the use of a `URI`.

Specifically this PR provides support for:
- username & password
- path
- scheme
- list of full URIs within the hosts option such as http://john:password@logs:9200/es/

There is also test coverage.
