### PR TITLE
Add logstash_prefix_separator config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Current maintainers: @cosmo0920
   + [user, password, path, scheme, ssl_verify](#user-password-path-scheme-ssl_verify)
   + [logstash_format](#logstash_format)
   + [logstash_prefix](#logstash_prefix)
+  + [logstash_prefix_separator](#logstash_prefix_separator)
   + [logstash_dateformat](#logstash_dateformat)
   + [pipeline](#pipeline)
   + [time_key_format](#time_key_format)
@@ -135,6 +136,12 @@ This is meant to make writing data into ElasticSearch indices compatible to what
 
 ```
 logstash_prefix mylogs # defaults to "logstash"
+```
+
+### logstash_prefix_separator
+
+```
+logstash_prefix_separator _ # defaults to "-"
 ```
 
 ### logstash_dateformat

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -35,6 +35,7 @@ module Fluent::Plugin
     config_param :time_precision, :integer, :default => 9
     config_param :logstash_format, :bool, :default => false
     config_param :logstash_prefix, :string, :default => "logstash"
+    config_param :logstash_prefix_separator, :string, :default => '-'
     config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
     config_param :utc_index, :bool, :default => true
     config_param :type_name, :string, :default => "fluentd"
@@ -334,7 +335,7 @@ module Fluent::Plugin
             record[TIMESTAMP_FIELD] = dt.iso8601(@time_precision)
           end
           dt = dt.new_offset(0) if @utc_index
-          target_index = "#{logstash_prefix}-#{dt.strftime(@logstash_dateformat)}"
+          target_index = "#{logstash_prefix}#{@logstash_prefix_separator}#{dt.strftime(@logstash_dateformat)}"
         else
           target_index = index_name
         end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -748,6 +748,21 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 
+  def test_writes_to_logstash_index_with_specified_prefix_and_separator
+    separator = '_'
+    driver.configure("logstash_format true
+                      logstash_prefix_separator #{separator}
+                      logstash_prefix myprefix")
+    time = Time.parse Date.today.to_s
+    logstash_index = "myprefix#{separator}#{time.getutc.strftime("%Y.%m.%d")}"
+    stub_elastic_ping
+    stub_elastic
+    driver.run(default_tag: 'test') do
+      driver.feed(time.to_i, sample_record)
+    end
+    assert_equal(logstash_index, index_cmds.first['index']['_index'])
+  end
+
   class LogStashPrefixPlaceholdersTest < self
     def test_writes_to_logstash_index_with_specified_prefix_and_tag_placeholder
       driver.configure("logstash_format true


### PR DESCRIPTION
Because logstash_prefix and datetime format strings are joined with
hardcoded with "-".
With this parameter, users can use arbitrary characters there.

Fixes #253 for v0.14.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible for v2.0.0.rc.4.
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
