### PR TITLE
[v0.14] Raise ConfigError when specifying different @hash_config.hash_id_key and id_key configration

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,9 @@ Here is a sample config:
 ```
 <hash>
   hash_id_key _id    # storing generated hash id key
+  hash_id_key _hash    # storing generated hash id key
 </hash>
+id_key _hash # specify same key name which is specified in hash_id_key
 ```
 
 ### Not seeing a config you need?

--- a/lib/fluent/plugin/generate_hash_id_support.rb
+++ b/lib/fluent/plugin/generate_hash_id_support.rb
@@ -7,7 +7,7 @@ module Fluent
       def self.included(klass)
         klass.instance_eval {
           config_section :hash, param_name: :hash_config, required: false, multi: false do
-            config_param :hash_id_key, :string, default: '_id'
+            config_param :hash_id_key, :string, default: '_hash'
           end
         }
       end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -134,6 +134,10 @@ module Fluent::Plugin
       if @password && m = @password.match(/%{(?<password>.*)}/)
         @password = URI.encode_www_form_component(m["password"])
       end
+
+      if @hash_config
+        raise Fluent::ConfigError, "@hash_config.hash_id_key and id_key must be equal." unless @hash_config.hash_id_key == @id_key
+      end
     end
 
     def create_meta_config_map

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -227,6 +227,21 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
   end
 
+  test 'with invaild generate id config' do
+    assert_raise(Fluent::ConfigError) {
+      driver.configure(Fluent::Config::Element.new(
+                         'ROOT', '', {
+                           '@type' => 'elasticsearch',
+                           'id_key' =>'id_mismatch',
+                         }, [
+                           Fluent::Config::Element.new('hash', '', {
+                                                         'hash_id_key' => '_hash',
+                                                       }, [])
+                         ]
+                       ))
+    }
+  end
+
   def test_template_already_present
     config = %{
       host            logs.google.com


### PR DESCRIPTION
This is v0.14 version of #326 work.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
