### PR TITLE
Added ability to specify how many documents are inserted in one bulk cal...

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ reload_on_failure true # defaults to false
 Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the
 request, this can be useful to quickly remove a dead node from the list of addresses.
 
+```
+bulk_size 1000 # defaults to 500
+```
+
+Specify how many records are inserted into ElasticSearch at once using a bulk request.
+
 ---
 
 ```


### PR DESCRIPTION
I needed this feature to send up smaller chunks to ElasticSearch at a time, otherwise failed huge requests keep backing up and nothing ever gets sent. I don't know if other people would benefit from this, but it makes our infrastructure a lot more reliable. Let me know what changes I should make to get it up to snuff.
