### PR TITLE
Fix placeholders testcase

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -72,6 +72,7 @@ module Fluent::Plugin
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
       config_set_default :chunk_keys, ['tag']
+      config_set_default :timekey_use_utc, true
     end
 
     include Fluent::ElasticsearchIndexTemplate

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -418,7 +418,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record)
       end
-      assert_equal("myindex.#{time.localtime.strftime("%Y.%m.%d")}", index_cmds.first['index']['_index'])
+      assert_equal("myindex.#{time.utc.strftime("%Y.%m.%d")}", index_cmds.first['index']['_index'])
     end
 
     def test_writes_to_speficied_index_with_custom_key_placeholder
@@ -776,7 +776,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
                          ]
                        ))
       time = Time.parse Date.today.to_s
-      logstash_index = "myprefix-#{time.localtime.strftime("%H")}-#{time.getutc.strftime("%Y.%m.%d")}"
+      logstash_index = "myprefix-#{time.getutc.strftime("%H")}-#{time.getutc.strftime("%Y.%m.%d")}"
       stub_elastic_ping
       stub_elastic
       driver.run(default_tag: 'test') do

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -418,7 +418,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record)
       end
-      assert_equal("myindex.#{time.getutc.strftime("%Y.%m.%d")}", index_cmds.first['index']['_index'])
+      assert_equal("myindex.#{time.localtime.strftime("%Y.%m.%d")}", index_cmds.first['index']['_index'])
     end
 
     def test_writes_to_speficied_index_with_custom_key_placeholder


### PR DESCRIPTION
Follows up #288.
Because extract_placeholders use locatime timezone by default.
But ES plugin uses utc by default.
We should specify timekey_use_utc as true by default.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible for 2.0.0.rc.2
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
