### PR TITLE
Use latest elasticsearch-ruby

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fluentd', '>= 0.10.43'
   s.add_runtime_dependency 'excon', '>= 0'
-  s.add_runtime_dependency 'elasticsearch', '< 1.1'
+  s.add_runtime_dependency 'elasticsearch'
 
 
   s.add_development_dependency 'rake', '>= 0'


### PR DESCRIPTION
Hi

I use Elasticsearch 5.x.

When I used fluent-plugin-elasticsearch 1.9.0, the following error occured.

```
error_class="Elasticsearch::Transport::Transport::Error" error="Cannot get new connection from pool." plugin_id="..."
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/elasticsearch-transport-1.0.18/lib/elasticsearch/transport/transport/base.rb:249:in `perform_request'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/elasticsearch-transport-1.0.18/lib/elasticsearch/transport/transport/http/faraday.rb:20:in `perform_request'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/elasticsearch-transport-1.0.18/lib/elasticsearch/transport/client.rb:128:in `perform_request'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/elasticsearch-api-1.0.18/lib/elasticsearch/api/actions/bulk.rb:90:in `bulk'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/fluent-plugin-elasticsearch-1.9.0/lib/fluent/plugin/out_elasticsearch.rb:353:in `send_bulk'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/fluent-plugin-elasticsearch-1.9.0/lib/fluent/plugin/out_elasticsearch.rb:339:in `write_objects'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/fluentd-0.12.27/lib/fluent/output.rb:480:in `write'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/fluentd-0.12.27/lib/fluent/buffer.rb:354:in `write_chunk'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/fluentd-0.12.27/lib/fluent/buffer.rb:333:in `pop'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/fluentd-0.12.27/lib/fluent/output.rb:338:in `try_flush'
/home/.../local/ruby-2.1/lib/ruby/gems/2.1.0/gems/fluentd-0.12.27/lib/fluent/output.rb:149:in `run'
```

elasticsearch-ruby 5.x is correspondent with Elasticsearch 5.x
https://github.com/elastic/elasticsearch-ruby

Why do you use elasticsearch-ruby 1.x?

After I upgraded elasticsearch-ruby, this error didn't occur.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
