### PR TITLE
Fix elasticsearch runtime dependency

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fluentd', '>= 0.10.43', '< 0.14'
   s.add_runtime_dependency 'excon', '>= 0'
-  s.add_runtime_dependency 'elasticsearch', '>= 0'
+  s.add_runtime_dependency 'elasticsearch', '~> 1.0.0'
 
 
   s.add_development_dependency 'rake', '>= 0'


### PR DESCRIPTION
I tried to install fluent-plugin-elasticsearch, but I got this error.

```
$ sudo /opt/td-agent/embedded/bin/gem install fluent-plugin-elasticsearch                                                               
Fetching: excon-0.50.1.gem (100%)
Successfully installed excon-0.50.1
Fetching: elasticsearch-api-2.0.0.pre.gem (100%)
Successfully installed elasticsearch-api-2.0.0.pre
Fetching: system_timer-1.2.4.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing fluent-plugin-elasticsearch:
        ERROR: Failed to build gem native extension.

    /opt/td-agent/embedded/bin/ruby extconf.rb
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling system_timer_native.c
In file included from system_timer_native.c:8:0:
/opt/td-agent/embedded/include/ruby-2.1.0/ruby/backward/rubysig.h:14:2: warning: #warning rubysig.h is obsolete [-Wcpp]
 #warning rubysig.h is obsolete
  ^
system_timer_native.c: In function ‘install_first_timer_and_save_original_configuration’:
system_timer_native.c:43:22: error: storage size of ‘timer_interval’ isn’t known
     struct itimerval timer_interval;
                      ^
system_timer_native.c:81:24: error: ‘ITIMER_REAL’ undeclared (first use in this function)
     if (0 != setitimer(ITIMER_REAL, &timer_interval, &original_timer_interval)) {
                        ^
system_timer_native.c:81:24: note: each undeclared identifier is reported only once for each function it appears in
system_timer_native.c: In function ‘install_next_timer’:
system_timer_native.c:108:22: error: storage size of ‘timer_interval’ isn’t known
     struct itimerval timer_interval;
                      ^
system_timer_native.c:129:24: error: ‘ITIMER_REAL’ undeclared (first use in this function)
     if (0 != setitimer(ITIMER_REAL, &timer_interval, NULL)) {
                        ^
system_timer_native.c: In function ‘restore_original_timer_interval’:
system_timer_native.c:189:24: error: ‘ITIMER_REAL’ undeclared (first use in this function)
     if (0 != setitimer(ITIMER_REAL, &original_timer_interval, NULL)) {
                        ^
system_timer_native.c: In function ‘install_ruby_sigalrm_handler’:
system_timer_native.c:211:5: error: ‘rb_thread_critical’ undeclared (first use in this function)
     rb_thread_critical = 1;
     ^
system_timer_native.c: In function ‘restore_original_ruby_sigalrm_handler’:
system_timer_native.c:217:5: error: ‘rb_thread_critical’ undeclared (first use in this function)
     rb_thread_critical = 1;
     ^
system_timer_native.c: In function ‘set_itimerval’:
system_timer_native.c:292:10: error: dereferencing pointer to incomplete type
     value->it_interval.tv_usec = 0;
          ^
system_timer_native.c:293:10: error: dereferencing pointer to incomplete type
     value->it_interval.tv_sec = 0;
          ^
system_timer_native.c:294:10: error: dereferencing pointer to incomplete type
     value->it_value.tv_sec = (long int) (seconds);
          ^
system_timer_native.c:295:10: error: dereferencing pointer to incomplete type
     value->it_value.tv_usec = (long int) ((seconds - value->it_value.tv_sec) \
          ^
system_timer_native.c:295:59: error: dereferencing pointer to incomplete type
     value->it_value.tv_usec = (long int) ((seconds - value->it_value.tv_sec) \
                                                           ^
system_timer_native.c:298:61: error: dereferencing pointer to incomplete type
       log_debug("[set_itimerval] Set to %ds + %dus\n", value->it_value.tv_sec, 
                                                             ^
system_timer_native.c:299:61: error: dereferencing pointer to incomplete type
                                                        value->it_value.tv_usec);
                                                             ^
make: *** [system_timer_native.o] Error 1

make failed, exit code 2

Gem files will remain installed in /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/system_timer-1.2.4 for inspection.
Results logged to /opt/td-agent/embedded/lib/ruby/gems/2.1.0/extensions/x86_64-linux/2.1.0/system_timer-1.2.4/gem_make.out
```

I think elasticsearch-transport 2.0.0.pre is problem. So I fix to install elasticsearch-transport stable version.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

