### PR TITLE
Change index name to lower-case

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -211,7 +211,11 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       else
         target_index = @index_name
       end
-
+      
+      # Change target_index to lower-case since Elasticsearch doesn't
+      # allow upper-case characters in index names.
+      target_index = target_index.downcase
+      
       if @include_tag_key
         record.merge!(@tag_key => tag)
       end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -145,7 +145,11 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
       else
         target_index = dynamic_conf['index_name']
       end
-
+    
+      # Change target_index to lower-case since Elasticsearch doesn't
+      # allow upper-case characters in index names.
+      target_index = target_index.downcase
+       
       if @include_tag_key
         record.merge!(dynamic_conf['tag_key'] => tag)
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -156,6 +156,17 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert_equal('myindex', index_cmds.first['index']['_index'])
   end
+  
+  def test_writes_to_speficied_index_uppercase
+    driver.configure("index_name MyIndex\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+	# Allthough index_name has upper-case characters,
+	# it should be set as lower-case when sent to elasticsearch.
+    assert_equal('myindex', index_cmds.first['index']['_index'])
+  end
 
   def test_writes_to_target_index_key
     driver.configure("target_index_key @target_index\n")
@@ -167,7 +178,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('local-override', index_cmds.first['index']['_index'])
     assert_nil(index_cmds[1]['@target_index'])
   end
-
+  
   def test_writes_to_target_index_key_logstash
     driver.configure("target_index_key @target_index\n")
     driver.configure("logstash_format true\n")
@@ -176,6 +187,19 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
     driver.emit(sample_record.merge('@target_index' => 'local-override'), time)
     driver.run
+    assert_equal('local-override', index_cmds.first['index']['_index'])
+  end
+  
+   def test_writes_to_target_index_key_logstash_uppercase
+    driver.configure("target_index_key @target_index\n")
+    driver.configure("logstash_format true\n")
+    time = Time.parse Date.today.to_s
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record.merge('@target_index' => 'Local-Override'), time)
+    driver.run
+	# Allthough @target_index has upper-case characters,
+	# it should be set as lower-case when sent to elasticsearch.
     assert_equal('local-override', index_cmds.first['index']['_index'])
   end
 
@@ -313,6 +337,20 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
     driver.emit(sample_record, time)
     driver.run
+    assert_equal(logstash_index, index_cmds.first['index']['_index'])
+  end
+  
+  def test_writes_to_logstash_index_with_specified_prefix_uppercase
+    driver.configure("logstash_format true
+                      logstash_prefix MyPrefix")
+    time = Time.parse Date.today.to_s
+    logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record, time)
+    driver.run
+	# Allthough logstash_prefix has upper-case characters,
+	# it should be set as lower-case when sent to elasticsearch.
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -154,6 +154,15 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.run
     assert_equal('myindex', index_cmds.first['index']['_index'])
   end
+  
+  def test_writes_to_speficied_index_uppercase
+    driver.configure("index_name MyIndex\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert_equal('myindex', index_cmds.first['index']['_index'])
+  end
 
   def test_writes_to_speficied_type
     driver.configure("type_name mytype\n")
@@ -258,6 +267,18 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_writes_to_logstash_index_with_specified_prefix
     driver.configure("logstash_format true
                       logstash_prefix myprefix")
+    time = Time.parse Date.today.to_s
+    logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record, time)
+    driver.run
+    assert_equal(logstash_index, index_cmds.first['index']['_index'])
+  end
+  
+  def test_writes_to_logstash_index_with_specified_prefix_uppercase
+    driver.configure("logstash_format true
+                      logstash_prefix MyPrefix")
     time = Time.parse Date.today.to_s
     logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic_ping


### PR DESCRIPTION
Change target_index to lower-case since Elasticsearch doesn't allow upper-case characters in index names.
Added some tests, and they are passing.
The plugin itself was checked by manually running it in fluentd, and it seems to work fine, changing upper-case index names to lowercase.

(check all that apply)
- [x] tests added
- [x] tests passing (not checked)
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
