### PR TITLE
Merge pull request #306 from uken/escape-placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ You can specify multiple ElasticSearch hosts with separator ",".
 
 If you specify multiple hosts, this plugin will load balance updates to ElasticSearch. This is an [elasticsearch-ruby](https://github.com/elasticsearch/elasticsearch-ruby) feature, the default strategy is round-robin.
 
+And this plugin will escape required URL encoded characters within `%{}` placeholders.
+
+```
+hosts https://%{j+hn}:%{passw@rd}@host1:443/elastic/,http://host2
+```
+
 ### user, password, path, scheme, ssl_verify
 
 If you specify this option, host and port options are ignored.
@@ -106,6 +112,13 @@ scheme https
 ```
 
 You can specify user and password for HTTP basic auth. If used in conjunction with a hosts list, then these options will be used by default i.e. if you do not provide any of these options within the hosts listed.
+
+And this plugin will escape required URL encoded characters within `%{}` placeholders.
+
+```
+user %{demo+}
+password %{@secret}
+```
 
 Specify `ssl_verify false` to skip ssl verification (defaults to true)
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -105,6 +105,13 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     rescue LoadError
       @dump_proc = Yajl.method(:dump)
     end
+
+    if @user && m = @user.match(/%{(?<user>.*)}/)
+      @user = URI.encode_www_form_component(m["user"])
+    end
+    if @password && m = @password.match(/%{(?<password>.*)}/)
+      @password = URI.encode_www_form_component(m["password"])
+    end
   end
 
   def create_meta_config_map
@@ -172,6 +179,18 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     end
   end
 
+  def get_escaped_userinfo(host_str)
+    if m = host_str.match(/(?<scheme>.*)%{(?<user>.*)}:%{(?<password>.*)}(?<path>@.*)/)
+      m["scheme"] +
+        URI.encode_www_form_component(m["user"]) +
+        ':' +
+        URI.encode_www_form_component(m["password"]) +
+        m["path"]
+    else
+      host_str
+    end
+  end
+
   def get_connection_options
     raise "`password` must be present if `user` is present" if @user && !@password
 
@@ -186,7 +205,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
           }
         else
           # New hosts format expects URLs such as http://logs.foo.com,https://john:pass@logs2.foo.com/elastic
-          uri = URI(host_str)
+          uri = URI(get_escaped_userinfo(host_str))
           %w(user password path).inject(host: uri.host, port: uri.port, scheme: uri.scheme) do |hash, key|
             hash[key.to_sym] = uri.public_send(key) unless uri.public_send(key).nil? || uri.public_send(key) == ''
             hash

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -80,7 +80,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
           }
         else
           # New hosts format expects URLs such as http://logs.foo.com,https://john:pass@logs2.foo.com/elastic
-          uri = URI(host_str)
+          uri = URI(get_escaped_userinfo(host_str))
           %w(user password path).inject(host: uri.host, port: uri.port, scheme: uri.scheme) do |hash, key|
             hash[key.to_sym] = uri.public_send(key) unless uri.public_send(key).nil? || uri.public_send(key) == ''
             hash

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -311,6 +311,32 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal '/default_path', host2[:path]
   end
 
+  def test_hosts_list_with_escape_placeholders
+    config = %{
+      hosts    https://%{j+hn}:%{passw@rd}@host1:443/elastic/,http://host2
+      path     /default_path
+      user     default_user
+      password default_password
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 2, instance.get_connection_options[:hosts].length
+    host1, host2 = instance.get_connection_options[:hosts]
+
+    assert_equal 'host1', host1[:host]
+    assert_equal 443, host1[:port]
+    assert_equal 'https', host1[:scheme]
+    assert_equal 'j%2Bhn', host1[:user]
+    assert_equal 'passw%40rd', host1[:password]
+    assert_equal '/elastic/', host1[:path]
+
+    assert_equal 'host2', host2[:host]
+    assert_equal 'http', host2[:scheme]
+    assert_equal 'default_user', host2[:user]
+    assert_equal 'default_password', host2[:password]
+    assert_equal '/default_path', host2[:path]
+  end
+
   def test_single_host_params_and_defaults
     config = %{
       host     logs.google.com
@@ -327,6 +353,25 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal 'http', host1[:scheme]
     assert_equal 'john', host1[:user]
     assert_equal 'doe', host1[:password]
+    assert_equal nil, host1[:path]
+  end
+
+  def test_single_host_params_and_defaults_with_escape_placeholders
+    config = %{
+      host     logs.google.com
+      user     %{j+hn}
+      password %{d@e}
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 1, instance.get_connection_options[:hosts].length
+    host1 = instance.get_connection_options[:hosts][0]
+
+    assert_equal 'logs.google.com', host1[:host]
+    assert_equal 9200, host1[:port]
+    assert_equal 'http', host1[:scheme]
+    assert_equal 'j%2Bhn', host1[:user]
+    assert_equal 'd%40e', host1[:password]
     assert_equal nil, host1[:path]
   end
 

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -142,6 +142,32 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal '/default_path', host2[:path]
   end
 
+  def test_hosts_list_with_escape_placeholders
+    config = %{
+      hosts    https://%{j+hn}:%{passw@rd}@host1:443/elastic/,http://host2
+      path     /default_path
+      user     default_user
+      password default_password
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 2, instance.get_connection_options(nil)[:hosts].length
+    host1, host2 = instance.get_connection_options(nil)[:hosts]
+
+    assert_equal 'host1', host1[:host]
+    assert_equal 443, host1[:port]
+    assert_equal 'https', host1[:scheme]
+    assert_equal 'j%2Bhn', host1[:user]
+    assert_equal 'passw%40rd', host1[:password]
+    assert_equal '/elastic/', host1[:path]
+
+    assert_equal 'host2', host2[:host]
+    assert_equal 'http', host2[:scheme]
+    assert_equal 'default_user', host2[:user]
+    assert_equal 'default_password', host2[:password]
+    assert_equal '/default_path', host2[:path]
+  end
+
   def test_single_host_params_and_defaults
     config = %{
       host     logs.google.com
@@ -158,6 +184,25 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal 'http', host1[:scheme]
     assert_equal 'john', host1[:user]
     assert_equal 'doe', host1[:password]
+    assert_equal nil, host1[:path]
+  end
+
+  def test_single_host_params_and_defaults_with_escape_placeholders
+    config = %{
+      host     logs.google.com
+      user     %{j+hn}
+      password %{d@e}
+    }
+    instance = driver('test', config).instance
+
+    assert_equal 1, instance.get_connection_options(nil)[:hosts].length
+    host1 = instance.get_connection_options(nil)[:hosts][0]
+
+    assert_equal 'logs.google.com', host1[:host]
+    assert_equal 9200, host1[:port]
+    assert_equal 'http', host1[:scheme]
+    assert_equal 'j%2Bhn', host1[:user]
+    assert_equal 'd%40e', host1[:password]
     assert_equal nil, host1[:path]
   end
 


### PR DESCRIPTION
Escape basic authentication user information placeholders
backported #306.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
