### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ The bundled elasticsearch_genid filter can generate a unique _hash key for each 
 Here is a sample config:
 
 ```
-<filter>
+<filter **>
   @type elasticsearch_genid
   hash_id_key _hash    # storing generated hash id key (default is _hash)
 </filter>

--- a/lib/fluent/plugin/generate_hash_id_support.rb
+++ b/lib/fluent/plugin/generate_hash_id_support.rb
@@ -8,7 +8,7 @@ module Fluent
         klass.instance_eval {
           config_section :hash, param_name: :hash_config, required: false, multi: false do
             config_param :hash_id_key, :string, default: '_hash',
-                         obsoleted: "Use bundled filer-elasticsearch-genid instead."
+                         obsoleted: "Use bundled filter-elasticsearch-genid instead."
           end
         }
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -228,7 +228,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
   end
 
   test 'with invaild generate id config' do
-    assert_raise_message(/Use bundled filer-elasticsearch-genid instead./) do
+    assert_raise_message(/Use bundled filter-elasticsearch-genid instead./) do
       driver.configure(Fluent::Config::Element.new(
                          'ROOT', '', {
                            '@type' => 'elasticsearch',
@@ -585,7 +585,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
          "custom hash_id_key" => {"hash_id_key" => '_hash_id'},
         )
     def test_writes_with_genrate_hash(data)
-      assert_raise_message(/Use bundled filer-elasticsearch-genid instead./) do
+      assert_raise_message(/Use bundled filter-elasticsearch-genid instead./) do
         driver.configure(Fluent::Config::Element.new(
                            'ROOT', '', {
                              '@type' => 'elasticsearch',

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -323,7 +323,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
          "custom hash_id_key" => {"hash_id_key" => '_hash_id'},
         )
     def test_writes_with_genrate_hash(data)
-      assert_raise_message(/Use bundled filer-elasticsearch-genid instead./) do
+      assert_raise_message(/Use bundled filter-elasticsearch-genid instead./) do
         driver.configure(Fluent::Config::Element.new(
                            'ROOT', '', {
                              '@type' => 'elasticsearch',


### PR DESCRIPTION
```log
fil er ->
filter
   +
```

Pointed out in https://github.com/uken/fluent-plugin-elasticsearch/pull/331#discussion_r152473491.
Thanks @lukas-vlcek!

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)