### PR TITLE
Support signing requests to AWS elasticsearch service optionally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [write_operation](#write_operation)
   + [time_parse_error_tag](#time_parse_error_tag)
   + [reconnect_on_error](#reconnect_on_error)
+  + [aws\_sign\_requests](#aws-request-signing-support)
+  + [aws\_access\_key\_id](#aws-request-signing-support)
+  + [aws\_secret\_access\_key](#aws-request-signing-support)
+  + [aws\_region](#aws-request-signing-support)
+  + [aws\_assume\_role\_arn](#aws-request-signing-support)
+  + [aws\_assume\_role\_session\_name](#aws-request-signing-support)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffered output options](#buffered-output-options)
@@ -415,6 +421,16 @@ We recommended to set this true in the presence of elasticsearch shield.
 ```
 reconnect_on_error true # defaults to false
 ```
+
+### AWS request signing support
+
+Set `aws\_sign\_requests` to `true` to enable signing outgoing requests with AWS credentials. This can be used when sending data to an AWS Elasticsearch Service instance.
+
+To use explicit credentials, set `aws\_access\_key\_id` and `aws\_secret\_access\_key`.
+
+To use role credentials, instead set `aws\_assume\_role\_arn` to an ARN and `aws\_assume\_role\_session\_name` to the correct session name.
+
+To set the region, set `aws\_region`. It defaults to `us-east-1`.
 
 ### Client/host certificate options
 


### PR DESCRIPTION
New configuration options:

- aws_sign_requests
- aws_region
- aws_access_key_id
- aws_secret_access_key
- aws_assume_role_arn
- aws_assume_role_session_name

If aws_sign_requests is true, the support is activated.

If the variables are set, aws_access_key_id and aws_secret_access_key
are used as explicit credentials. Otherwise, a variety of methods are
tried to retrieve IAM credentials. You can also assume an IAM role by
specifying a role ARN and session name.

Ported from atomita/fluent-plugin-aws-elasticsearch-service.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

Will proceed with future steps once initial direction is validated. See also #261 and #131 