### PR TITLE
WIP: Allow logstash prefix via key in record

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-elasticsearch.gemspec
+gem 'fluentd', '~> 0.12.0'
+
 gemspec
+
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/Gemfile.v0.14
+++ b/Gemfile.v0.14
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in fluent-plugin-elasticsearch.gemspec
-gem 'fluentd', '~> 0.12.0'
-
 gemspec
-
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/lib/fluent/plugin/example.bulkerror.json
+++ b/lib/fluent/plugin/example.bulkerror.json
@@ -1,0 +1,125 @@
+{
+    "took"=>3,
+    "errors"=>true,
+    "items"=>[
+        {
+            "create"=>{
+                "_index"=>".operations.2017.07.13",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV09lEt-yHUkC3cmRhe-",
+                "status"=>429,
+                "error"=>{
+                    "type"=>"es_rejected_execution_exception",
+                    "reason"=>"rejected execution of org.elasticsearch.transport.TransportService$4@1a34d37a on EsThreadPoolExecutor[bulk, queue capacity = 50, org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor@312a2162[Running, pool size = 32, active threads = 32, queued tasks = 50, completed tasks = 327053]]"
+                }
+            }
+        }
+    ]
+}
+
+{
+    "took"=>1,
+    "errors"=>true,
+    "items"=>[
+        {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jX",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jY",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jZ",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-ja",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jb",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jc",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jd",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-je",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }, {
+            "create"=>{
+                "_index"=>".operations.2017.08.03",
+                "_type"=>"com.redhat.viaq.common",
+                "_id"=>"AV2oBsIyOBWEQxXNi-jf",
+                "status"=>500,
+                "error"=>{
+                    "type"=>"out_of_memory_error",
+                    "reason"=>"Java heap space"
+                }
+            }
+        }
+    ]
+}

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -53,6 +53,22 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
   end
 
+  def stub_elastic_bulk_rejected(url="http://localhost:9200/_bulk")
+    stub_request(:post, url).to_return(:status => 200, :body => "", :headers => {})
+  end
+
+  def stub_elastic_out_of_memory(url="http://localhost:9200/_bulk")
+    stub_request(:post, url).to_return(:status => 200, :body => "", :headers => {})
+  end
+
+  def stub_elastic_unrecognized_error(url="http://localhost:9200/_bulk")
+    stub_request(:post, url).to_return(:status => 200, :body => "", :headers => {})
+  end
+
+  def stub_elastic_version_mismatch(url="http://localhost:9200/_bulk")
+    stub_request(:post, url).to_return(:status => 200, :body => "", :headers => {})
+  end
+
   def test_configure
     config = %{
       host     logs.google.com
@@ -352,7 +368,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('fluentd', index_cmds.first['index']['_type'])
   end
 
-  def test_writes_to_speficied_index
+  def test_writes_to_specified_index
     driver.configure("index_name myindex\n")
     stub_elastic_ping
     stub_elastic
@@ -361,7 +377,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('myindex', index_cmds.first['index']['_index'])
   end
 
-  def test_writes_to_speficied_index_uppercase
+  def test_writes_to_specified_index_uppercase
     driver.configure("index_name MyIndex\n")
     stub_elastic_ping
     stub_elastic
@@ -428,7 +444,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 
-  def test_writes_to_speficied_type
+  def test_writes_to_specified_type
     driver.configure("type_name mytype\n")
     stub_elastic_ping
     stub_elastic
@@ -494,7 +510,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('fluentd', index_cmds.first['index']['_type'])
   end
 
-  def test_writes_to_speficied_host
+  def test_writes_to_specified_host
     driver.configure("host 192.168.33.50\n")
     stub_elastic_ping("http://192.168.33.50:9200")
     elastic_request = stub_elastic("http://192.168.33.50:9200/_bulk")
@@ -503,7 +519,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_requested(elastic_request)
   end
 
-  def test_writes_to_speficied_port
+  def test_writes_to_specified_port
     driver.configure("port 9201\n")
     stub_elastic_ping("http://localhost:9201")
     elastic_request = stub_elastic("http://localhost:9201/_bulk")


### PR DESCRIPTION
DESCRIPTION HERE

This is a Work-in-Progress to test out a simple behavior change to obviate the need for elasticsearch_dynamic in OpenShift's origin-aggregated-loggings fluentd use.

Basically, we only need to be able to specify the index prefix dynamically. This can be provided by a simple key in the record being indexed.

It avoids the overhead CPU calculations necessary to eval all the dynamic parameters.

This is untested, and purely a proof of concept to demonstrate a possibility.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
