### PR TITLE
add param to specify multiple templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Specify index templates in form of hash. Can contain multiple templates.
 templates { "templane_name_1": "path_to_template_1_file", "templane_name_2": "path_to_template_2_file"}
 ```
 
-If `template_file` and `template_name` are set, at first there is the creation of it and then on the hash.
+If `template_file` and `template_name` are set, then this parameter will be ignored.
 
 ### request_timeout
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [target_type_key](#target_type_key)
   + [template_name](#template_name)
   + [template_file](#template_file)
+  + [templates](#templates)
   + [request_timeout](#request_timeout)
   + [reload_connections](#reload_connections)
   + [reload_on_failure](#reload_on_failure)
@@ -239,6 +240,16 @@ This parameter along with template_file allow the plugin to behave similarly to 
 The path to the file containing the template to install.
 
 [template_name](#template_name) must also be specified.
+
+### templates
+
+Specify index templates in form of hash. Can contain multiple templates.
+
+```
+templates { "templane_name_1": "path_to_template_1_file", "templane_name_2": "path_to_template_2_file"}
+```
+
+If `template_file` and `template_name` are set, at first there is the creation of it and then on the hash.
 
 ### request_timeout
 

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -28,4 +28,10 @@ module Fluent::ElasticsearchIndexTemplate
     end
   end
 
+  def templates_hash_install (templates)
+    templates.each do |key, value|
+      template_install(key, value)
+    end
+  end
+
 end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -54,6 +54,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
   config_param :flatten_hashes_separator, :string, :default => "_"
   config_param :template_name, :string, :default => nil
   config_param :template_file, :string, :default => nil
+  config_param :templates, :hash, :default => nil
 
   include Fluent::SetTagKeyMixin
   include Fluent::ElasticsearchIndexTemplate
@@ -87,6 +88,11 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     if @template_name && @template_file
       template_install(@template_name, @template_file)
     end
+
+    if @templates
+      templates_hash_install (@templates)
+    end
+
   end
 
   def start

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -87,9 +87,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
 
     if @template_name && @template_file
       template_install(@template_name, @template_file)
-    end
-
-    if @templates
+    elsif @templates
       templates_hash_install (@templates)
     end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -139,8 +139,46 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver('test', config)
     }
   end
-  
+
   def test_templates_create
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_template.json')
+    config = %{
+      host            logs.google.com
+      port            777
+      scheme          https
+      path            /es/
+      user            john
+      password        doe
+      templates       {"logstash1":"#{template_file}", "logstash2":"#{template_file}","logstash3":"#{template_file}" }
+    }
+
+    stub_request(:head, "https://john:doe@logs.google.com:777/es//").
+      to_return(:status => 200, :body => "", :headers => {})
+     # check if template exists
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash1").
+      to_return(:status => 404, :body => "", :headers => {})
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash2").
+      to_return(:status => 404, :body => "", :headers => {})
+
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash3").
+      to_return(:status => 200, :body => "", :headers => {}) #exists
+
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash1").
+      to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash2").
+      to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash3").
+      to_return(:status => 200, :body => "", :headers => {})
+    
+    driver('test', config)
+    
+    assert_requested( :put, "https://john:doe@logs.google.com:777/es//_template/logstash1", times: 1)
+    assert_requested( :put, "https://john:doe@logs.google.com:777/es//_template/logstash2", times: 1)
+    assert_not_requested(:put, "https://john:doe@logs.google.com:777/es//_template/logstash3") #exists
+  end
+  
+  def test_templates_not_used
     cwd = File.dirname(__FILE__)
     template_file = File.join(cwd, 'test_template.json')
 
@@ -174,6 +212,44 @@ class ElasticsearchOutput < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
 
     driver('test', config)
+
+    assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/logstash", times: 1)
+
+    assert_not_requested(:put, "https://john:doe@logs.google.com:777/es//_template/logstash1")
+    assert_not_requested(:put, "https://john:doe@logs.google.com:777/es//_template/logstash2")
+  end
+
+  def test_templates_can_be_partially_created_if_error_occurs
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_template.json')
+    config = %{
+      host            logs.google.com
+      port            777
+      scheme          https
+      path            /es/
+      user            john
+      password        doe
+      templates       {"logstash1":"#{template_file}", "logstash2":"/abc" }
+    }
+    stub_request(:head, "https://john:doe@logs.google.com:777/es//").
+      to_return(:status => 200, :body => "", :headers => {})
+     # check if template exists
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash1").
+      to_return(:status => 404, :body => "", :headers => {})
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash2").
+      to_return(:status => 404, :body => "", :headers => {})
+
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash1").
+      to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash2").
+      to_return(:status => 200, :body => "", :headers => {})
+
+    assert_raise(RuntimeError) {
+      driver('test', config)
+    }
+    
+    assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/logstash1", times: 1)
+    assert_not_requested(:put, "https://john:doe@logs.google.com:777/es//_template/logstash2")
   end
 
   def test_legacy_hosts_list

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -113,7 +113,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
 
     driver('test', config)
-  end
+  end 
+  
 
   def test_template_create_invalid_filename
     config = %{
@@ -137,6 +138,42 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_raise(RuntimeError) {
       driver('test', config)
     }
+  end
+  
+  def test_templates_create
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_template.json')
+
+    config = %{
+      host            logs.google.com
+      port            777
+      scheme          https
+      path            /es/
+      user            john
+      password        doe
+      template_name   logstash
+      template_file   #{template_file}
+      templates       {"logstash1":"#{template_file}", "logstash2":"#{template_file}" }
+    }    
+    # connection start
+    stub_request(:head, "https://john:doe@logs.google.com:777/es//").
+      to_return(:status => 200, :body => "", :headers => {})
+    # check if template exists
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash").
+      to_return(:status => 404, :body => "", :headers => {})
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash1").
+      to_return(:status => 404, :body => "", :headers => {})
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/logstash2").
+      to_return(:status => 404, :body => "", :headers => {})
+    #creation
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash").
+      to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash1").
+      to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/logstash2").
+      to_return(:status => 200, :body => "", :headers => {})
+
+    driver('test', config)
   end
 
   def test_legacy_hosts_list


### PR DESCRIPTION
Multiple templates.

With `target_index`, `target_type` and `record_transformer` you can use only one output point for any number of indices.
It should be possible set multiple templates to work in such configs.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

