### PR TITLE
Adding unit test for custom time_key with custom time_key_format

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -156,6 +156,17 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert_equal('myindex', index_cmds.first['index']['_index'])
   end
+  
+  def test_writes_to_speficied_index_uppercase
+    driver.configure("index_name MyIndex\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+	# Allthough index_name has upper-case characters,
+	# it should be set as lower-case when sent to elasticsearch.
+    assert_equal('myindex', index_cmds.first['index']['_index'])
+  end
 
   def test_writes_to_target_index_key
     driver.configure("target_index_key @target_index\n")
@@ -176,6 +187,19 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
     driver.emit(sample_record.merge('@target_index' => 'local-override'), time)
     driver.run
+    assert_equal('local-override', index_cmds.first['index']['_index'])
+  end
+  
+   def test_writes_to_target_index_key_logstash_uppercase
+    driver.configure("target_index_key @target_index\n")
+    driver.configure("logstash_format true\n")
+    time = Time.parse Date.today.to_s
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record.merge('@target_index' => 'Local-Override'), time)
+    driver.run
+	# Allthough @target_index has upper-case characters,
+	# it should be set as lower-case when sent to elasticsearch.
     assert_equal('local-override', index_cmds.first['index']['_index'])
   end
 
@@ -313,6 +337,20 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
     driver.emit(sample_record, time)
     driver.run
+    assert_equal(logstash_index, index_cmds.first['index']['_index'])
+  end
+  
+  def test_writes_to_logstash_index_with_specified_prefix_uppercase
+    driver.configure("logstash_format true
+                      logstash_prefix MyPrefix")
+    time = Time.parse Date.today.to_s
+    logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record, time)
+    driver.run
+	# Allthough logstash_prefix has upper-case characters,
+	# it should be set as lower-case when sent to elasticsearch.
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -156,17 +156,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert_equal('myindex', index_cmds.first['index']['_index'])
   end
-  
-  def test_writes_to_speficied_index_uppercase
-    driver.configure("index_name MyIndex\n")
-    stub_elastic_ping
-    stub_elastic
-    driver.emit(sample_record)
-    driver.run
-	# Allthough index_name has upper-case characters,
-	# it should be set as lower-case when sent to elasticsearch.
-    assert_equal('myindex', index_cmds.first['index']['_index'])
-  end
 
   def test_writes_to_target_index_key
     driver.configure("target_index_key @target_index\n")
@@ -187,19 +176,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
     driver.emit(sample_record.merge('@target_index' => 'local-override'), time)
     driver.run
-    assert_equal('local-override', index_cmds.first['index']['_index'])
-  end
-  
-   def test_writes_to_target_index_key_logstash_uppercase
-    driver.configure("target_index_key @target_index\n")
-    driver.configure("logstash_format true\n")
-    time = Time.parse Date.today.to_s
-    stub_elastic_ping
-    stub_elastic
-    driver.emit(sample_record.merge('@target_index' => 'Local-Override'), time)
-    driver.run
-	# Allthough @target_index has upper-case characters,
-	# it should be set as lower-case when sent to elasticsearch.
     assert_equal('local-override', index_cmds.first['index']['_index'])
   end
 
@@ -337,20 +313,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
     driver.emit(sample_record, time)
     driver.run
-    assert_equal(logstash_index, index_cmds.first['index']['_index'])
-  end
-  
-  def test_writes_to_logstash_index_with_specified_prefix_uppercase
-    driver.configure("logstash_format true
-                      logstash_prefix MyPrefix")
-    time = Time.parse Date.today.to_s
-    logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
-    stub_elastic_ping
-    stub_elastic
-    driver.emit(sample_record, time)
-    driver.run
-	# Allthough logstash_prefix has upper-case characters,
-	# it should be set as lower-case when sent to elasticsearch.
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -383,6 +383,20 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(index_cmds[1]['@timestamp'], ts)
   end
 
+  def test_uses_custom_time_key_with_format
+    driver.configure("logstash_format true
+                      time_key_format %Y-%m-%d %H:%M:%S.%N%z
+                      time_key vtm\n")
+    stub_elastic_ping
+    stub_elastic
+    ts = "2001-02-03 13:14:01.673+02:00"
+    driver.emit(sample_record.merge!('vtm' => ts))
+    driver.run
+    assert(index_cmds[1].has_key? '@timestamp')
+    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal("logstash-2001.02.03", index_cmds[0]['index']['_index'])
+  end
+  
   def test_uses_custom_time_key_exclude_timekey
     driver.configure("logstash_format true
                       time_key vtm


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
