### PR TITLE
Allow `tag` to be used as `_type` property.

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -28,6 +28,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :reload_connections, :bool, :default => true
   config_param :reload_on_failure, :bool, :default => false
   config_param :time_key, :string, :default => nil
+  config_param :tag_as_type, :bool, :default => false
 
   include Fluent::SetTagKeyMixin
   config_set_default :include_tag_key, false
@@ -143,6 +144,12 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
 
       if @include_tag_key
         record.merge!(@tag_key => tag)
+      end
+
+      if @tag_as_type
+        type_name = tag.split(".").last
+      else
+        type_name = @type_name
       end
 
       meta = { "index" => {"_index" => target_index, "_type" => type_name} }

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -157,6 +157,15 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('fluentd', index_cmds.first['index']['_type'])
   end
 
+  def test_writes_tag_as_type
+    driver.configure("tag_as_type true\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert_equal('test', index_cmds.first['index']['_type'])
+  end
+
   def test_writes_to_speficied_index
     driver.configure("index_name myindex\n")
     stub_elastic_ping


### PR DESCRIPTION
Take the last tag component and set it as the `_type` property. e.g. `foo.bar.baz` gets `_type: "baz"`. For something like the following use case:

```javascript
fluent.configure('foo.bar');
fluent.emit('baz', { ... });
```

It is quite handy to capture the `baz` as the `_type` property. I think this is a common enough behavior to warrant a configuration option for. It's also impossible to configure with any of the existing options; using `tag_name "#{tag}"` fails since the evaluation happens when the config file is parsed, not when the message is processed.

Specs added for this new behavior.