### PR TITLE
add the parsed time to records

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -298,7 +298,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
         elsif record.has_key?(@time_key)
           rts = record[@time_key]
           dt = parse_time(rts, time, tag)
-          record[TIMESTAMP_FIELD] = rts unless @time_key_exclude_timestamp
+          record[TIMESTAMP_FIELD] = dt.strftime(@time_key_format ? @time_key_format : String.new) unless @time_key_exclude_timestamp
         else
           dt = Time.at(time).to_datetime
           record[TIMESTAMP_FIELD] = dt.iso8601(@time_precision)
@@ -308,7 +308,6 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       else
         target_index = @index_name
       end
-
       # Change target_index to lower-case since Elasticsearch doesn't
       # allow upper-case characters in index names.
       target_index = target_index.downcase


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

Fix the bug that the parsed time is not added into the record.

The original code just get the time from `record` and add it back as `@timestamp`. The parsed time `dt` has not been used!
```
           rts = record[@time_key]
           dt = parse_time(rts, time, tag)
           record[TIMESTAMP_FIELD] = rts unless @time_key_exclude_timestamp
```
Say my record is `{"a":"123", "time":"2017-06-30T06:25:05.197419064Z"}`. After processing, it just becomes `{"a":"123", "time":"2017-06-30T06:25:05.197419064Z", "@timestamp": "2017-06-30T06:25:05.197419064Z"}`.