### PR TITLE
Fix license identifier in gemspec

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.description   = %q{ElasticSearch output plugin for Fluent event collector}
   s.summary       = s.description
   s.homepage      = 'https://github.com/uken/fluent-plugin-elasticsearch'
-  s.license       = 'MIT'
+  s.license       = 'Apache-2.0'
 
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
fluent-plugin-elasticsearch's license had been changed: https://github.com/uken/fluent-plugin-elasticsearch/commit/874deca6640494204f535437aaef2a1e106bcc28 
We should use `Apache-2.0` license identifier in gemspec.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
