### PR TITLE
Add in allow_overrides feature

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,9 @@
 
 ### Future
 
+### 0.9.0
+- Add new `allow_overrides` option
+
 ### 0.8.0
 - Replace Patron with Excon HTTP client
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,28 @@ Please consider using [fluent-plugin-forest](https://github.com/tagomoris/fluent
 </match>
 ```
 
+---
+
+Sometimes, though, you may not have configuration access to the collector that's pushing data to your elastic search cluster.  This can limit your options for setting your own `_id`, `_index`, `_type`, and `_parent` values which may be calculated on your own software or in your own fluentd collectors.  Setting `allow_overrides` to `true` in this plugin will allow other fluentd collectors to set these values themselves before sending them to this collector.  This plugin will modify these values if they already exist.
+
+For example, you could have one machine that injects an `_index` value of `api-2015.05.21`.  You could have another machine that injects an `_index` value of `www-2015.05.21`.  Both forward their data, for example, to the fluentd collector `es-collector` with the following config:
+
+```
+host localhost
+port 9200
+index_name fluentd
+type_name fluentd
+user demo
+password secret
+logstash_format true
+logstash_prefix mylogs
+allow_overrides true
+```
+
+For these two particular machines, they'll have their data put in the `api-2015.05.21` and `www-2015.05.21` indexes respectively.  For all other machines forwarding to this `es-collector`, they'd have their data put in the `mylogs-2015.05.21`.  This allows there to be a collector that deals with pushing to elastic search when it comes ot host names, ports, passwords, and etc, yet allows the option for determining the index, id, parent, and type on a different machine.
+
+---
+
 ## Contributing
 
 1. Fork it

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = 'fluent-plugin-elasticsearch'
-  s.version       = '0.8.0'
+  s.version       = '0.9.0'
   s.authors       = ['diogo', 'pitr']
   s.email         = ['pitr@uken.com', 'diogo@uken.com']
   s.description   = %q{ElasticSearch output plugin for Fluent event collector}

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -19,6 +19,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :logstash_format, :bool, :default => false
   config_param :logstash_prefix, :string, :default => "logstash"
   config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
+  config_param :allow_overrides, :bool, :default => false
   config_param :utc_index, :bool, :default => true
   config_param :type_name, :string, :default => "fluentd"
   config_param :index_name, :string, :default => "fluentd"
@@ -146,13 +147,30 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       end
 
       meta = { "index" => {"_index" => target_index, "_type" => type_name} }
+      if @allow_overrides && record.has_key?("_index")
+        meta['index']['_index'] = record['_index']
+      end
+
+      if @allow_overrides && record.has_key?("_type")
+        meta['index']['_type'] = record['_type']
+      end
+
       if @id_key && record[@id_key]
         meta['index']['_id'] = record[@id_key]
+      end
+
+      if @allow_overrides && record.has_key?('_id')
+        meta['index']['_id'] = record['_id']
       end
 
       if @parent_key && record[@parent_key]
         meta['index']['_parent'] = record[@parent_key]
       end
+
+      if @allow_overrides && record.has_key?('_parent')
+        meta['index']['_parent'] = record['_parent']
+      end
+
 
       bulk_message << meta
       bulk_message << record

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -29,6 +29,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
     {'age' => 26, 'request_id' => '42', 'parent_id' => 'parent'}
   end
 
+  def sample_record_allow_overrides
+    {'_index' => 'my_index', '_type' => 'my_type', '_id' => 'my_id', '_parent' => 'my_parent_id'}
+  end
+
   def stub_elastic_ping(url="http://localhost:9200")
     stub_request(:head, url).to_return(:status => 200, :body => "", :headers => {})
   end
@@ -449,4 +453,65 @@ class ElasticsearchOutput < Test::Unit::TestCase
     }
     assert_equal(connection_resets, 3)
   end
+
+  def test_allow_override_keeps_index
+    stub_elastic_ping
+    stub_elastic
+
+    driver.configure("allow_overrides false")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_not_equal(sample_record_allow_overrides['_index'], index_cmds.first['index']['_index'])
+
+    driver.configure("allow_overrides true")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_equal(sample_record_allow_overrides['_index'], index_cmds.first['index']['_index'])
+  end
+
+  def test_allow_override_keeps_type
+    stub_elastic_ping
+    stub_elastic
+
+    driver.configure("allow_overrides false")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_not_equal(sample_record_allow_overrides['_type'], index_cmds.first['index']['_type'])
+
+    driver.configure("allow_overrides true")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_equal(sample_record_allow_overrides['_type'], index_cmds.first['index']['_type'])
+  end
+
+  def test_allow_override_keeps_id
+    stub_elastic_ping
+    stub_elastic
+
+    driver.configure("allow_overrides false")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_not_equal(sample_record_allow_overrides['_id'], index_cmds.first['index']['_id'])
+
+    driver.configure("allow_overrides true")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_equal(sample_record_allow_overrides['_id'], index_cmds.first['index']['_id'])
+  end
+
+  def test_allow_override_keeps_parent
+    stub_elastic_ping
+    stub_elastic
+
+    driver.configure("allow_overrides false")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_not_equal(sample_record_allow_overrides['_parent'], index_cmds.first['index']['_parent'])
+
+    driver.configure("allow_overrides true")
+    driver.emit(sample_record_allow_overrides)
+    driver.run
+    assert_equal(sample_record_allow_overrides['_parent'], index_cmds.first['index']['_parent'])
+  end
+
 end


### PR DESCRIPTION
A feature that allows other fluentd collectors to determine either the `_index`, `_id`, `_type`, or `_parent` values before pushing the data to the elastic search fluentd collector.