### PR TITLE
add remove_keys support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [id_key](#id_key)
   + [parent_key](#parent_key)
   + [routing_key](#routing_key)
+  + [remove_keys](#remove_keys)
   + [write_operation](#write_operation)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
@@ -311,6 +312,14 @@ if `parent_key` is not configed or the `parent_key` is absent in input record, n
 ### routing_key
 
 Similar to `parent_key` config, will add `_routing` into elasticsearch command if `routing_key` is set and the field does exist in input event.
+
+### remove_keys
+
+```
+parent_key a_parent
+routing_key a_routing
+remove_keys a_parent, a_routing # a_parent and a_routing fileds wont be sent to elasticsearch
+```
 
 ### write_operation
 

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -169,6 +169,10 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
         host = "#{dynamic_conf['host']}:#{dynamic_conf['port']}"
       end
 
+      if @remove_keys
+        @remove_keys.each { |key| record.delete(key) }
+      end
+
       append_record_to_messages(dynamic_conf["write_operation"], meta, record, bulk_message[host])
     end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -577,6 +577,26 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert(!index_cmds[0]['index'].has_key?('_routing'))
   end
 
+  def test_remove_one_key
+    driver.configure("remove_keys key1\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
+    driver.run
+    assert(!index_cmds[1].has_key?('key1'))
+    assert(index_cmds[1].has_key?('key2'))
+  end
+
+  def test_remove_multi_keys
+    driver.configure("remove_keys key1, key2\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
+    driver.run
+    assert(!index_cmds[1].has_key?('key1'))
+    assert(!index_cmds[1].has_key?('key2'))
+  end
+
   def test_request_error
     stub_elastic_ping
     stub_elastic_unavailable

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -462,6 +462,27 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.run
     assert(!index_cmds[0]['index'].has_key?('_routing'))
   end
+
+  def test_remove_one_key
+    driver.configure("remove_keys key1\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
+    driver.run
+    assert(!index_cmds[1].has_key?('key1'))
+    assert(index_cmds[1].has_key?('key2'))
+  end
+
+  def test_remove_multi_keys
+    driver.configure("remove_keys key1, key2\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
+    driver.run
+    assert(!index_cmds[1].has_key?('key1'))
+    assert(!index_cmds[1].has_key?('key2'))
+  end
+
   def test_request_error
     stub_elastic_ping
     stub_elastic_unavailable


### PR DESCRIPTION
Add a config to delete fields before send data to elasticsearch.
 
(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)

