### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ The bundled elasticsearch_genid filter can generate a unique _hash key for each 
 Here is a sample config:
 
 ```
-<filter>
+<filter **>
   @type elasticsearch_genid
   hash_id_key _hash    # storing generated hash id key (default is _hash)
 </filter>

--- a/lib/fluent/plugin/generate_hash_id_support.rb
+++ b/lib/fluent/plugin/generate_hash_id_support.rb
@@ -7,7 +7,7 @@ module Fluent
       klass.instance_eval {
         config_section :hash, param_name: :hash_config, required: false, multi: false do
           config_param :hash_id_key, :string, default: '_hash',
-                       obsoleted: "Use bundled filer-elasticsearch-genid instead."
+                       obsoleted: "Use bundled filter-elasticsearch-genid instead."
 
         end
       }

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -205,7 +205,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   def test_configure_with_invaild_generate_id_config
-    assert_raise_message(/Use bundled filer-elasticsearch-genid instead./) do
+    assert_raise_message(/Use bundled filter-elasticsearch-genid instead./) do
       driver.configure(Fluent::Config::Element.new(
                          'ROOT', '', {
                            '@type' => 'elasticsearch',
@@ -558,7 +558,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
          "custom hash_id_key" => {"hash_id_key" => '_hash_id'},
         )
     def test_writes_with_genrate_hash(data)
-      assert_raise_message(/Use bundled filer-elasticsearch-genid instead./) do
+      assert_raise_message(/Use bundled filter-elasticsearch-genid instead./) do
         driver.configure(Fluent::Config::Element.new(
                            'ROOT', '', {
                              '@type' => 'elasticsearch',

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -313,7 +313,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
          "custom hash_id_key" => {"hash_id_key" => '_hash_id'},
         )
     def test_writes_with_genrate_hash(data)
-      assert_raise_message(/Use bundled filer-elasticsearch-genid instead./) do
+      assert_raise_message(/Use bundled filter-elasticsearch-genid instead./) do
         driver.configure(Fluent::Config::Element.new(
                            'ROOT', '', {
                              '@type' => 'elasticsearch',


### PR DESCRIPTION
```log
fil er ->
filter
   +
```

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
