### PR TITLE
Add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ Current maintainers: @cosmo0920
 * [Contributing](#contributing)
 * [Running tests](#running-tests)
 
+## Requirements
+
+| fluent-plugin-elasticsearch  | fluentd | ruby |
+|-------------------|---------|------|
+| >= 2.0.0 | >= v0.14.0 | >= 2.1 |
+|  < 2.0.0 | >= v0.12.0 | >= 1.9 |
+
+NOTE: fluent-plugin-elasticsearch v2.0.0 is now RC. We will release stable v2.0.0 soon.
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Current maintainers: @cosmo0920
 |  < 2.0.0 | >= v0.12.0 | >= 1.9 |
 
 NOTE: fluent-plugin-elasticsearch v2.0.0 is now RC. We will release stable v2.0.0 soon.
+NOTE: For v0.12 version, you should use 1.x.y version. Please send patch into v0.12 branch if you encountered 1.x version's bug.
 
 ## Installation
 


### PR DESCRIPTION
We should announce Fluentd compatibility for Fluentd v0.14 and v0.12.

- [ ] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
