### PR TITLE
Add config parameter to enable elasticsearch-ruby's transporter logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Current maintainers: @cosmo0920
   + [write_operation](#write_operation)
   + [time_parse_error_tag](#time_parse_error_tag)
   + [reconnect_on_error](#reconnect_on_error)
+  + [with_transporter_log](#with_transporter_log)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffer options](#buffer-options)
@@ -504,6 +505,17 @@ By default it will reconnect only on "host unreachable exceptions".
 We recommended to set this true in the presence of elasticsearch shield.
 ```
 reconnect_on_error true # defaults to false
+```
+
+### with_transporter_log
+
+This is debugging purpose option to enable to obtain transporter layer log.
+Default value is `false` for backward compatibility.
+
+We recommend to set this true if you start to debug this plugin.
+
+```
+with_transporter_log true
 ```
 
 ### Client/host certificate options

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -74,7 +74,7 @@ module Fluent::Plugin
     config_param :time_parse_error_tag, :string, :default => 'Fluent::ElasticsearchOutput::TimeParser.error'
     config_param :reconnect_on_error, :bool, :default => false
     config_param :pipeline, :string, :default => nil
-
+    config_param :with_transporter_log, :bool, :default => false
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -139,6 +139,12 @@ module Fluent::Plugin
       if @hash_config
         raise Fluent::ConfigError, "@hash_config.hash_id_key and id_key must be equal." unless @hash_config.hash_id_key == @id_key
       end
+      @transport_logger = nil
+      if @with_transporter_log
+        @transport_logger = log
+        log_level = conf['@log_level'] || conf['log_level']
+        log.warn "Consider to specify log_level with @log_level." unless log_level
+      end
     end
 
     def create_meta_config_map
@@ -187,6 +193,7 @@ module Fluent::Plugin
                                                                               reload_on_failure: @reload_on_failure,
                                                                               resurrect_after: @resurrect_after,
                                                                               retry_on_failure: 5,
+                                                                              logger: @transport_logger,
                                                                               transport_options: {
                                                                                 headers: { 'Content-Type' => 'application/json' },
                                                                                 request: { timeout: @request_timeout },

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -52,6 +52,7 @@ module Fluent::Plugin
                                                                               reload_on_failure: @reload_on_failure,
                                                                               resurrect_after: @resurrect_after,
                                                                               retry_on_failure: 5,
+                                                                              logger: @transport_logger,
                                                                               transport_options: {
                                                                                 headers: { 'Content-Type' => 'application/json' },
                                                                                 request: { timeout: @request_timeout },

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -205,6 +205,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_nil instance.client_key
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
+    assert_false instance.with_transporter_log
   end
 
   test 'lack of tag in chunk_keys' do

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -78,6 +78,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_nil instance.client_key
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
+    assert_false instance.with_transporter_log
   end
 
   def test_defaults


### PR DESCRIPTION
Fixes #341.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
