### PR TITLE
add `target_type_key` to specify target type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [time_key_exclude_timestamp](#time_key_exclude_timestamp)
   + [utc_index](#utc_index)
   + [target_index_key](#target_index_key)
+  + [target_type_key](#target_type_key)
   + [request_timeout](#request_timeout)
   + [reload_connections](#reload_connections)
   + [reload_on_failure](#reload_on_failure)
@@ -216,6 +217,10 @@ The output would be
 ```
 
 and this record will be written to the specified index (`logstash-2014.12.19`) rather than `fallback`.
+
+### target_type_key
+
+Similar to `target_index_key` config, find the type name to write to in the record under this key. If key not found in record - fallback to `type_name` (default "fluentd").
 
 ### request_timeout
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -21,6 +21,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :scheme, :string, :default => 'http'
   config_param :hosts, :string, :default => nil
   config_param :target_index_key, :string, :default => nil
+  config_param :target_type_key, :string, :default => nil
   config_param :time_key_format, :string, :default => nil
   config_param :logstash_format, :bool, :default => false
   config_param :logstash_prefix, :string, :default => "logstash"
@@ -245,8 +246,14 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       if @include_tag_key
         record.merge!(@tag_key => tag)
       end
-
-      meta = {"_index" => target_index, "_type" => type_name}
+      
+      if @target_type_key && record[@target_type_key]
+        target_type = record.delete @target_type_key
+      else
+        target_type = @type_name
+      end
+      
+      meta = {"_index" => target_index, "_type" => target_type}
 
       @meta_config_map ||= { 'id_key' => '_id', 'parent_key' => '_parent', 'routing_key' => '_routing' }
       @meta_config_map.each_pair do |config_name, meta_key|

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -233,6 +233,36 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('mytype', index_cmds.first['index']['_type'])
   end
 
+  def test_writes_to_target_type_key
+    driver.configure("target_type_key @target_type\n")
+    stub_elastic_ping
+    stub_elastic
+    record = sample_record.clone
+    driver.emit(sample_record.merge('@target_type' => 'local-override'))
+    driver.run
+    assert_equal('local-override', index_cmds.first['index']['_type'])
+    assert_nil(index_cmds[1]['@target_type'])
+  end
+
+  def test_writes_to_target_type_key_fallack_to_default
+    driver.configure("target_type_key @target_type\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert_equal('fluentd', index_cmds.first['index']['_type'])
+  end
+
+  def test_writes_to_target_type_key_fallack_to_type_name
+    driver.configure("target_type_key @target_type\n")
+    driver.configure("type_name mytype\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    assert_equal('mytype', index_cmds.first['index']['_type'])
+  end
+
   def test_writes_to_speficied_host
     driver.configure("host 192.168.33.50\n")
     stub_elastic_ping("http://192.168.33.50:9200")


### PR DESCRIPTION
Pull Request Description HERE

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

