### PR TITLE
Format time values with time formatter that is capable of rendering nanosecond-precision timestamps

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -309,8 +309,10 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
           dt = parse_time(rts, time, tag)
           record[TIMESTAMP_FIELD] = rts unless @time_key_exclude_timestamp
         else
-          # A Fluent::EventTime object is compatible with being passed as an
-          # argument to Time::at.
+          # Within this else-block, we assume that our time value has not been
+          # user-specified. If running fluentd v0.14+, our time value could be
+          # of the type Fluent::EventTime. Regardless of its type, we can safely
+          # pass the value to Time::at and the time_fomatter.
           dt = Time.at(time).to_datetime
           record[TIMESTAMP_FIELD] = @time_formatter.call(time)
         end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -140,11 +140,18 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   # formatter. However, if unavailable the default method of formatting time
   # will be used.
   def create_time_formatter
+    default_formatter = Proc.new { |value| Time.at(value).to_datetime.to_s }
     if defined?(Fluent::TimeFormatter)
       f = Fluent::TimeFormatter.new(@time_key_format)
-      Proc.new { |value| f.format_with_subsec(value) }
+      Proc.new do |value|
+          begin
+            f.format_with_subsec(value)
+          rescue
+            default_formatter.call(value)
+          end
+      end
     else
-      Proc.new { |value| Time.at(value).to_datetime.to_s }
+      default_formatter
     end
   end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -142,7 +142,12 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   def create_time_formatter
     default_formatter = Proc.new { |value| Time.at(value).to_datetime.to_s }
     if defined?(Fluent::TimeFormatter)
-      f = Fluent::TimeFormatter.new(@time_key_format)
+      begin
+        f = Fluent::TimeFormatter.new(@time_key_format)
+      rescue
+        return default_formatter
+      end
+
       Proc.new do |value|
           begin
             f.format_with_subsec(value)

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -324,7 +324,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
           # Within this else-block, we assume that our time value has not been
           # user-specified. If running fluentd v0.14+, our time value could be
           # of the type Fluent::EventTime. Regardless of its type, we can safely
-          # pass the value to Time::at and the time_fomatter.
+          # pass the value to Time::at and the time_formatter.
           dt = Time.at(time).to_datetime
           record[TIMESTAMP_FIELD] = @time_formatter.call(time)
         end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1142,22 +1142,51 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert(index_cmds[0].has_key?("create"))
   end
 
-  def test_adds_nanosecond_precision_timestamp
-    # Configure driver with a time_key_format that specifies nanoseconds should
-    # be included in the outputted timestamp (%N).
+  # Configures a driver with nanosecond precision when time_as_int is false.
+  def configure_nanosecond_driver(time_as_int: false)
     time_key_format = "%Y-%m-%dT%H:%M:%S.%N%z"
     driver.configure("logstash_format true
-                     time_as_integer false
+                     time_as_integer #{time_as_int}
                      time_key_format #{time_key_format}")
+    time_key_format
+  end
+
+  def test_adds_nanosecond_precision_timestamp
+    time_key_format = configure_nanosecond_driver(time_as_int: false)
+
     stub_elastic_ping
     stub_elastic
+
     now = Fluent::EventTime.now
     driver.emit(sample_record, now)
     driver.run
-    assert(index_cmds[1].has_key? '@timestamp')
+
     formatter = Fluent::TimeFormatter.new(time_key_format)
     ts = formatter.format_with_subsec(now)
+
+    # Assert timestamp included in record is as Fluent::TimeFormatter would
+    # format it: with nanoseconds.
+    assert(index_cmds[1].has_key? '@timestamp')
     assert_equal(index_cmds[1]['@timestamp'], ts)
   end
 
+  def test_nanosecond_precision_disabled
+    time_key_format = configure_nanosecond_driver(time_as_int: true)
+
+    stub_elastic_ping
+    stub_elastic
+
+    now = Fluent::EventTime.now
+    driver.emit(sample_record, now)
+    driver.run
+
+    now_without_nsec = Time.at(now.sec)
+    formatter = Fluent::TimeFormatter.new(time_key_format)
+    ts = formatter.format_with_subsec(now_without_nsec)
+
+    # Assert timestamp included in record effectively has its nanosecond value
+    # zeroed out.
+    assert(index_cmds[1].has_key? '@timestamp')
+    assert_equal(index_cmds[1]['@timestamp'], ts)
+  end
 end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1141,4 +1141,17 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert(index_cmds[0].has_key?("create"))
   end
+
+  def test_adds_nanosecond_precision_timestamp
+    driver.configure("logstash_format true
+                     time_as_integer false")
+    stub_elastic_ping
+    stub_elastic
+    ts = DateTime.now.to_s
+    driver.emit(sample_record)
+    driver.run
+    assert(index_cmds[1].has_key? '@timestamp')
+    assert_equal(index_cmds[1]['@timestamp'], ts)
+  end
+
 end


### PR DESCRIPTION
This PR introduces a time formatter instance variable that will be set to an instance of a Fluent::TimeFormatter, if available. By using Fluent::TimeFormatter, we are able to render and write nanosecond-precision timestamps to ElasticSearch. 

(check all that apply)
- [x]  tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

EDIT: For some reason, I didn't realize that my PR is about the 3rd one that attempts to get nanosecond-precision timestamp support into your lib. Take your pick :dancer: 