### PR TITLE
Add secret parameters

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -12,7 +12,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :host, :string,  :default => 'localhost'
   config_param :port, :integer, :default => 9200
   config_param :user, :string, :default => nil
-  config_param :password, :string, :default => nil
+  config_param :password, :string, :default => nil, :secret => true
   config_param :path, :string, :default => nil
   config_param :scheme, :string, :default => 'http'
   config_param :hosts, :string, :default => nil


### PR DESCRIPTION
Fluentd's config_params now supports concealing given parameters with xxxxxx as below:

```log
2015-07-25 16:48:57 +0900 [info]: using configuration file: <ROOT>
  <match my.logs>
    host localhost
    user fluent
    password xxxxxx
    type elasticsearch
    include_tag_key true
    tag_key _key
  </match>
</ROOT>
```