### PR TITLE
Using nested record in id_key, parent_key, and routing_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Current maintainers: @cosmo0920
 
 | fluent-plugin-elasticsearch  | fluentd | ruby |
 |-------------------|---------|------|
-| >= 2.0.0 | >= v0.14.0 | >= 2.1 |
+| >= 2.0.0 | >= v0.14.20 | >= 2.1 |
 |  < 2.0.0 | >= v0.12.0 | >= 1.9 |
 
 NOTE: For v0.12 version, you should use 1.x.y version. Please send patch into v0.12 branch if you encountered 1.x version's bug.
@@ -422,7 +422,30 @@ Example configuration for [fluent-plugin-genhashvalue](https://github.com/mtakem
 </filter>
 ```
 
-:warning: In order to avoid hash-collisions and loosing data careful consideration is required when choosing the keys in the event record that should be used to calculate the hash 
+:warning: In order to avoid hash-collisions and loosing data careful consideration is required when choosing the keys in the event record that should be used to calculate the hash
+
+#### Using nested key
+
+Nested key specifying syntax is also supported.
+
+With the following configuration
+
+```aconf
+id_key $.nested.request_id
+```
+
+and the following nested record
+
+```json
+{"nested":{"name": "Johnny", "request_id": "87d89af7daffad6"}}
+```
+
+will trigger the following Elasticsearch command
+
+```
+{"index":{"_index":"fluentd","_type":"fluentd","_id":"87d89af7daffad6"}}
+{"nested":{"name":"Johnny","request_id":"87d89af7daffad6"}}
+```
 
 ### parent_key
 
@@ -443,6 +466,29 @@ Elasticsearch command would be
 ```
 
 if `parent_key` is not configed or the `parent_key` is absent in input record, nothing will happen.
+
+#### Using nested key
+
+Nested key specifying syntax is also supported.
+
+With the following configuration
+
+```aconf
+parent_key $.nested.a_parent
+```
+
+and the following nested record
+
+```json
+{"nested":{ "name": "Johnny", "a_parent": "my_parent" }}
+```
+
+will trigger the following Elasticsearch command
+
+```
+{"index":{"_index":"fluentd","_type":"fluentd","_parent":"my_parent"}}
+{"nested":{"name":"Johnny","a_parent":"my_parent"}}
+```
 
 ### routing_key
 

--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ will trigger the following Elasticsearch command
 {"nested":{"name":"Johnny","request_id":"87d89af7daffad6"}}
 ```
 
+:warning: Note that [Hash flattening](#hash-flattening) may be conflict nested record feature.
+
 ### parent_key
 
 ```
@@ -489,6 +491,8 @@ will trigger the following Elasticsearch command
 {"index":{"_index":"fluentd","_type":"fluentd","_parent":"my_parent"}}
 {"nested":{"name":"Johnny","a_parent":"my_parent"}}
 ```
+
+:warning: Note that [Hash flattening](#hash-flattening) may be conflict nested record feature.
 
 ### routing_key
 

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.0".freeze)
 
-  s.add_runtime_dependency 'fluentd', '>= 0.14.8'
+  s.add_runtime_dependency 'fluentd', '>= 0.14.20'
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'elasticsearch'
 

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -188,7 +188,9 @@ module Fluent::Plugin
 
         @meta_config_map.each_pair do |config_name, meta_key|
           if dynamic_conf[config_name] && accessor = record_accessor_create(dynamic_conf[config_name])
-            meta[meta_key] = accessor.call(record)
+            if raw_value = accessor.call(record)
+              meta[meta_key] = raw_value
+            end
           end
         end
 

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -187,8 +187,8 @@ module Fluent::Plugin
         meta = {"_index" => target_index, "_type" => dynamic_conf['type_name']}
 
         @meta_config_map.each_pair do |config_name, meta_key|
-          if dynamic_conf[config_name] && record[dynamic_conf[config_name]]
-            meta[meta_key] = record[dynamic_conf[config_name]]
+          if dynamic_conf[config_name] && accessor = record_accessor_create(dynamic_conf[config_name])
+            meta[meta_key] = accessor.call(record)
           end
         end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -34,6 +34,12 @@ class ElasticsearchOutput < Test::Unit::TestCase
     {'age' => 26, 'request_id' => '42', 'parent_id' => 'parent', 'routing_id' => 'routing'}
   end
 
+  def nested_sample_record
+    {'nested' =>
+     {'age' => 26, 'parent_id' => 'parent', 'routing_id' => 'routing', 'request_id' => '42'}
+    }
+  end
+
   def stub_elastic_ping(url="http://localhost:9200")
     stub_request(:head, url).to_return(:status => 200, :body => "", :headers => {})
   end
@@ -1429,6 +1435,38 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(index_cmds[0]['index']['_id'], '42')
   end
 
+  class NestedIdKeyTest < self
+    def test_adds_nested_id_key_with_dot
+      driver.configure("id_key nested.request_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_id'], '42')
+    end
+
+    def test_adds_nested_id_key_with_dollar_dot
+      driver.configure("id_key $.nested.request_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_id'], '42')
+    end
+
+    def test_adds_nested_id_key_with_bracket
+      driver.configure("id_key $['nested']['request_id']\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_id'], '42')
+    end
+  end
+
   def test_doesnt_add_id_key_if_missing_when_configured
     driver.configure("id_key another_request_id\n")
     stub_elastic_ping
@@ -1458,6 +1496,38 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(index_cmds[0]['index']['_parent'], 'parent')
   end
 
+  class NestedParentKeyTest < self
+    def test_adds_nested_parent_key_with_dot
+      driver.configure("parent_key nested.parent_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    end
+
+    def test_adds_nested_parent_key_with_dollar_dot
+      driver.configure("parent_key $.nested.parent_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    end
+
+    def test_adds_nested_parent_key_with_bracket
+      driver.configure("parent_key $['nested']['parent_id']\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    end
+  end
+
   def test_doesnt_add_parent_key_if_missing_when_configured
     driver.configure("parent_key another_parent_id\n")
     stub_elastic_ping
@@ -1485,6 +1555,38 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record)
     end
     assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+  end
+
+  class NestedRoutingKeyTest < self
+    def test_adds_nested_routing_key_with_dot
+      driver.configure("routing_key nested.routing_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+    end
+
+    def test_adds_nested_routing_key_with_dollar_dot
+      driver.configure("routing_key $.nested.routing_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+    end
+
+    def test_adds_nested_routing_key_with_bracket
+      driver.configure("routing_key $['nested']['routing_id']\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+    end
   end
 
   def test_doesnt_add_routing_key_if_missing_when_configured

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -31,6 +31,12 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     {'age' => 26, 'request_id' => '42', 'parent_id' => 'parent', 'routing_id' => 'routing'}
   end
 
+  def nested_sample_record
+    {'nested' =>
+     {'age' => 26, 'parent_id' => 'parent', 'routing_id' => 'routing', 'request_id' => '42'}
+    }
+  end
+
   def stub_elastic_ping(url="http://localhost:9200")
     stub_request(:head, url).to_return(:status => 200, :body => "", :headers => {})
   end
@@ -582,6 +588,38 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal(index_cmds[0]['index']['_id'], '42')
   end
 
+  class NestedIdKeyTest < self
+    def test_adds_nested_id_key_with_dot
+      driver.configure("id_key nested.request_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_id'], '42')
+    end
+
+    def test_adds_nested_id_key_with_dollar_dot
+      driver.configure("id_key $.nested.request_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_id'], '42')
+    end
+
+    def test_adds_nested_id_key_with_bracket
+      driver.configure("id_key $['nested']['request_id']\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_id'], '42')
+    end
+  end
+
   def test_doesnt_add_id_key_if_missing_when_configured
     driver.configure("id_key another_request_id\n")
     stub_elastic_ping
@@ -611,6 +649,38 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal(index_cmds[0]['index']['_parent'], 'parent')
   end
 
+  class NestedParentKeyTest < self
+    def test_adds_nested_parent_key_with_dot
+      driver.configure("parent_key nested.parent_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    end
+
+    def test_adds_nested_parent_key_with_dollar_dot
+      driver.configure("parent_key $.nested.parent_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    end
+
+    def test_adds_nested_parent_key_with_bracket
+      driver.configure("parent_key $['nested']['parent_id']\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    end
+  end
+
   def test_doesnt_add_parent_key_if_missing_when_configured
     driver.configure("parent_key another_parent_id\n")
     stub_elastic_ping
@@ -638,6 +708,38 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record)
     end
     assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+  end
+
+  class NestedRoutingKeyTest < self
+    def test_adds_nested_routing_key_with_dot
+      driver.configure("routing_key nested.routing_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+    end
+
+    def test_adds_nested_routing_key_with_dollar_dot
+      driver.configure("routing_key $.nested.routing_id\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+    end
+
+    def test_adds_nested_routing_key_with_bracket
+      driver.configure("routing_key $['nested']['routing_id']\n")
+      stub_elastic_ping
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(nested_sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+    end
   end
 
   def test_doesnt_add_routing_key_if_missing_when_configured


### PR DESCRIPTION
This is patches for https://github.com/uken/fluent-plugin-elasticsearch/issues/347 on Fluentd v0.14/v1.0.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
