### PR TITLE
add additional logging when client.bulk results in errors

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -352,9 +352,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     begin
       response = client.bulk body: data
       if response['errors']
-        message = "Could not push log to Elasticsearch.\n"
-        response['items'].each { |item| message += "#{item}\n" } unless response['items'].nil?
-        log.error message
+        log.error "Could not push log to Elasticsearch: #{response}"
       end
     rescue *client.transport.host_unreachable_exceptions => e
       if retries < 2

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -192,9 +192,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
     begin
       response = client(host).bulk body: data
       if response['errors']
-        message = "Could not push log to Elasticsearch.\n"
-        response['items'].each { |item| message += "#{item}\n" } unless response['items'].nil?
-        log.error message
+        log.error "Could not push log to Elasticsearch: #{response}"
       end
     rescue *client(host).transport.host_unreachable_exceptions => e
       if retries < 2


### PR DESCRIPTION
Additional logging when client.bulk results in errors (https://github.com/uken/fluent-plugin-elasticsearch/issues/227).

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

The tests are running after the changes and I have checked that the logging actually happens in my setup (described in the issue report). I have also added the change to the dynamic mode but I haven't tested it, however according to unit tests it should be fine.