### PR TITLE
add msec_key to have msec in @timestamp

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -124,9 +124,9 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     chunk.msgpack_each do |tag, time, record|
       next unless record.is_a? Hash
       if @logstash_format
-        if record[@msec_key]
+        if record.has_key?("@msec_key")
           record.merge!({"@timestamp" => Time.at(time, record[@msec_key].to_i * 1000).strftime("%Y-%m-%dT%H:%M:%S.%L%z")})
-          record.delete(@msec_key)
+          record.delete("@msec_key")
         elsif record.has_key?("@timestamp")
           time = Time.parse record["@timestamp"]
         else


### PR DESCRIPTION
If the plugin send time with format "%Y-%m-%dT%H:%M:%S.%L%z" which include milli second,
Elasticsearch is able to store the time with milli second.

But normally, 'time' passed by fluentd doesn't include milli second information. So, milli second information should be include as a separated value.

This patch enables fluentd-plugin-elasticsearch to make a 'timestamp' value from 'time' and the separated milli second value.