### PR TITLE
Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Similar to `parent_key` config, will add `_routing` into elasticsearch command i
 ```
 parent_key a_parent
 routing_key a_routing
-remove_keys a_parent, a_routing # a_parent and a_routing fileds wont be sent to elasticsearch
+remove_keys a_parent, a_routing # a_parent and a_routing fields won't be sent to elasticsearch
 ```
 
 ### write_operation


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

