### PR TITLE
Add built-in placeholders support against type_name parameter

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -320,7 +320,8 @@ module Fluent::Plugin
     def expand_placeholders(metadata)
       logstash_prefix = extract_placeholders(@logstash_prefix, metadata)
       index_name = extract_placeholders(@index_name, metadata)
-      return logstash_prefix, index_name
+      type_name = extract_placeholders(@type_name, metadata)
+      return logstash_prefix, index_name, type_name
     end
 
     def multi_workers_ready?
@@ -333,7 +334,7 @@ module Fluent::Plugin
       meta = {}
 
       tag = chunk.metadata.tag
-      logstash_prefix, index_name = expand_placeholders(chunk.metadata)
+      logstash_prefix, index_name, type_name = expand_placeholders(chunk.metadata)
       @error = Fluent::Plugin::ElasticsearchErrorHandler.new(self)
 
       chunk.msgpack_each do |time, record|
@@ -384,7 +385,7 @@ module Fluent::Plugin
         if target_type_parent && target_type_parent[target_type_child_key]
           target_type = target_type_parent.delete(target_type_child_key)
         else
-          target_type = @type_name
+          target_type = type_name
         end
 
         meta.clear

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -821,6 +821,16 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal('mytype', index_cmds.first['index']['_type'])
   end
 
+  def test_writes_to_speficied_type_with_placeholders
+    driver.configure("type_name mytype.${tag}\n")
+    stub_elastic_ping
+    stub_elastic
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+    assert_equal('mytype.test', index_cmds.first['index']['_type'])
+  end
+
   def test_writes_to_target_type_key
     driver.configure("target_type_key @target_type\n")
     stub_elastic_ping


### PR DESCRIPTION
Fixes https://github.com/uken/fluent-plugin-elasticsearch/issues/330.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
