### PR TITLE
Add support Elasticsearch 1.x version of gem

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fluentd', '~> 0'
   s.add_runtime_dependency 'patron', '~> 0'
-  s.add_runtime_dependency 'elasticsearch', '~> 0'
+  s.add_runtime_dependency 'elasticsearch', '>= 0'
 
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'webmock', '~> 1'


### PR DESCRIPTION
Hi

It seems it doesn't support recent gems of elasticsearch.
c.f. https://rubygems.org/gems/elasticsearch/versions

Thus, this patch adds supporting elasticsearch 1.x gems.
