### PR TITLE
Added support for dot separated target_index_key and target_type_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ By default, the records inserted into index `logstash-YYMMDD` with UTC (Coordina
 
 ### target_index_key
 
-Tell this plugin to find the index name to write to in the record under this key in preference to other mechanisms.
+Tell this plugin to find the index name to write to in the record under this key in preference to other mechanisms. Key can be specified as path to nested record using dot ('.') as a separator.
 
 If it is present in the record (and the value is non falsey) the value will be used as the index name to write to and then removed from the record before output; if it is not found then it will use logstash_format or index_name settings as configured.
 
@@ -220,7 +220,7 @@ and this record will be written to the specified index (`logstash-2014.12.19`) r
 
 ### target_type_key
 
-Similar to `target_index_key` config, find the type name to write to in the record under this key. If key not found in record - fallback to `type_name` (default "fluentd").
+Similar to `target_index_key` config, find the type name to write to in the record under this key (or nested record). If key not found in record - fallback to `type_name` (default "fluentd").
 
 ### request_timeout
 

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'fluentd', '>= 0.10.43'
+  s.add_runtime_dependency 'fluentd', '~> 0.12.0'
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'elasticsearch', '>= 0'
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -63,12 +63,12 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     if @remove_keys
       @remove_keys = @remove_keys.split(/\s*,\s*/)
     end
-    
-    if @target_index_key
+
+    if @target_index_key && @target_index_key.is_a?(String)
       @target_index_key = @target_index_key.split '.'
     end
-    
-    if @target_type_key
+
+    if @target_type_key && @target_type_key.is_a?(String)
       @target_type_key = @target_type_key.split '.'
     end
   end
@@ -197,7 +197,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       if meta.has_key?("_id")
         msgs << { "create" => meta }
         msgs << record
-      end        
+      end
     when "index"
       msgs << { "index" => meta }
       msgs << record
@@ -247,21 +247,21 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       else
         target_index = @index_name
       end
-      
+
       # Change target_index to lower-case since Elasticsearch doesn't
       # allow upper-case characters in index names.
       target_index = target_index.downcase
       if @include_tag_key
         record.merge!(@tag_key => tag)
       end
-      
+
       target_type_parent, target_type_child_key = get_parent_of(record, @target_type_key)
       if target_type_parent && target_type_parent[target_type_child_key]
         target_type = target_type_parent.delete(target_type_child_key)
       else
         target_type = @type_name
       end
-      
+
       meta = {"_index" => target_index, "_type" => target_type}
 
       @meta_config_map ||= { 'id_key' => '_id', 'parent_key' => '_parent', 'routing_key' => '_routing' }
@@ -280,12 +280,12 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     send(bulk_message) unless bulk_message.empty?
     bulk_message.clear
   end
-  
+
   # returns [parent, child_key] of child described by path array in record's tree
   # returns [nil, child_key] if path doesnt exist in record
   def get_parent_of(record, path)
     return [nil, nil] unless path
-    
+
     parent_object = path[0..-2].reduce(record) { |a, e| a.is_a?(Hash) ? a[e] : nil }
     [parent_object, path[-1]]
   end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -63,6 +63,14 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     if @remove_keys
       @remove_keys = @remove_keys.split(/\s*,\s*/)
     end
+    
+    if @target_index_key
+      @target_index_key = @target_index_key.split '.'
+    end
+    
+    if @target_type_key
+      @target_type_key = @target_type_key.split '.'
+    end
   end
 
   def start
@@ -220,8 +228,9 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       end
 
       next unless record.is_a? Hash
-      if @target_index_key && record[@target_index_key]
-        target_index = record.delete @target_index_key
+      target_index_parent, target_index_child_key = get_parent_of(record, @target_index_key)
+      if target_index_parent && target_index_parent[target_index_child_key]
+        target_index = target_index_parent.delete(target_index_child_key)
       elsif @logstash_format
         if record.has_key?("@timestamp")
           dt = record["@timestamp"]
@@ -242,13 +251,13 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       # Change target_index to lower-case since Elasticsearch doesn't
       # allow upper-case characters in index names.
       target_index = target_index.downcase
-      
       if @include_tag_key
         record.merge!(@tag_key => tag)
       end
       
-      if @target_type_key && record[@target_type_key]
-        target_type = record.delete @target_type_key
+      target_type_parent, target_type_child_key = get_parent_of(record, @target_type_key)
+      if target_type_parent && target_type_parent[target_type_child_key]
+        target_type = target_type_parent.delete(target_type_child_key)
       else
         target_type = @type_name
       end
@@ -270,6 +279,15 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
 
     send(bulk_message) unless bulk_message.empty?
     bulk_message.clear
+  end
+  
+  # returns [parent, child_key] of child described by path array in record's tree
+  # returns [nil, child_key] if path doesnt exist in record
+  def get_parent_of(record, path)
+    return [nil, nil] unless path
+    
+    parent_object = path[0..-2].reduce(record) { |a, e| a.is_a?(Hash) ? a[e] : nil }
+    [parent_object, path[-1]]
   end
 
   def send(data)


### PR DESCRIPTION
Some docker plugins like Kubernetes or Docker metadata plugins adds nested objects that contains values usable for `target_type`. For example setting tag_key to `kubernetes.container-name` will use value in `record['kubernetes']['container-name']`. That is useful for `target_type` value because different containers may have different log formats (that can conflict with names in ES if send with same type)

This patch allows to specify dot separated path for target_index_key and target_type_key to make this metadata plugins usable for this scenario.

It is backwards compatible with non nested keys. It only adds small additional overhead if used.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
