### PR TITLE
Explicit development dependencies for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.1
+  - 2.2
 
 script: bundle exec ruby -S -Itest test/plugin/test_out_elasticsearch.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.1
+  - 2.1
   - 2.2
 
 script: bundle exec ruby -S -Itest test/plugin/test_out_elasticsearch.rb

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 0'
   s.add_development_dependency 'webmock', '~> 1'
+  s.add_development_dependency 'test-unit', '~> 3.1.0'
+  s.add_development_dependency 'minitest', '~> 5.7.0'
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible API.