### PR TITLE
Add placeholders support for index_name and logstash_prefix parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Current maintainers: @cosmo0920
   + [Hash flattening](#hash-flattening)
   + [Not seeing a config you need?](#not-seeing-a-config-you-need)
   + [Dynamic configuration](#dynamic-configuration)
+  + [Placeholders](#placeholders)
 * [Contact](#contact)
 * [Contributing](#contributing)
 * [Running tests](#running-tests)
@@ -515,6 +516,59 @@ If you want configurations to depend on information in messages, you can use `el
 ```
 
 **Please note, this uses Ruby's `eval` for every message, so there are performance and security implications.**
+
+### Placeholders
+
+v0.14 placeholders can handle `${tag}` for tag, `%Y%m%d` like strftime format, and custom record keys like as `record["mykey"]`.
+
+Note that custom chunk key is diffrent notations for `record_reformer` and `record_modifier`.
+They uses `record["some_key"]` to specify placeholders, but this feature uses `${key1}`, `${key2}` notation. And tag, time, and some arbitrary keys must be included in buffer directive attributes.
+
+They are used as below:
+
+#### tag
+
+```aconf
+<match my.logs>
+  @type elasticsearch
+  index_name elastic.${tag} #=> replaced with each event's tag. e.g.) elastic.test.tag
+  <buffer tag>
+    @type memory
+  </buffer>
+  # <snip>
+</match>
+```
+
+#### time
+
+```aconf
+<match my.logs>
+  @type elasticsearch
+  index_name elastic.%Y%m%d #=> e.g.) elastic.20170811
+  <buffer tag, time>
+    @type memory
+    timekey 3600
+  </buffer>
+  # <snip>
+</match>
+```
+
+#### custom key
+
+```log
+records = {key1: "value1", key2: "value2"}
+```
+
+```aconf
+<match my.logs>
+  @type elasticsearch
+  index_name elastic.${key1}.${key2} # => e.g.) elastic.value1.value2
+  <buffer tag, key1, key2>
+    @type memory
+  </buffer>
+  # <snip>
+</match>
+```
 
 ## Contact
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -389,14 +389,57 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('myindex', index_cmds.first['index']['_index'])
   end
 
-  def test_writes_to_speficied_index_with_placeholder
-    driver.configure("index_name myindex.${tag}\n")
-    stub_elastic_ping
-    stub_elastic
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
+  class IndexNamePlaceholdersTest < self
+    def test_writes_to_speficied_index_with_tag_placeholder
+      driver.configure("index_name myindex.${tag}\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(sample_record)
+      end
+      assert_equal('myindex.test', index_cmds.first['index']['_index'])
     end
-    assert_equal('myindex.test', index_cmds.first['index']['_index'])
+
+    def test_writes_to_speficied_index_with_time_placeholder
+      driver.configure(Fluent::Config::Element.new(
+                         'ROOT', '', {
+                           '@type' => 'elasticsearch',
+                           'index_name' => 'myindex.%Y.%m.%d',
+                         }, [
+                           Fluent::Config::Element.new('buffer', 'tag,time', {
+                                                         'chunk_keys' => ['tag', 'time'],
+                                                         'timekey' => 3600,
+                                                       }, [])
+                         ]
+                       ))
+      stub_elastic_ping
+      stub_elastic
+      time = Time.parse Date.today.to_s
+      driver.run(default_tag: 'test') do
+        driver.feed(time.to_i, sample_record)
+      end
+      assert_equal("myindex.#{time.getutc.strftime("%Y.%m.%d")}", index_cmds.first['index']['_index'])
+    end
+
+    def test_writes_to_speficied_index_with_custom_key_placeholder
+      driver.configure(Fluent::Config::Element.new(
+                         'ROOT', '', {
+                           '@type' => 'elasticsearch',
+                           'index_name' => 'myindex.${pipeline_id}',
+                         }, [
+                           Fluent::Config::Element.new('buffer', 'tag,pipeline_id', {}, [])
+                         ]
+                       ))
+      time = Time.parse Date.today.to_s
+      pipeline_id = "mypipeline"
+      logstash_index = "myindex.#{pipeline_id}"
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
+      end
+      assert_equal(logstash_index, index_cmds.first['index']['_index'])
+    end
   end
 
   def test_writes_to_speficied_index_uppercase
@@ -694,17 +737,63 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 
-  def test_writes_to_logstash_index_with_specified_prefix_and_placeholder
-    driver.configure("logstash_format true
+  class LogStashPrefixPlaceholdersTest < self
+    def test_writes_to_logstash_index_with_specified_prefix_and_tag_placeholder
+      driver.configure("logstash_format true
                       logstash_prefix myprefix-${tag}")
-    time = Time.parse Date.today.to_s
-    logstash_index = "myprefix-test-#{time.getutc.strftime("%Y.%m.%d")}"
-    stub_elastic_ping
-    stub_elastic
-    driver.run(default_tag: 'test') do
-      driver.feed(time.to_i, sample_record)
+      time = Time.parse Date.today.to_s
+      logstash_index = "myprefix-test-#{time.getutc.strftime("%Y.%m.%d")}"
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(time.to_i, sample_record)
+      end
+      assert_equal(logstash_index, index_cmds.first['index']['_index'])
     end
-    assert_equal(logstash_index, index_cmds.first['index']['_index'])
+
+    def test_writes_to_logstash_index_with_specified_prefix_and_time_placeholder
+      driver.configure(Fluent::Config::Element.new(
+                         'ROOT', '', {
+                           '@type' => 'elasticsearch',
+                           'logstash_format' => true,
+                           'logstash_prefix' => 'myprefix-%H',
+                         }, [
+                           Fluent::Config::Element.new('buffer', 'tag,time', {
+                                                         'chunk_keys' => ['tag', 'time'],
+                                                         'timekey' => 3600,
+                                                       }, [])
+                         ]
+                       ))
+      time = Time.parse Date.today.to_s
+      logstash_index = "myprefix-#{time.localtime.strftime("%H")}-#{time.getutc.strftime("%Y.%m.%d")}"
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(time.to_i, sample_record)
+      end
+      assert_equal(logstash_index, index_cmds.first['index']['_index'])
+    end
+
+    def test_writes_to_logstash_index_with_specified_prefix_and_custom_key_placeholder
+      driver.configure(Fluent::Config::Element.new(
+                         'ROOT', '', {
+                           '@type' => 'elasticsearch',
+                           'logstash_format' => true,
+                           'logstash_prefix' => 'myprefix-${pipeline_id}',
+                         }, [
+                           Fluent::Config::Element.new('buffer', 'tag,pipeline_id', {}, [])
+                         ]
+                       ))
+      time = Time.parse Date.today.to_s
+      pipeline_id = "mypipeline"
+      logstash_index = "myprefix-#{pipeline_id}-#{time.getutc.strftime("%Y.%m.%d")}"
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
+      end
+      assert_equal(logstash_index, index_cmds.first['index']['_index'])
+    end
   end
 
   def test_writes_to_logstash_index_with_specified_prefix_uppercase


### PR DESCRIPTION
This is v0.14 way to extract placeholders in fluentd conf.

${tag} will be replaced with events's tag:

With `[test.elasticsearch, #<EventTime>, #<Records>]`,
`${tag}` will be replaced into `test.elasticsearch`.

DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible for 2.0.0.rc.1 (Note: This patch does not work with Fluentd v0.12)
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

---

This is another approach of fixing #233.