### PR TITLE
Add include timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Current maintainers: @cosmo0920
   + [time_precision](#time_precision)
   + [time_key](#time_key)
   + [time_key_exclude_timestamp](#time_key_exclude_timestamp)
+  + [include_timestamp](#time_key_exclude_timestamp)
   + [utc_index](#utc_index)
   + [target_index_key](#target_index_key)
   + [target_type_key](#target_type_key)
@@ -146,6 +147,14 @@ logstash_format true # defaults to false
 This is meant to make writing data into ElasticSearch indices compatible to what [Logstash](https://www.elastic.co/products/logstash) calls them. By doing this, one could take advantage of [Kibana](https://www.elastic.co/products/kibana). See logstash_prefix and logstash_dateformat to customize this index name pattern. The index name will be `#{logstash_prefix}-#{formated_date}`
 
 :warning: Setting this option to `true` will ignore the `index_name` setting. The default index name prefix is `logstash-`.
+
+### include_timestamp
+
+```
+include_timestamp true # defaults to false
+```
+
+Adds a `@timestamp` field to the log, following all settings `logstash_format` does, except without the restrictions on `index_name`. This allows one to log to an alias in Elasticsearch and utilize the rollover API.
 
 ### logstash_prefix
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -33,6 +33,7 @@ module Fluent::Plugin
     config_param :target_type_key, :string, :default => nil
     config_param :time_key_format, :string, :default => nil
     config_param :time_precision, :integer, :default => 9
+    config_param :include_timestamp, :bool, :default => false
     config_param :logstash_format, :bool, :default => false
     config_param :logstash_prefix, :string, :default => "logstash"
     config_param :logstash_prefix_separator, :string, :default => '-'
@@ -339,10 +340,8 @@ module Fluent::Plugin
           record = flatten_record(record)
         end
 
-        target_index_parent, target_index_child_key = @target_index_key ? get_parent_of(record, @target_index_key) : nil
-        if target_index_parent && target_index_parent[target_index_child_key]
-          target_index = target_index_parent.delete(target_index_child_key)
-        elsif @logstash_format
+        dt = nil
+        if @logstash_format || @include_timestamp
           if record.has_key?(TIMESTAMP_FIELD)
             rts = record[TIMESTAMP_FIELD]
             dt = parse_time(rts, time, tag)
@@ -354,6 +353,12 @@ module Fluent::Plugin
             dt = Time.at(time).to_datetime
             record[TIMESTAMP_FIELD] = dt.iso8601(@time_precision)
           end
+        end
+
+        target_index_parent, target_index_child_key = @target_index_key ? get_parent_of(record, @target_index_key) : nil
+        if target_index_parent && target_index_parent[target_index_child_key]
+          target_index = target_index_parent.delete(target_index_child_key)
+        elsif @logstash_format
           dt = dt.new_offset(0) if @utc_index
           target_index = "#{logstash_prefix}#{@logstash_prefix_separator}#{dt.strftime(@logstash_dateformat)}"
         else

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -10,7 +10,7 @@ module Fluent::Plugin
 
     config_param :delimiter, :string, :default => "."
 
-    DYNAMIC_PARAM_NAMES = %W[hosts host port logstash_format logstash_prefix logstash_dateformat time_key utc_index index_name tag_key type_name id_key parent_key routing_key write_operation]
+    DYNAMIC_PARAM_NAMES = %W[hosts host port include_timestamp logstash_format logstash_prefix logstash_dateformat time_key utc_index index_name tag_key type_name id_key parent_key routing_key write_operation]
     DYNAMIC_PARAM_SYMBOLS = DYNAMIC_PARAM_NAMES.map { |n| "@#{n}".to_sym }
 
     attr_reader :dynamic_config
@@ -148,7 +148,7 @@ module Fluent::Plugin
           next
         end
 
-        if eval_or_val(dynamic_conf['logstash_format'])
+        if eval_or_val(dynamic_conf['logstash_format']) || eval_or_val(dynamic_conf['include_timestamp'])
           if record.has_key?("@timestamp")
             time = Time.parse record["@timestamp"]
           elsif record.has_key?(dynamic_conf['time_key'])
@@ -157,7 +157,9 @@ module Fluent::Plugin
           else
             record.merge!({"@timestamp" => Time.at(time).to_datetime.to_s})
           end
+        end
 
+        if eval_or_val(dynamic_conf['logstash_format'])
           if eval_or_val(dynamic_conf['utc_index'])
             target_index = "#{dynamic_conf['logstash_prefix']}-#{Time.at(time).getutc.strftime("#{dynamic_conf['logstash_dateformat']}")}"
           else


### PR DESCRIPTION
Allows setting `include_timestamp true` to include the `@timestamp` that `logstash_format` does, except without the index name restriction.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
