### PR TITLE
Converting string to bool in dynamicconfig.

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -1,6 +1,12 @@
 # encoding: UTF-8
 require_relative 'out_elasticsearch'
 
+class String
+  def to_bool
+    self == 'true'
+  end
+end
+
 class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
 
   Fluent::Plugin.register_output('elasticsearch_dynamic', self)
@@ -51,8 +57,8 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
       adapter_conf = lambda {|f| f.adapter :excon, excon_options }
       transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                           options: {
-                                                                            reload_connections: to_b(@dynamic_config['reload_connections']),
-                                                                            reload_on_failure: to_b(@dynamic_config['reload_on_failure']),
+                                                                            reload_connections: @dynamic_config['reload_connections'].to_bool,
+                                                                            reload_on_failure: @dynamic_config['reload_on_failure'].to_bool,
                                                                             resurrect_after: @dynamic_config['resurrect_after'].to_i,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {
@@ -264,9 +270,5 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
     end
 
     return true
-  end
-
-  def to_b(args)
-    args == "true" ? true : false
   end
 end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -51,8 +51,8 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
       adapter_conf = lambda {|f| f.adapter :excon, excon_options }
       transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                           options: {
-                                                                            reload_connections: @dynamic_config['reload_connections'],
-                                                                            reload_on_failure: @dynamic_config['reload_on_failure'],
+                                                                            reload_connections: to_b(@dynamic_config['reload_connections']),
+                                                                            reload_on_failure: to_b(@dynamic_config['reload_on_failure']),
                                                                             resurrect_after: @dynamic_config['resurrect_after'].to_i,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {
@@ -264,5 +264,9 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
     end
 
     return true
+  end
+
+  def to_b(args)
+    args == "true" ? true : false
   end
 end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -1,12 +1,6 @@
 # encoding: UTF-8
 require_relative 'out_elasticsearch'
 
-class String
-  def to_bool
-    self == 'true'
-  end
-end
-
 class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
 
   Fluent::Plugin.register_output('elasticsearch_dynamic', self)
@@ -57,8 +51,8 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
       adapter_conf = lambda {|f| f.adapter :excon, excon_options }
       transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                           options: {
-                                                                            reload_connections: @dynamic_config['reload_connections'].to_bool,
-                                                                            reload_on_failure: @dynamic_config['reload_on_failure'].to_bool,
+                                                                            reload_connections: Fluent::Config.bool_value(@dynamic_config['reload_connections']),
+                                                                            reload_on_failure: Fluent::Config.bool_value(@dynamic_config['reload_on_failure']),
                                                                             resurrect_after: @dynamic_config['resurrect_after'].to_i,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {


### PR DESCRIPTION
DESCRIPTION HERE
reload_connections and reload_on_failure are expected as bool in Elasticsearch Client.

There are many discussion to be related this issue.
https://discuss.elastic.co/t/elasitcsearch-ruby-raises-cannot-get-new-connection-from-pool-error/36252
https://forums.aws.amazon.com/thread.jspa?threadID=222600
https://github.com/atomita/fluent-plugin-aws-elasticsearch-service/issues/15

I found this PR will fix "Cannot get new connection from pool."  error when sending logs to some kind of elasticsearch clusters whose _nodes API doesn't return IP address of nodes. This kind of elasticsearch is not only AWS elasticsearch but also the elasticsearch behind http proxy.
Elasticsearch Ruby client expects reload_connections and reload_on_failure parameter as a bool type. 
https://github.com/elastic/elasticsearch-ruby/issues/164

However, when we use your dynamic configuration feature, these parameters would be string type. Then reload_connections method are invoked at some point even if we specify ``reload_connections false``. 
https://github.com/elastic/elasticsearch-ruby/blob/v2.0.0/elasticsearch-transport/lib/elasticsearch/transport/transport/base.rb#L70
```ruby
reload_connections!         if reload_connections && counter % reload_after == 0
```

If you find something wrong in my PR, please let me know.

(check all that apply)
- [ ] tests added: difficult to add test.
- [X] tests passing
- [X] README updated (if needed)
- [X] README Table of Contents updated (if needed)
- [X] History.md and `version` in gemspec are untouched
- [X] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

