### PR TITLE
--add reset connection on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [remove_keys_on_update_key](#remove_keys_on_update_key)
   + [write_operation](#write_operation)
   + [time_parse_error_tag](#time_parse_error_tag)
-  + [reconnect_on_error](#reset_on_error)
+  + [reconnect_on_error](#reconnect_on_error)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffered output options](#buffered-output-options)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [remove_keys_on_update_key](#remove_keys_on_update_key)
   + [write_operation](#write_operation)
   + [time_parse_error_tag](#time_parse_error_tag)
-  + [reset_on_error](#reset_on_error)
+  + [reconnect_on_error](#reset_on_error)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffered output options](#buffered-output-options)
@@ -401,12 +401,12 @@ With `logstash_format true`, elasticsearch plugin parses timestamp field for gen
 Default value is `Fluent::ElasticsearchOutput::TimeParser.error` for backward compatibility. `::` separated tag is not good for tag routing because some plugins assume tag is separated by `.`. We recommend to set this parameter like `time_parse_error_tag es_plugin.output.time.error`.
 We will change default value to `.` separated tag.
 
-### reset_on_error
-Indicates that the plugin should reset connection on any error.
-By default it will reset connection only on "host unreachable exceptions".
+### reconnect_on_error
+Indicates that the plugin should reset connection on any error (reconnect on next send).
+By default it will reconnect only on "host unreachable exceptions".
 We recommended to set this true in the presence of elasticsearch shield.
 ```
-reset_on_error true # defaults to false
+reconnect_on_error true # defaults to false
 ```
 
 ### Client/host certificate options

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [remove_keys_on_update_key](#remove_keys_on_update_key)
   + [write_operation](#write_operation)
   + [time_parse_error_tag](#time_parse_error_tag)
+  + [reset_on_error](#reset_on_error)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffered output options](#buffered-output-options)
@@ -399,6 +400,14 @@ With `logstash_format true`, elasticsearch plugin parses timestamp field for gen
 
 Default value is `Fluent::ElasticsearchOutput::TimeParser.error` for backward compatibility. `::` separated tag is not good for tag routing because some plugins assume tag is separated by `.`. We recommend to set this parameter like `time_parse_error_tag es_plugin.output.time.error`.
 We will change default value to `.` separated tag.
+
+### reset_on_error
+Indicates that the plugin should reset connection on any error.
+By default it will reset connection only on "host unreachable exceptions".
+We recommended to set this true in the presence of elasticsearch shield.
+```
+reset_on_error true # defaults to false
+```
 
 ### Client/host certificate options
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -59,6 +59,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :include_tag_key, :bool, :default => false
   config_param :tag_key, :string, :default => 'tag'
   config_param :time_parse_error_tag, :string, :default => 'Fluent::ElasticsearchOutput::TimeParser.error'
+  config_param :reset_on_error, :bool, :default => false
 
   include Fluent::ElasticsearchIndexTemplate
 
@@ -359,6 +360,9 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
         retry
       end
       raise ConnectionFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
+    rescue Exception
+      @_es = nil if @reset_on_error
+      raise
     end
   end
 end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -59,7 +59,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :include_tag_key, :bool, :default => false
   config_param :tag_key, :string, :default => 'tag'
   config_param :time_parse_error_tag, :string, :default => 'Fluent::ElasticsearchOutput::TimeParser.error'
-  config_param :reset_on_error, :bool, :default => false
+  config_param :reconnect_on_error, :bool, :default => false
 
   include Fluent::ElasticsearchIndexTemplate
 
@@ -361,7 +361,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       end
       raise ConnectionFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
     rescue Exception
-      @_es = nil if @reset_on_error
+      @_es = nil if @reconnect_on_error
       raise
     end
   end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -16,7 +16,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
   config_param :reload_on_failure, :string, :default => "false"
   config_param :resurrect_after, :string, :default => "60"
   config_param :ssl_verify, :string, :default => "true"
-  config_param :reset_on_error, :bool, :default => false
+  config_param :reconnect_on_error, :bool, :default => false
 
   def configure(conf)
     super
@@ -209,7 +209,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
       end
       raise ConnectionFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
     rescue Exception
-      @_es = nil if @reset_on_error
+      @_es = nil if @reconnect_on_error
       raise
     end
   end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -16,6 +16,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
   config_param :reload_on_failure, :string, :default => "false"
   config_param :resurrect_after, :string, :default => "60"
   config_param :ssl_verify, :string, :default => "true"
+  config_param :reset_on_error, :bool, :default => false
 
   def configure(conf)
     super
@@ -207,6 +208,9 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
         retry
       end
       raise ConnectionFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
+    rescue Exception
+      @_es = nil if @reset_on_error
+      raise
     end
   end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -914,6 +914,54 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(connection_resets, 3)
   end
 
+  def test_reset_connection_on_error_enabled
+    connection_resets = 0
+
+    stub_elastic_ping(url="http://localhost:9200").with do |req|
+      connection_resets += 1
+    end
+
+    stub_request(:post, "http://localhost:9200/_bulk").with do |req|
+      raise ZeroDivisionError, "Test message"
+    end
+    
+    driver.configure("reset_on_error true\n")
+    driver.emit(sample_record)
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+    assert_equal(connection_resets, 2)
+  end
+
+  def test_reset_connection_on_error_disabled
+    connection_resets = 0
+
+    stub_elastic_ping(url="http://localhost:9200").with do |req|
+      connection_resets += 1
+    end
+
+    stub_request(:post, "http://localhost:9200/_bulk").with do |req|
+      raise ZeroDivisionError, "Test message"
+    end
+    
+    driver.configure("reset_on_error false\n")
+    driver.emit(sample_record)
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+    assert_equal(connection_resets, 1)
+  end
+
   def test_update_should_not_write_if_theres_no_id
     driver.configure("write_operation update\n")
     stub_elastic_ping

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -914,7 +914,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(connection_resets, 3)
   end
 
-  def test_reset_connection_on_error_enabled
+  def test_reconnect_on_error_enabled
     connection_resets = 0
 
     stub_elastic_ping(url="http://localhost:9200").with do |req|
@@ -922,10 +922,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
 
     stub_request(:post, "http://localhost:9200/_bulk").with do |req|
-      raise ZeroDivisionError, "Test message"
+      raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
     
-    driver.configure("reset_on_error true\n")
+    driver.configure("reconnect_on_error true\n")
     driver.emit(sample_record)
 
     assert_raise(ZeroDivisionError) {
@@ -938,7 +938,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(connection_resets, 2)
   end
 
-  def test_reset_connection_on_error_disabled
+  def test_reconnect_on_error_disabled
     connection_resets = 0
 
     stub_elastic_ping(url="http://localhost:9200").with do |req|
@@ -946,10 +946,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
 
     stub_request(:post, "http://localhost:9200/_bulk").with do |req|
-      raise ZeroDivisionError, "Test message"
+      raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
     
-    driver.configure("reset_on_error false\n")
+    driver.configure("reconnect_on_error false\n")
     driver.emit(sample_record)
 
     assert_raise(ZeroDivisionError) {

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -538,7 +538,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal(connection_resets, 3)
   end
 
-  def test_reset_connection_on_error_enabled
+  def test_reconnect_on_error_enabled
     connection_resets = 0
 
     stub_elastic_ping(url="http://localhost:9200").with do |req|
@@ -549,7 +549,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
     
-    driver.configure("reset_on_error true\n")
+    driver.configure("reconnect_on_error true\n")
     driver.emit(sample_record)
 
     assert_raise(ZeroDivisionError) {
@@ -562,7 +562,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal(connection_resets, 2)
   end
 
-  def test_reset_connection_on_error_disabled
+  def test_reconnect_on_error_disabled
     connection_resets = 0
 
     stub_elastic_ping(url="http://localhost:9200").with do |req|
@@ -573,7 +573,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
     
-    driver.configure("reset_on_error false\n")
+    driver.configure("reconnect_on_error false\n")
     driver.emit(sample_record)
 
     assert_raise(ZeroDivisionError) {

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -538,6 +538,54 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal(connection_resets, 3)
   end
 
+  def test_reset_connection_on_error_enabled
+    connection_resets = 0
+
+    stub_elastic_ping(url="http://localhost:9200").with do |req|
+      connection_resets += 1
+    end
+
+    stub_request(:post, "http://localhost:9200/_bulk").with do |req|
+      raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
+    end
+    
+    driver.configure("reset_on_error true\n")
+    driver.emit(sample_record)
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+    assert_equal(connection_resets, 2)
+  end
+
+  def test_reset_connection_on_error_disabled
+    connection_resets = 0
+
+    stub_elastic_ping(url="http://localhost:9200").with do |req|
+      connection_resets += 1
+    end
+
+    stub_request(:post, "http://localhost:9200/_bulk").with do |req|
+      raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
+    end
+    
+    driver.configure("reset_on_error false\n")
+    driver.emit(sample_record)
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+
+    assert_raise(ZeroDivisionError) {
+      driver.run
+    }
+    assert_equal(connection_resets, 1)
+  end
+
   def test_update_should_not_write_if_theres_no_id
     driver.configure("write_operation update\n")
     stub_elastic_ping


### PR DESCRIPTION
Add option to reset connection on any error.(#213)

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)

