### PR TITLE
Add _routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [resurrect_after](#resurrect_after)
   + [include_tag_key, tag_key](#include_tag_key-tag_key)
   + [id_key](#id_key)
+  + [parent_key](#parent_key)
+  + [routing_key](#routing_key)
   + [write_operation](#write_operation)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)

--- a/README.md
+++ b/README.md
@@ -275,6 +275,30 @@ This following record `{"name":"Johnny","request_id":"87d89af7daffad6"}` will tr
 { "name": "Johnny", "request_id": "87d89af7daffad6" }
 ```
 
+### parent_key
+
+```
+parent_key a_parent # use "a_parent" field value to set _parent in elasticsearch command
+```
+
+If your input is
+```
+{ "name": "Johnny", "a_parent": "my_parent" }
+```
+
+ElasticSearch command would be
+
+```
+{ "index" : { "_index" : "****", "_type" : "****", "_id" : "****", "_parent" : "my_parent" } }
+{ "name": "Johnny", "a_parent": "my_parent" }
+```
+
+if `parent_key` is not configed or the `parent_key` is absent in input record, nothing will happen.
+
+### routing_key
+
+Similar to `parent_key` config, will add `_routing` into elasticsearch command if `routing_key` is set and the field does exist in input event.
+
 ### write_operation
 
 The write_operation can be any of:

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -150,12 +150,12 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
       end
 
       meta = {"_index" => target_index, "_type" => dynamic_conf['type_name']}
-      if dynamic_conf['id_key'] && record[dynamic_conf['id_key']]
-        meta['_id'] = record[dynamic_conf['id_key']]
-      end
 
-      if dynamic_conf['parent_key'] && record[dynamic_conf['parent_key']]
-        meta['_parent'] = record[dynamic_conf['parent_key']]
+      @meta_config_map ||= { 'id_key' => '_id', 'parent_key' => '_parent', 'routing_key' => '_routing' }
+      @meta_config_map.each_pair do |config_name, meta_key|
+        if dynamic_conf[config_name] && record[dynamic_conf[config_name]]
+          meta[meta_key] = record[dynamic_conf[config_name]]
+        end
       end
 
       if dynamic_conf['hosts']

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -17,7 +17,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   def sample_record
-    {'age' => 26, 'request_id' => '42', 'parent_id' => 'parent'}
+    {'age' => 26, 'request_id' => '42', 'parent_id' => 'parent', 'routing_id' => 'routing'}
   end
 
   def stub_elastic_ping(url="http://localhost:9200")
@@ -500,6 +500,32 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.emit(sample_record)
     driver.run
     assert(!index_cmds[0]['index'].has_key?('_parent'))
+  end
+
+  def test_adds_routing_key_when_configured
+    driver.configure("routing_key routing_id\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+  end
+
+  def test_doesnt_add_routing_key_if_missing_when_configured
+    driver.configure("routing_key another_routing_id\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert(!index_cmds[0]['index'].has_key?('_routing'))
+  end
+
+  def test_adds_routing_key_when_not_configured
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert(!index_cmds[0]['index'].has_key?('_routing'))
   end
 
   def test_request_error


### PR DESCRIPTION
- Also requested in
  https://github.com/uken/fluent-plugin-elasticsearch/issues/147
- Refactoring: set meta fields(`_id`, `_parent` and `_routing`) in a
  common way.
- Add `parent_key` and `routing_key` doc in README.md.