### PR TITLE
Optimize output plugins

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -9,6 +9,7 @@ begin
 rescue LoadError
 end
 
+require 'fluent/output'
 require_relative 'elasticsearch_index_template'
 
 class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -11,7 +11,7 @@ end
 
 require_relative 'elasticsearch_index_template'
 
-class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
+class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   class ConnectionFailure < StandardError; end
 
   Fluent::Plugin.register_output('elasticsearch', self)
@@ -198,10 +198,6 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     end.join(', ')
   end
 
-  def format(tag, time, record)
-    [tag, time, record].to_msgpack
-  end
-
   def shutdown
     super
   end
@@ -261,7 +257,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     ret
   end
 
-  def write(chunk)
+  def write_objects(tag, chunk)
     bulk_message = []
 
     chunk.msgpack_each do |tag, time, record|

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -55,10 +55,10 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :template_name, :string, :default => nil
   config_param :template_file, :string, :default => nil
   config_param :templates, :hash, :default => nil
+  config_param :include_tag_key, :bool, :default => false
+  config_param :tag_key, :string, :default => 'tag'
 
-  include Fluent::SetTagKeyMixin
   include Fluent::ElasticsearchIndexTemplate
-  config_set_default :include_tag_key, false
 
   def initialize
     super

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -278,7 +278,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
           record['@timestamp'] = record[@time_key] unless time_key_exclude_timestamp
         else
           dt = Time.at(time).to_datetime
-          record.merge!({"@timestamp" => dt.to_s})
+          record["@timestamp"] = dt.to_s
         end
         dt = dt.new_offset(0) if @utc_index
         target_index = "#{@logstash_prefix}-#{dt.strftime(@logstash_dateformat)}"
@@ -290,7 +290,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       # allow upper-case characters in index names.
       target_index = target_index.downcase
       if @include_tag_key
-        record.merge!(@tag_key => tag)
+        record[@tag_key] = tag
       end
 
       target_type_parent, target_type_child_key = get_parent_of(record, @target_type_key)

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -347,7 +347,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     end
 
     send_bulk(bulk_message) unless bulk_message.empty?
-    bulk_message = nil
+    bulk_message.clear
   end
 
   # returns [parent, child_key] of child described by path array in record's tree

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -291,11 +291,11 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     meta = {}
 
     chunk.msgpack_each do |time, record|
+      next unless record.is_a? Hash
+
       if @flatten_hashes
         record = flatten_record(record)
       end
-
-      next unless record.is_a? Hash
 
       target_index_parent, target_index_child_key = @target_index_key ? get_parent_of(record, @target_index_key) : nil
       if target_index_parent && target_index_parent[target_index_child_key]

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -295,7 +295,8 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       end
 
       next unless record.is_a? Hash
-      target_index_parent, target_index_child_key = get_parent_of(record, @target_index_key)
+
+      target_index_parent, target_index_child_key = @target_index_key ? get_parent_of(record, @target_index_key) : nil
       if target_index_parent && target_index_parent[target_index_child_key]
         target_index = target_index_parent.delete(target_index_child_key)
       elsif @logstash_format
@@ -322,7 +323,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
         record[@tag_key] = tag
       end
 
-      target_type_parent, target_type_child_key = get_parent_of(record, @target_type_key)
+      target_type_parent, target_type_child_key = @target_type_key ? get_parent_of(record, @target_type_key) : nil
       if target_type_parent && target_type_parent[target_type_child_key]
         target_type = target_type_parent.delete(target_type_child_key)
       else
@@ -351,8 +352,6 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   # returns [parent, child_key] of child described by path array in record's tree
   # returns [nil, child_key] if path doesnt exist in record
   def get_parent_of(record, path)
-    return [nil, nil] unless path
-
     parent_object = path[0..-2].reduce(record) { |a, e| a.is_a?(Hash) ? a[e] : nil }
     [parent_object, path[-1]]
   end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -249,7 +249,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
 
   def update_body(record, op)
     update = remove_keys(record)
-    body = {"doc".freeze => update }
+    body = {"doc".freeze => update}
     if op == UPSERT_OP
       if update == record
         body["doc_as_upsert".freeze] = true
@@ -300,15 +300,15 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       if target_index_parent && target_index_parent[target_index_child_key]
         target_index = target_index_parent.delete(target_index_child_key)
       elsif @logstash_format
-        if record.has_key?("@timestamp")
-          dt = record["@timestamp"]
-          dt = @time_parser.parse(record["@timestamp"], time)
+        if record.has_key?(TIMESTAMP_FIELD)
+          dt = record[TIMESTAMP_FIELD]
+          dt = @time_parser.parse(record[TIMESTAMP_FIELD], time)
         elsif record.has_key?(@time_key)
           dt = @time_parser.parse(record[@time_key], time)
-          record['@timestamp'] = record[@time_key] unless time_key_exclude_timestamp
+          record[TIMESTAMP_FIELD] = record[@time_key] unless time_key_exclude_timestamp
         else
           dt = Time.at(time).to_datetime
-          record["@timestamp"] = dt.to_s
+          record[TIMESTAMP_FIELD] = dt.to_s
         end
         dt = dt.new_offset(0) if @utc_index
         target_index = "#{@logstash_prefix}-#{dt.strftime(@logstash_dateformat)}"

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -189,8 +189,8 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
     end
 
     bulk_message.each do |hKey, msgs|
-      send_builk(msgs, hKey) unless msgs.empty?
-      msgs = nil
+      send_bulk(msgs, hKey) unless msgs.empty?
+      msgs.clear
     end
   end
 


### PR DESCRIPTION
I sometimes receives the report which Elasticsearch plugin consumes lots of memory rathar than other plugins.
So I optimizes performance and memory usage by reducing object allocation.
Approaches are:
- Convert events into json before passes elasticsearch-ruby. elasticsearch-ruby re-creates incoming array in `bulk` method. Passing string avoids it.
- Reuse meta header object. Old implementation creates hash object in each loop. Each write operation uses corresponding fixed format, so we can reuse it.
- Use ObjectBufferedOutput plugin instead of BufferedOutput to reduce format/serialization cost.
- [x] tests passing
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)

This patch changes lots of places, so need tests on some actual workloads.
On my laptop, memory usage becomes around 200MB from around 400MB with 1000,000 records import.
