### PR TITLE
Exclude timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [logstash_dateformat](#logstash_dateformat)
   + [time_key_format](#time_key_format)
   + [time_key](#time_key)
+  + [time_key_exclude_timestamp](#time_key_exclude_timestamp)
   + [utc_index](#utc_index)
   + [target_index_key](#target_index_key)
   + [request_timeout](#request_timeout)
@@ -162,6 +163,16 @@ The output will be
   "vtm": "2014-12-19T08:01:03Z"
 }
 ```
+
+See `time_key_exclude_timestamp` to avoid adding `@timestamp`.
+
+### time_key_exclude_timestamp
+
+```
+time_key_exclude_timestamp false
+```
+
+By default, setting `time_key` will copy the value to an additional field `@timestamp`. When setting `time_key_exclude_timestamp true`, no additional field will be added.
 
 ### utc_index
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -37,6 +37,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :reload_on_failure, :bool, :default => false
   config_param :resurrect_after, :time, :default => 60
   config_param :time_key, :string, :default => nil
+  config_param :time_key_exclude_timestamp, :bool, :default => false
   config_param :ssl_verify , :bool, :default => true
   config_param :client_key, :string, :default => nil
   config_param :client_cert, :string, :default => nil
@@ -200,7 +201,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
           dt = @time_parser.parse(record["@timestamp"], time)
         elsif record.has_key?(@time_key)
           dt = @time_parser.parse(record[@time_key], time)
-          record['@timestamp'] = record[@time_key]
+          record['@timestamp'] = record[@time_key] unless time_key_exclude_timestamp
         else
           dt = Time.at(time).to_datetime
           record.merge!({"@timestamp" => dt.to_s})

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -11,6 +11,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
   config_param :port, :string, :default => "9200"
   config_param :logstash_format, :string, :default => "false"
   config_param :utc_index, :string, :default => "true"
+  config_param :time_key_exclude_timestamp, :bool, :default => false
   config_param :reload_connections, :string, :default => "true"
   config_param :reload_on_failure, :string, :default => "false"
   config_param :resurrect_after, :string, :default => "60"
@@ -131,7 +132,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
           time = Time.parse record["@timestamp"]
         elsif record.has_key?(dynamic_conf['time_key'])
           time = Time.parse record[dynamic_conf['time_key']]
-          record['@timestamp'] = record[dynamic_conf['time_key']]
+          record['@timestamp'] = record[dynamic_conf['time_key']] unless time_key_exclude_timestamp
         else
           record.merge!({"@timestamp" => Time.at(time).to_datetime.to_s})
         end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -383,6 +383,17 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(index_cmds[1]['@timestamp'], ts)
   end
 
+  def test_uses_custom_time_key_exclude_timekey
+    driver.configure("logstash_format true
+                      time_key vtm
+                      time_key_exclude_timestamp true\n")
+    stub_elastic_ping
+    stub_elastic
+    ts = DateTime.new(2001,2,3).to_s
+    driver.emit(sample_record.merge!('vtm' => ts))
+    driver.run
+    assert(!index_cmds[1].key?('@timestamp'), '@timestamp should be messing')
+  end
 
   def test_uses_custom_time_key_format
     driver.configure("logstash_format true

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -334,6 +334,18 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal(index_cmds[1]['@timestamp'], ts)
   end
 
+  def test_uses_custom_time_key_exclude_timestamp
+    driver.configure("logstash_format true
+                      time_key vtm
+                      time_key_exclude_timestamp true\n")
+    stub_elastic_ping
+    stub_elastic
+    ts = DateTime.new(2001,2,3).to_s
+    driver.emit(sample_record.merge!('vtm' => ts))
+    driver.run
+    assert(!index_cmds[1].key?('@timestamp'), '@timestamp should be missing')
+  end
+
   def test_doesnt_add_tag_key_by_default
     stub_elastic_ping
     stub_elastic


### PR DESCRIPTION
Added a new config option `time_key_exclude_timestamp` to disable the copying of the value from field `time_key` to `@timestamp`. Works in both dynamic and non-dynamic.
See #160.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
