### PR TITLE
Fix elasticsearch_dynamic for v0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,9 @@ rvm:
   - 2.2
   - 2.3.1
 
+gemfile:
+ - Gemfile
+ - Gemfile.v0.12
+
 script: bundle exec rake test
 sudo: false

--- a/Gemfile.v0.12
+++ b/Gemfile.v0.12
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in fluent-plugin-elasticsearch.gemspec
+gem 'fluentd', '~> 0.12.0'
+
+gemspec
+
+
+gem 'simplecov', require: false
+gem 'coveralls', require: false
+gem 'strptime', require: false if RUBY_ENGINE == "ruby" && RUBY_VERSION =~ /^2/

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -12,11 +12,6 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
   config_param :logstash_format, :string, :default => "false"
   config_param :utc_index, :string, :default => "true"
   config_param :time_key_exclude_timestamp, :bool, :default => false
-  config_param :reload_connections, :string, :default => "true"
-  config_param :reload_on_failure, :string, :default => "false"
-  config_param :resurrect_after, :string, :default => "60"
-  config_param :ssl_verify, :string, :default => "true"
-  config_param :reconnect_on_error, :bool, :default => false
 
   def configure(conf)
     super
@@ -47,17 +42,17 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
 
     @_es ||= begin
       @current_config = connection_options[:hosts].clone
-      excon_options = { client_key: @dynamic_config['client_key'], client_cert: @dynamic_config['client_cert'], client_key_pass: @dynamic_config['client_key_pass'] }
+      excon_options = { client_key: @client_key, client_cert: @client_cert, client_key_pass: @client_key_pass }
       adapter_conf = lambda {|f| f.adapter :excon, excon_options }
       transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                           options: {
-                                                                            reload_connections: Fluent::Config.bool_value(@dynamic_config['reload_connections']),
-                                                                            reload_on_failure: Fluent::Config.bool_value(@dynamic_config['reload_on_failure']),
-                                                                            resurrect_after: @dynamic_config['resurrect_after'].to_i,
+                                                                            reload_connections: @reload_connections,
+                                                                            reload_on_failure: @reload_on_failure,
+                                                                            resurrect_after: @resurrect_after,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {
-                                                                              request: { timeout: @dynamic_config['request_timeout'] },
-                                                                              ssl: { verify: @dynamic_config['ssl_verify'], ca_file: @dynamic_config['ca_file'] }
+                                                                              request: { timeout: @request_timeout },
+                                                                              ssl: { verify: @ssl_verify, ca_file: @ca_file }
                                                                             }
                                                                           }), &adapter_conf)
       es = Elasticsearch::Client.new transport: transport
@@ -74,16 +69,16 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
   end
 
   def get_connection_options(con_host)
-    raise "`password` must be present if `user` is present" if @dynamic_config['user'] && !@dynamic_config['password']
+    raise "`password` must be present if `user` is present" if @user && !@password
 
-    hosts = if con_host || @dynamic_config['hosts']
-      (con_host || @dynamic_config['hosts']).split(',').map do |host_str|
+    hosts = if con_host || @hosts
+      (con_host || @hosts).split(',').map do |host_str|
         # Support legacy hosts format host:port,host:port,host:port...
         if host_str.match(%r{^[^:]+(\:\d+)?$})
           {
             host:   host_str.split(':')[0],
-            port:   (host_str.split(':')[1] || @dynamic_config['port'] || @port).to_i,
-            scheme: @dynamic_config['scheme']
+            port:   (host_str.split(':')[1] || @port).to_i,
+            scheme: @scheme
           }
         else
           # New hosts format expects URLs such as http://logs.foo.com,https://john:pass@logs2.foo.com/elastic
@@ -95,10 +90,10 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
         end
       end.compact
     else
-      [{host: @dynamic_config['host'], port: @dynamic_config['port'].to_i, scheme: @dynamic_config['scheme']}]
+      [{host: @host, port: @port.to_i, scheme: @scheme}]
     end.each do |host|
-      host.merge!(user: @dynamic_config['user'], password: @dynamic_config['password']) if !host[:user] && @dynamic_config['user']
-      host.merge!(path: @dynamic_config['path']) if !host[:path] && @dynamic_config['path']
+      host.merge!(user: @user, password: @password) if !host[:user] && @user
+      host.merge!(path: @path) if !host[:path] && @path
     end
 
     {

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -7,14 +7,10 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
 
   config_param :delimiter, :string, :default => "."
 
-  # params overloaded as strings
-  config_param :port, :string, :default => "9200"
-  config_param :logstash_format, :string, :default => "false"
-  config_param :utc_index, :string, :default => "true"
-  config_param :time_key_exclude_timestamp, :bool, :default => false
-
   DYNAMIC_PARAM_NAMES = %W[hosts host port logstash_format logstash_prefix logstash_dateformat time_key utc_index index_name tag_key type_name id_key parent_key routing_key write_operation]
   DYNAMIC_PARAM_SYMBOLS = DYNAMIC_PARAM_NAMES.map { |n| "@#{n}".to_sym }
+
+  attr_reader :dynamic_config
 
   def configure(conf)
     super
@@ -24,7 +20,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
     DYNAMIC_PARAM_SYMBOLS.each_with_index { |var, i|
       value = expand_param(self.instance_variable_get(var), nil, nil, nil)
       key = DYNAMIC_PARAM_NAMES[i]
-      @dynamic_config[key] = value
+      @dynamic_config[key] = value.to_s
     }
     # end eval all configs
     @current_config = nil

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -13,7 +13,14 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   def driver(tag='test', conf='')
-    @driver ||= Fluent::Test::BufferedOutputTestDriver.new(Fluent::ElasticsearchOutput, tag).configure(conf)
+    @driver ||= Fluent::Test::BufferedOutputTestDriver.new(Fluent::ElasticsearchOutput, tag) {
+      # v0.12's test driver assume format definition. This simulates ObjectBufferedOutput format
+      if !defined?(Fluent::Plugin::Output)
+        def format(tag, time, record)
+          [time, record].to_msgpack
+        end
+      end
+    }.configure(conf)
   end
 
   def sample_record
@@ -1134,5 +1141,4 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert(index_cmds[0].has_key?("create"))
   end
-
 end

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -77,10 +77,6 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal "false", instance.logstash_format
     assert_equal "true", instance.utc_index
     assert_equal false, instance.time_key_exclude_timestamp
-    assert_equal "true", instance.reload_connections
-    assert_equal "false", instance.reload_on_failure
-    assert_equal "60", instance.resurrect_after
-    assert_equal "true", instance.ssl_verify
   end
 
   def test_legacy_hosts_list

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -11,7 +11,14 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   end
 
   def driver(tag='test', conf='')
-    @driver ||= Fluent::Test::BufferedOutputTestDriver.new(Fluent::ElasticsearchOutputDynamic, tag).configure(conf)
+    @driver ||= Fluent::Test::BufferedOutputTestDriver.new(Fluent::ElasticsearchOutputDynamic, tag) {
+      # v0.12's test driver assume format definition. This simulates ObjectBufferedOutput format
+      if !defined?(Fluent::Plugin::Output)
+        def format(tag, time, record)
+          [time, record].to_msgpack
+        end
+      end
+    }.configure(conf)
   end
 
   def sample_record
@@ -55,12 +62,12 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }
     instance = driver('test', config).instance
 
-    assert_equal 'logs.google.com', instance.host
-    assert_equal 777, instance.port
-    assert_equal 'https', instance.scheme
-    assert_equal '/es/', instance.path
+    conf = instance.dynamic_config
+    assert_equal 'logs.google.com', conf['host']
+    assert_equal "777", conf['port']
     assert_equal 'john', instance.user
     assert_equal 'doe', instance.password
+    assert_equal '/es/', instance.path
   end
 
   def test_defaults
@@ -73,9 +80,10 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }
     instance = driver('test', config).instance
 
-    assert_equal "9200", instance.port
-    assert_equal "false", instance.logstash_format
-    assert_equal "true", instance.utc_index
+    conf = instance.dynamic_config
+    assert_equal "9200", conf['port']
+    assert_equal "false", conf['logstash_format']
+    assert_equal "true", conf['utc_index']
     assert_equal false, instance.time_key_exclude_timestamp
   end
 


### PR DESCRIPTION
`elasticsearch_dynamic` depends on fluentd's internal implementation and it is why `elasticsearch_dynamic` doesn't work with v0.14.
This patch fixes the problem by changing the approach.

- Use whitelist approach for dynamic parameters.
- Use fixed value for connection related parameters. These are not dynamic.
- Add v0.12 test for compatibility check in travis

I confirmed https://github.com/uken/fluent-plugin-elasticsearch/issues/193#issuecomment-242493899 this configuration works.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
