### PR TITLE
Remove needless constants

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -242,14 +242,6 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     end.join(', ')
   end
 
-  BODY_DELIMITER = "\n".freeze
-  UPDATE_OP = "update".freeze
-  UPSERT_OP = "upsert".freeze
-  CREATE_OP = "create".freeze
-  INDEX_OP = "index".freeze
-  ID_FIELD = "_id".freeze
-  TIMESTAMP_FIELD = "@timestamp".freeze
-
   def append_record_to_messages(op, meta, header, record, msgs)
     case op
     when UPDATE_OP, UPSERT_OP


### PR DESCRIPTION
They are defined in Fluent::ElasticsearchConstants.

Follows up #324.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
