### PR TITLE
configurable sub-second precision with no time key

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [logstash_prefix](#logstash_prefix)
   + [logstash_dateformat](#logstash_dateformat)
   + [time_key_format](#time_key_format)
+  + [time_precision](#time_precision)
   + [time_key](#time_key)
   + [time_key_exclude_timestamp](#time_key_exclude_timestamp)
   + [utc_index](#utc_index)
@@ -139,6 +140,12 @@ For example to parse ISO8601 times with sub-second precision:
 ```
 time_key_format %Y-%m-%dT%H:%M:%S.%N%z
 ```
+
+### time_precision
+
+Should the record not include a `time_key`, define the degree of sub-second time precision to preserve from the `time` portion of the routed event.
+
+For example, should your input plugin not include a `time_key` in the record but it able to pass a `time` to the router when emitting the event (AWS CloudWatch events are an example of this), then this setting will allow you to preserve the sub-second time resolution of those events. This is the case for: [fluent-plugin-cloudwatch-ingest](https://github.com/sampointer/fluent-plugin-cloudwatch-ingest).
 
 ### time_key
 
@@ -360,7 +367,7 @@ remove_keys a_parent, a_routing # a_parent and a_routing fields won't be sent to
 
 ### remove_keys_on_update
 
-Remove keys on update will not update the configured keys in elasticsearch when a record is being updated.  
+Remove keys on update will not update the configured keys in elasticsearch when a record is being updated.
 This setting only has any effect if the write operation is update or upsert.
 
 If the write setting is upsert then these keys are only removed if the record is being

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -27,6 +27,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :target_index_key, :string, :default => nil
   config_param :target_type_key, :string, :default => nil
   config_param :time_key_format, :string, :default => nil
+  config_param :time_precision, :integer, :default => 0
   config_param :logstash_format, :bool, :default => false
   config_param :logstash_prefix, :string, :default => "logstash"
   config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
@@ -299,7 +300,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
           record[TIMESTAMP_FIELD] = rts unless @time_key_exclude_timestamp
         else
           dt = Time.at(time).to_datetime
-          record[TIMESTAMP_FIELD] = dt.to_s
+          record[TIMESTAMP_FIELD] = dt.iso8601(@time_precision)
         end
         dt = dt.new_offset(0) if @utc_index
         target_index = "#{@logstash_prefix}-#{dt.strftime(@logstash_dateformat)}"


### PR DESCRIPTION
For input plugins that do not provide a time key as part of the
record but do provide a `time` to the router, allow the degree
of sub-second time precision to be configurable.

Some sources (such as AWS CloudWatch) may provide an accurate time
source but do not include a time portion for an otherwise free-form
record: there is nothing to parse.

In this case the casting of a `DateTime` to a `String` loses any
sub-second precision.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
