### PR TITLE
Faster time format parsing for most formats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false
+gem 'strptime', require: false if RUBY_ENGINE == "ruby" && RUBY_VERSION =~ /^2/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [logstash_format](#logstash_format)
   + [logstash_prefix](#logstash_prefix)
   + [logstash_dateformat](#logstash_dateformat)
+  + [time_key_format](#time_key_format)
   + [time_key](#time_key)
   + [utc_index](#utc_index)
   + [target_index_key](#target_index_key)
@@ -97,7 +98,7 @@ Specify `ssl_verify false` to skip ssl verification (defaults to true)
 logstash_format true # defaults to false
 ```
 
-This is meant to make writing data into ElasticSearch compatible to what [Logstash](https://www.elastic.co/products/logstash) writes. By doing this, one could take advantage of [Kibana](https://www.elastic.co/products/kibana).
+This is meant to make writing data into ElasticSearch indices compatible to what [Logstash](https://www.elastic.co/products/logstash) calls them. By doing this, one could take advantage of [Kibana](https://www.elastic.co/products/kibana). See logstash_prefix and logstash_dateformat to customize this index name pattern. The index name will be `#{logstash_prefix}-#{formated_date}`
 
 ### logstash_prefix
 
@@ -107,10 +108,22 @@ logstash_prefix mylogs # defaults to "logstash"
 
 ### logstash_dateformat
 
-By default, the records inserted into index `logstash-YYMMDD`. This option allows to insert into specified index like `mylogs-YYYYMM` for a monthly index.
+The strftime format to generate index target index name when `logstash_format` is set to true. By default, the records are inserted into index `logstash-YYYY.MM.DD`. This option, alongwith `logstash_prefix` lets us insert into specified index like `mylogs-YYYYMM` for a monthly index.
 
 ```
 logstash_dateformat %Y.%m. # defaults to "%Y.%m.%d"
+```
+
+### time_key_format
+
+The format of the time stamp field (`@timestamp` or what you specify with [time_key][#time_key]). This parameter only has an effect when [logstash_format][#logstash_format] is true as it only affects the name of the index we write to. Please see [Time#strftime](http://ruby-doc.org/core-1.9.3/Time.html#method-i-strftime) for information about the value of this format.
+
+Setting this to a known format can vastly improve your log ingestion speed if all most of your logs are in the same format. If there is an error parsing this format the timestamp will default to the ingestion time.
+
+For example to parse ISO8601 times with sub-second precision:
+
+```
+time_key_format %Y-%m-%dT%H:%M:%S.%N%z
 ```
 
 ### time_key

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ logstash_dateformat %Y.%m. # defaults to "%Y.%m.%d"
 
 The format of the time stamp field (`@timestamp` or what you specify with [time_key][#time_key]). This parameter only has an effect when [logstash_format][#logstash_format] is true as it only affects the name of the index we write to. Please see [Time#strftime](http://ruby-doc.org/core-1.9.3/Time.html#method-i-strftime) for information about the value of this format.
 
-Setting this to a known format can vastly improve your log ingestion speed if all most of your logs are in the same format. If there is an error parsing this format the timestamp will default to the ingestion time.
+Setting this to a known format can vastly improve your log ingestion speed if all most of your logs are in the same format. If there is an error parsing this format the timestamp will default to the ingestion time. If you are on Ruby 2.0 or later you can get a further performance improvment by installing the "strptime" gem: `fluent-gem install strptime`.
 
 For example to parse ISO8601 times with sub-second precision:
 

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fluentd', '>= 0.10.43'
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'elasticsearch', '>= 0'
-  s.add_runtime_dependency 'strptime', ">= 0.1.3"
 
 
   s.add_development_dependency 'rake', '>= 0'

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'fluentd', '>= 0.10.43'
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'elasticsearch', '>= 0'
+  s.add_runtime_dependency 'strptime', ">= 0.1.3"
 
 
   s.add_development_dependency 'rake', '>= 0'

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -3,7 +3,10 @@ require 'date'
 require 'excon'
 require 'elasticsearch'
 require 'uri'
-require 'strptime'
+begin
+  require 'strptime'
+rescue LoadError
+end
 
 class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   class ConnectionFailure < StandardError; end
@@ -67,6 +70,9 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
         strptime = Strptime.new(time_key_format)
         Proc.new { |value| strptime.exec(value).to_datetime }
       rescue
+        # Can happen if Strptime doesn't recognize the format; or
+        # if strptime couldn't be required (because it's not installed -- it's
+        # ruby 2 only)
         Proc.new { |value| DateTime.strptime(value, time_key_format) }
       end
     else


### PR DESCRIPTION
DateTime and Time have different APIs (DateTime is missing getutc) so making the time code support getting a Time or a DateTime would be rather complex (to deal with the UTC index vs not cases). However I was looking at the fluentd source code and in v0.14 they started using the [strptime gem](https://github.com/nurse/strptime): https://github.com/fluent/fluentd/blob/v0.14.0.pre.1/lib/fluent/parser.rb#L61-L71

That gem doesn't support all formats (for instance `%a` isn't supported) hence why they fallback to `Time.strptime` if creating the parser object fails. It's also fast:

```
(themisto tmp/fluent…search strptime:+)% ~/.rbenv/shims/bundle exec ruby bench.rb
                                     user     system      total        real
Time.parse                       7.910000   0.040000   7.950000 (  7.966731)
Time.strptime                    3.140000   0.020000   3.160000 (  3.176454)
Time.xmlschema                   2.880000   0.010000   2.890000 (  2.893675)
DateTime.strptime                1.460000   0.020000   1.480000 (  1.484857)
DateTime.strptime.to_time        2.810000   0.020000   2.830000 (  2.842479)
Strptime.strptime                0.130000   0.000000   0.130000 (  0.140551)
```

Benchmark code:

```ruby
require 'time'
require 'benchmark'
require 'strptime'
n = 200_000

Benchmark.bm(30) do |x|
  x.report('Time.parse') { n.times { Time.parse('Thu Nov 29 14:33:20 GMT 2001') } }
  x.report('Time.strptime') { n.times { Time.strptime("Thu Nov 29 14:33:20 GMT 2001", "%a %b %d %H:%M:%S %Z %Y") } }
  x.report('Time.xmlschema') { n.times { Time.xmlschema("2001-11-29T09:33:20-05:00") } }
  x.report('DateTime.strptime') { n.times { DateTime.strptime("Thu Nov 29 14:33:20 GMT 2001", "%a %b %d %H:%M:%S %Z %Y") } }
  x.report('DateTime.strptime.to_time') { n.times { DateTime.strptime("Thu Nov 29 14:33:20 GMT 2001", "%a %b %d %H:%M:%S %Z %Y").to_time } }
  x.report('Strptime.strptime') { p = Strptime.new("%m/%d %H:%M:%S %z %Y"); n.times { p.exec("11/29 14:33:20 +00:00 2001") } }
end
```