### PR TITLE
Add supports for dynamic index & type names. add `remove_keys` feature

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -21,6 +21,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
   config_param :utc_index, :bool, :default => true
   config_param :type_name, :string, :default => "fluentd"
+  config_param :type_delimiter, :string, :default => nil
   config_param :index_name, :string, :default => "fluentd"
   config_param :id_key, :string, :default => nil
   config_param :parent_key, :string, :default => nil
@@ -155,6 +156,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       end
 
       target_type = expand_param(@type_name, tag, record)
+      target_type = target_type.gsub! '.', @type_delimiter if @type_delimiter
 
       meta = { "index" => {"_index" => target_index, "_type" => target_type} }
       if @id_key && record[@id_key]


### PR DESCRIPTION
Although I can do this with [fluent-plugin-forest](https://github.com/tagomoris/fluent-plugin-forest), but it would be memory
consuming if there were tons of different tags of fluentd events since
`fluent-plugin-forest` creates new plugin instance for each template.
So I implement this inside this plugin.
You can use the following configuration to gain this feature:

    <match fluent.*>
      type null # to prevent recursively logging
    </match>
    <match **>
         type elasticsearch
         logstash_format true
         logstash_prefix ${my_index_key}
         type_name ${tag}
         remove_keys my_index_key,foo
     </match>

Suppose you send a message with tag `test.es`:
`{"foo":"u won't see me", "my_index_key": "myfluent", "bar": "Hello from fluentd"}`

You will get the following document from the index `myfluent-YYYY.MM.DD` of elasticsearch:
`{"bar": "Hello from fluentd"}`