### PR TITLE
Convert binary strings to utf-8 before creating json

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fluentd', '>= 0.10.43'
   s.add_runtime_dependency 'patron', '~> 0'
   s.add_runtime_dependency 'elasticsearch', '>= 0'
+  s.add_runtime_dependency "yajl-ruby", "~> 1.0"
 
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'webmock', '~> 1'

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = 'fluent-plugin-elasticsearch'
-  s.version       = '0.7.0'
+  s.version       = '0.7.1'
   s.authors       = ['diogo', 'pitr']
   s.email         = ['pitr@uken.com', 'diogo@uken.com']
   s.description   = %q{ElasticSearch output plugin for Fluent event collector}
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fluentd', '>= 0.10.43'
   s.add_runtime_dependency 'patron', '~> 0'
   s.add_runtime_dependency 'elasticsearch', '>= 0'
-  s.add_runtime_dependency "yajl-ruby", "~> 1.0"
 
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'webmock', '~> 1'

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -154,8 +154,8 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
         meta['index']['_parent'] = record[@parent_key]
       end
 
-      bulk_message << meta
-      bulk_message << record
+      bulk_message << Yajl::Encoder.encode(meta)
+      bulk_message << Yajl::Encoder.encode(record)
     end
 
     send(bulk_message) unless bulk_message.empty?

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -153,9 +153,16 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       if @parent_key && record[@parent_key]
         meta['index']['_parent'] = record[@parent_key]
       end
+      
+      record.each_pair { |k, v|
+        if v.is_a?(String)
+          v.force_encoding('ISO-8859-1') if v.encoding == Encoding::BINARY
+          v.encode!('utf-8', 'ISO-8859-1', :invalid => :replace, :undef => :replace)
+        end
+      }
 
-      bulk_message << Yajl::Encoder.encode(meta)
-      bulk_message << Yajl::Encoder.encode(record)
+      bulk_message << meta
+      bulk_message << record
     end
 
     send(bulk_message) unless bulk_message.empty?


### PR DESCRIPTION
This is to prevent the following errors in case of high bit characters in log messages:
Caused by: org.elasticsearch.common.jackson.core.JsonParseException: Invalid UTF-8 start byte 0xff

Also should fix #77.