### PR TITLE
send method name is changed to send_bulk since it is a reserved keyword

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -315,7 +315,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
       append_record_to_messages(@write_operation, meta, record, bulk_message)
     end
 
-    send(bulk_message) unless bulk_message.empty?
+    send_bulk(bulk_message) unless bulk_message.empty?
     bulk_message.clear
   end
 
@@ -328,7 +328,7 @@ class Fluent::ElasticsearchOutput < Fluent::BufferedOutput
     [parent_object, path[-1]]
   end
 
-  def send(data)
+  def send_bulk(data)
     retries = 0
     begin
       client.bulk body: data

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -178,12 +178,12 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
     end
 
     bulk_message.each do | hKey, array |
-      send(array, hKey) unless array.empty?
+      send_bulk(array, hKey) unless array.empty?
       array.clear
     end
   end
 
-  def send(data, host)
+  def send_bulk(data, host)
     retries = 0
     begin
       client(host).bulk body: data


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)

