### PR TITLE
Fix timestamp precision issue when using time_key and time_key_format

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -376,7 +376,7 @@ module Fluent::Plugin
           elsif record.has_key?(@time_key)
             rts = record[@time_key]
             dt = parse_time(rts, time, tag)
-            record[TIMESTAMP_FIELD] = rts unless @time_key_exclude_timestamp
+            record[TIMESTAMP_FIELD] = dt.iso8601(@time_precision) unless @time_key_exclude_timestamp
           else
             dt = Time.at(time).to_datetime
             record[TIMESTAMP_FIELD] = dt.iso8601(@time_precision)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1265,7 +1265,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
                       time_key vtm
-                      time_precision 0\n")
+                      time_precision 3\n")
     stub_elastic_ping
     stub_elastic
     ts = "2001-02-03 13:14:01.673+02:00"
@@ -1282,7 +1282,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
                       index_name test
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
                       time_key vtm
-                      time_precision 0\n")
+                      time_precision 3\n")
     stub_elastic_ping
     stub_elastic
     ts = "2001-02-03 13:14:01.673+02:00"

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1249,8 +1249,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   def test_uses_custom_time_key
     driver.configure("logstash_format true
-                      time_key vtm
-                      time_precision 0\n")
+                      time_key vtm\n")
     stub_elastic_ping
     stub_elastic
     ts = DateTime.new(2001,2,3).to_s
@@ -1258,14 +1257,13 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
   end
 
   def test_uses_custom_time_key_with_format
     driver.configure("logstash_format true
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
-                      time_key vtm
-                      time_precision 3\n")
+                      time_key vtm\n")
     stub_elastic_ping
     stub_elastic
     ts = "2001-02-03 13:14:01.673+02:00"
@@ -1273,7 +1271,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
     assert_equal("logstash-2001.02.03", index_cmds[0]['index']['_index'])
   end
 
@@ -1281,8 +1279,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.configure("include_timestamp true
                       index_name test
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
-                      time_key vtm
-                      time_precision 3\n")
+                      time_key vtm\n")
     stub_elastic_ping
     stub_elastic
     ts = "2001-02-03 13:14:01.673+02:00"
@@ -1290,7 +1287,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
     assert_equal("test", index_cmds[0]['index']['_index'])
   end
 
@@ -1318,7 +1315,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
     assert_equal("logstash-2001.02.03", index_cmds[0]['index']['_index'])
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
   end
 
   def test_uses_custom_time_key_format_without_logstash
@@ -1333,7 +1330,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
     assert_equal("test", index_cmds[0]['index']['_index'])
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
   end
 
   data(:default => nil,

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1252,9 +1252,9 @@ class ElasticsearchOutput < Test::Unit::TestCase
                       time_key vtm\n")
     stub_elastic_ping
     stub_elastic
-    ts = DateTime.new(2001,2,3).to_s
+    ts = DateTime.new(2001,2,3)
     driver.run(default_tag: 'test') do
-      driver.feed(sample_record.merge!('vtm' => ts))
+      driver.feed(sample_record.merge!('vtm' => ts.to_s))
     end
     assert(index_cmds[1].has_key? '@timestamp')
     assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
@@ -1271,7 +1271,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
+    assert_equal(index_cmds[1]['@timestamp'], Time.parse(ts).iso8601(9))
     assert_equal("logstash-2001.02.03", index_cmds[0]['index']['_index'])
   end
 
@@ -1287,7 +1287,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
+    assert_equal(index_cmds[1]['@timestamp'], Time.parse(ts).iso8601(9))
     assert_equal("test", index_cmds[0]['index']['_index'])
   end
 


### PR DESCRIPTION
This is an old issue that hasn't been fixed...


(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
