### PR TITLE
Include 'Content-Type' header in `transport_options`

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -150,6 +150,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
                                                                             resurrect_after: @resurrect_after,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {
+                                                                              headers: { 'Content-Type' => 'application/json' },
                                                                               request: { timeout: @request_timeout },
                                                                               ssl: { verify: @ssl_verify, ca_file: @ca_file }
                                                                             }

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -48,6 +48,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
                                                                             resurrect_after: @resurrect_after,
                                                                             retry_on_failure: 5,
                                                                             transport_options: {
+                                                                              headers: { 'Content-Type' => 'application/json' },
                                                                               request: { timeout: @request_timeout },
                                                                               ssl: { verify: @ssl_verify, ca_file: @ca_file }
                                                                             }

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -326,6 +326,16 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal nil, host1[:path]
   end
 
+  def test_content_type_header
+    stub_request(:head, "http://localhost:9200/").
+      to_return(:status => 200, :body => "", :headers => {})
+    elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+      with(headers: { "Content-Type" => "application/json" })
+    driver.emit(sample_record)
+    driver.run
+    assert_requested(elastic_request)
+  end
+
   def test_writes_to_default_index
     stub_elastic_ping
     stub_elastic

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -154,6 +154,16 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal nil, host1[:path]
   end
 
+  def test_content_type_header
+    stub_request(:head, "http://localhost:9200/").
+      to_return(:status => 200, :body => "", :headers => {})
+    elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+      with(headers: { "Content-Type" => "application/json" })
+    driver.emit(sample_record)
+    driver.run
+    assert_requested(elastic_request)
+  end
+
   def test_writes_to_default_index
     stub_elastic_ping
     stub_elastic


### PR DESCRIPTION
Starting with Elasticsearch 5.3, (REST) requests without an explicit Content-Type are deprecated and Elasticsearch will log a warning for every request that is sent without a Content-Type header.

I addressed this in a similar manner to how `elasticsearch-ruby` did, see [1], [2].

[1]: https://github.com/elastic/elasticsearch-ruby/issues/400
[2]: https://github.com/elastic/elasticsearch-ruby/commit/76f86793cde0a0e7e816a743c73f69002a53483e

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)