### PR TITLE
Permit multi workers feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Current maintainers: @cosmo0920
   + [Not seeing a config you need?](#not-seeing-a-config-you-need)
   + [Dynamic configuration](#dynamic-configuration)
   + [Placeholders](#placeholders)
+  + [Multi workers](#multi-workers)
 * [Contact](#contact)
 * [Contributing](#contributing)
 * [Running tests](#running-tests)
@@ -579,6 +580,16 @@ records = {key1: "value1", key2: "value2"}
   </buffer>
   # <snip>
 </match>
+```
+
+## Multi workers
+
+Since Fluentd v0.14, multi workers feature had been implemented to increase throughput with multiple processes. This feature allows Fluentd processes to use one or more CPUs. This feature will be enabled by the following system configuration:
+
+```
+<system>
+  workers N # where N is a natural number (N >= 1).
+</system>
 ```
 
 ## Contact

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -299,6 +299,10 @@ module Fluent::Plugin
       return logstash_prefix, index_name
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def write(chunk)
       bulk_message = ''
       header = {}

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -108,6 +108,10 @@ module Fluent::Plugin
       end.join(', ')
     end
 
+    def multi_workers_ready?
+      true
+    end
+
     def write(chunk)
       bulk_message = Hash.new { |h,k| h[k] = '' }
       dynamic_conf = @dynamic_config.clone


### PR DESCRIPTION
Since Fluentd v0.14, multi workers feature had been implemented to increase throughput with multiple processes.

Note that this feature works with v0.14 only. It is hard to backport v0.12 branch. :cry:

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible for 2.0.0.rc.2
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
