### PR TITLE
Improve time parse error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [remove_keys_on_update](#remove_keys_on_update)
   + [remove_keys_on_update_key](#remove_keys_on_update_key)
   + [write_operation](#write_operation)
+  + [time_parse_error_tag](#time_parse_error_tag)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffered output options](#buffered-output-options)
@@ -391,6 +392,13 @@ The write_operation can be any of:
 | upsert      | known as merge or insert if the data does not exist, updates if the data exists (based on its id).|
 
 **Please note, id is required in create, update, and upsert scenario. Without id, the message will be dropped.**
+
+### time_parse_error_tag
+
+With `logstash_format true`, elasticsearch plugin parses timestamp field for generating index name. If the record has invalid timestamp value, this plugin emits an error event to `@ERROR` label with `time_parse_error_tag` configured tag.
+
+Default value is `Fluent::ElasticsearchOutput::TimeParser.error` for backward compatibility. `::` separated tag is not good for tag routing because some plugins assume tag is separated by `.`. We recommend to set this parameter like `time_parse_error_tag es_plugin.output.time.error`.
+We will change default value to `.` separated tag.
 
 ### Client/host certificate options
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -109,10 +109,6 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     result
   end
 
-  def start
-    super
-  end
-
   # once fluent v0.14 is released we might be able to use
   # Fluent::Parser::TimeParser, but it doesn't quite do what we want - if gives
   # [sec,nsec] where as we want something we can call `strftime` on...
@@ -208,10 +204,6 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       attributes[:password] = 'obfuscated' if attributes.has_key?(:password)
       attributes.inspect
     end.join(', ')
-  end
-
-  def shutdown
-    super
   end
 
   BODY_DELIMITER = "\n".freeze

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -58,6 +58,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :templates, :hash, :default => nil
   config_param :include_tag_key, :bool, :default => false
   config_param :tag_key, :string, :default => 'tag'
+  config_param :time_parse_error_tag, :string, :default => 'Fluent::ElasticsearchOutput::TimeParser.error'
 
   include Fluent::ElasticsearchIndexTemplate
 
@@ -133,7 +134,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   def parse_time(value, event_time, tag)
     @time_parser.call(value)
   rescue => e
-    router.emit_error_event("Fluent::ElasticsearchOutput::TimeParser.error", Fluent::Engine.now, {'tag' => tag, 'time' => event_time, 'format' => @time_key_format, 'value' => value}, e)
+    router.emit_error_event(@time_parse_error_tag, Fluent::Engine.now, {'tag' => tag, 'time' => event_time, 'format' => @time_key_format, 'value' => value}, e)
     return Time.at(event_time).to_datetime
   end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -297,11 +297,12 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
         target_index = target_index_parent.delete(target_index_child_key)
       elsif @logstash_format
         if record.has_key?(TIMESTAMP_FIELD)
-          dt = record[TIMESTAMP_FIELD]
-          dt = parse_time(record[TIMESTAMP_FIELD], time, tag)
+          rts = record[TIMESTAMP_FIELD]
+          dt = parse_time(rts, time, tag)
         elsif record.has_key?(@time_key)
-          dt = parse_time(record[@time_key], time, tag)
-          record[TIMESTAMP_FIELD] = record[@time_key] unless time_key_exclude_timestamp
+          rts = record[@time_key]
+          dt = parse_time(rts, time, tag)
+          record[TIMESTAMP_FIELD] = rts unless @time_key_exclude_timestamp
         else
           dt = Time.at(time).to_datetime
           record[TIMESTAMP_FIELD] = dt.to_s


### PR DESCRIPTION
Improve time parse error handling. In addition, I did small refacotring.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
