### PR TITLE
Added option "resurrect_after"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [request_timeout](#request_timeout)
   + [reload_connections](#reload_connections)
   + [reload_on_failure](#reload_on_failure)
+  + [resurrect_after](#resurrect_after)
   + [include_tag_key, tag_key](#include_tag_key-tag_key)
   + [id_key](#id_key)
   + [Client/host certificate options](#clienthost-certificate-options)
@@ -177,6 +178,14 @@ reload_on_failure true # defaults to false
 
 Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the
 request, this can be useful to quickly remove a dead node from the list of addresses.
+
+### resurrect_after
+
+You can set in the elasticsearch-transport how often dead connections from pool will be resurrected. 
+
+```
+resurrect_after 5 # defaults to 60s
+```
 
 ### include_tag_key, tag_key
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ request, this can be useful to quickly remove a dead node from the list of addre
 
 ### resurrect_after
 
-You can set in the elasticsearch-transport how often dead connections from pool will be resurrected. 
+You can set in the elasticsearch-transport how often dead connections from the elasticsearch-transport's pool will be resurrected. 
 
 ```
 resurrect_after 5 # defaults to 60s

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ retry_wait 1.0
 num_threads 1
 ```
 
+The value for option `buffer_chunk_limit` should not exceed value `http.max_content_length` in your Elasticsearch setup (by default it is 104857600 bytes). 
+
 ### Not seeing a config you need?
 
 We try to keep the scope of this plugin small and not add too many configuration options. If you think an option would be useful to others, feel free to open an issue or contribute a Pull Request.

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -27,6 +27,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :request_timeout, :time, :default => 5
   config_param :reload_connections, :bool, :default => true
   config_param :reload_on_failure, :bool, :default => false
+  config_param :resurrect_after, :time, :default => 5
   config_param :time_key, :string, :default => nil
   config_param :ssl_verify , :bool, :default => true
   config_param :client_key, :string, :default => nil
@@ -57,6 +58,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
                                                                           options: {
                                                                             reload_connections: @reload_connections,
                                                                             reload_on_failure: @reload_on_failure,
+                                                                            resurrect_after: @resurrect_after,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {
                                                                               request: { timeout: @request_timeout },

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -27,7 +27,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :request_timeout, :time, :default => 5
   config_param :reload_connections, :bool, :default => true
   config_param :reload_on_failure, :bool, :default => false
-  config_param :resurrect_after, :time, :default => 5
+  config_param :resurrect_after, :time, :default => 60
   config_param :time_key, :string, :default => nil
   config_param :ssl_verify , :bool, :default => true
   config_param :client_key, :string, :default => nil


### PR DESCRIPTION
Adding this option give possibility to avoid starvation of the pool from Elasticsearch Ruby client when requests number more frequent than the "resurrect_after" time.

+ Additional comment for `buffer_chunk_limit` option