### PR TITLE
Make configurable ssl_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,11 @@ client_key /path/to/your/private/key
 client_key_pass password
 ```
 
+If you want to configure SSL/TLS version, you can specify ssl\_version parameter.
+```
+ssl_version TLSv1_2 # or [SSLv23, TLSv1, TLSv1_1]
+```
+
 ### Proxy Support
 
 Starting with version 0.8.0, this gem uses excon, which supports proxy with environment variables - https://github.com/excon/excon#proxy-support

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -55,6 +55,7 @@ module Fluent::Plugin
     config_param :client_cert, :string, :default => nil
     config_param :client_key_pass, :string, :default => nil
     config_param :ca_file, :string, :default => nil
+    config_param :ssl_version, :enum, list: [:SSLv23, :TLSv1, :TLSv1_1, :TLSv1_2], :default => :TLSv1
     config_param :remove_keys, :string, :default => nil
     config_param :remove_keys_on_update, :string, :default => ""
     config_param :remove_keys_on_update_key, :string, :default => nil
@@ -171,7 +172,7 @@ module Fluent::Plugin
                                                                               transport_options: {
                                                                                 headers: { 'Content-Type' => 'application/json' },
                                                                                 request: { timeout: @request_timeout },
-                                                                                ssl: { verify: @ssl_verify, ca_file: @ca_file }
+                                                                                ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
                                                                               }
                                                                             }), &adapter_conf)
         es = Elasticsearch::Client.new transport: transport

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -74,6 +74,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal '/es/', instance.path
     assert_equal 'john', instance.user
     assert_equal 'doe', instance.password
+    assert_equal :TLSv1, instance.ssl_version
+    assert_nil instance.client_key
+    assert_nil instance.client_cert
+    assert_nil instance.client_key_pass
   end
 
   test 'lack of tag in chunk_keys' do

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -69,6 +69,10 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal 'john', instance.user
     assert_equal 'doe', instance.password
     assert_equal '/es/', instance.path
+    assert_equal :TLSv1, instance.ssl_version
+    assert_nil instance.client_key
+    assert_nil instance.client_cert
+    assert_nil instance.client_key_pass
   end
 
   def test_defaults


### PR DESCRIPTION
Ruby's default is weaker than ES's default.

DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
