### PR TITLE
Typo in defaults for ssl_verify on elasticsearch_dynamic

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -15,7 +15,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
   config_param :reload_connections, :string, :default => "true"
   config_param :reload_on_failure, :string, :default => "false"
   config_param :resurrect_after, :string, :default => "60"
-  config_param :ssl_verify, :string, :dfeault => "true"
+  config_param :ssl_verify, :string, :default => "true"
 
   def configure(conf)
     super

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -63,6 +63,26 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal 'doe', instance.password
   end
 
+  def test_defaults
+    config = %{
+      host     logs.google.com
+      scheme   https
+      path     /es/
+      user     john
+      password doe
+    }
+    instance = driver('test', config).instance
+
+    assert_equal "9200", instance.port
+    assert_equal "false", instance.logstash_format
+    assert_equal "true", instance.utc_index
+    assert_equal false, instance.time_key_exclude_timestamp
+    assert_equal "true", instance.reload_connections
+    assert_equal "false", instance.reload_on_failure
+    assert_equal "60", instance.resurrect_after
+    assert_equal "true", instance.ssl_verify
+  end
+
   def test_legacy_hosts_list
     config = %{
       hosts    host1:50,host2:100,host3


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)

`ssl_verify` should be enabled by default, but this typo is preventing that.