### PR TITLE
Support webmock 1.20.3+

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -30,7 +30,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   def stub_elastic_ping(url="http://localhost:9200")
-    stub_request(:head, url).with.to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:head, url).to_return(:status => 200, :body => "", :headers => {})
   end
 
   def stub_elastic(url="http://localhost:9200/_bulk")


### PR DESCRIPTION
When running bundle install it pulled webmock 1.20.4 that produced the following errors when running the tests:

```
test_adds_id_key_when_configured(ElasticsearchOutput):
ArgumentError: #with method invoked with no arguments. Either options hash or block must be specified.
    /path/to/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.20.4/lib/webmock/request_pattern.rb:23:in `with'
    /path/to/.rvm/gems/ruby-1.9.3-p551/gems/webmock-1.20.4/lib/webmock/request_stub.rb:13:in `with'
    test/plugin/test_out_elasticsearch.rb:33:in `stub_elastic_ping'
    test/plugin/test_out_elasticsearch.rb:356:in `test_adds_id_key_when_configured'
```
