### PR TITLE
Allow for configuring the "reload_on_failure" and "reload_connections" flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ You can specify HTTP request timeout.
 
 This is useful when Elasticsearch cannot return response for bulk request within the default of 5 seconds.
 
+```
+reload_connections false # defaults to true
+```
+
+You can tune how the elasticsearch-transport host reloading feature works. By default it will reload the host list from the server
+every 10,000th request to spread the load. This can be an issue if your ElasticSearch cluster is behind a Reverse Proxy,
+as fluentd process may not have direct network access to the ElasticSearch nodes.
+
+```
+reload_on_failure true # defaults to false
+```
+
+Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the
+request, this can be useful to quickly remove a dead node from the list of addresses.
+
 ---
 
 ```

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -25,6 +25,8 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :id_key, :string, :default => nil
   config_param :parent_key, :string, :default => nil
   config_param :request_timeout, :time, :default => 5
+  config_param :reload_connections, :bool, :default => true
+  config_param :reload_on_failure, :bool, :default => false
 
   include Fluent::SetTagKeyMixin
   config_set_default :include_tag_key, false
@@ -46,7 +48,8 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       adapter_conf = lambda {|f| f.adapter :patron }
       transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(get_connection_options.merge(
                                                                           options: {
-                                                                            reload_connections: true,
+                                                                            reload_connections: @reload_connections,
+                                                                            reload_on_failure: @reload_on_failure,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {
                                                                               request: { timeout: @request_timeout }


### PR DESCRIPTION
Allow for configuring the "reload_on_failure" and "reload_connections" flags. 
Useful if your ElasticSearch cluster is behind a load balancer and does not have direct access to the network addresses of the nodes.
