### PR TITLE
Merge pull request #342 from uken/enable-es-transport-logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [write_operation](#write_operation)
   + [time_parse_error_tag](#time_parse_error_tag)
   + [reconnect_on_error](#reconnect_on_error)
+  + [with_transporter_log](#with_transporter_log)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffered output options](#buffered-output-options)
@@ -466,6 +467,17 @@ By default it will reconnect only on "host unreachable exceptions".
 We recommended to set this true in the presence of elasticsearch shield.
 ```
 reconnect_on_error true # defaults to false
+```
+
+### with_transporter_log
+
+This is debugging purpose option to enable to obtain transporter layer log.
+Default value is `false` for backward compatibility.
+
+We recommend to set this true if you start to debug this plugin.
+
+```
+with_transporter_log true
 ```
 
 ### Client/host certificate options

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -69,6 +69,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :time_parse_error_tag, :string, :default => 'Fluent::ElasticsearchOutput::TimeParser.error'
   config_param :reconnect_on_error, :bool, :default => false
   config_param :pipeline, :string, :default => nil
+  config_param :with_transporter_log, :bool, :default => false
 
   include Fluent::ElasticsearchIndexTemplate
   include Fluent::GenerateHashIdSupport
@@ -123,6 +124,13 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     if @hash_config
       raise Fluent::ConfigError, "@hash_config.hash_id_key and id_key must be equal." unless @hash_config.hash_id_key == @id_key
     end
+
+    @transport_logger = nil
+    if @with_transporter_log
+      @transport_logger = log
+      log_level = conf['@log_level'] || conf['log_level']
+      log.warn "Consider to specify log_level with @log_level." unless log_level
+    end
   end
 
   def create_meta_config_map
@@ -171,6 +179,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
                                                                             reload_on_failure: @reload_on_failure,
                                                                             resurrect_after: @resurrect_after,
                                                                             retry_on_failure: 5,
+                                                                            logger: @transport_logger,
                                                                             transport_options: {
                                                                               headers: { 'Content-Type' => 'application/json' },
                                                                               request: { timeout: @request_timeout },

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -49,6 +49,7 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
                                                                             reload_on_failure: @reload_on_failure,
                                                                             resurrect_after: @resurrect_after,
                                                                             retry_on_failure: 5,
+                                                                            logger: @transport_logger,
                                                                             transport_options: {
                                                                               headers: { 'Content-Type' => 'application/json' },
                                                                               request: { timeout: @request_timeout },

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -202,6 +202,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_nil instance.client_key
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
+    assert_false instance.with_transporter_log
   end
 
   def test_configure_with_invaild_generate_id_config

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -75,6 +75,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_nil instance.client_key
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
+    assert_false instance.with_transporter_log
   end
 
   def test_defaults


### PR DESCRIPTION
Backported #342.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
