### PR TITLE
Update tests

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1249,7 +1249,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   def test_uses_custom_time_key
     driver.configure("logstash_format true
-                      time_key vtm\n")
+                      time_key vtm
+                      time_precision 0\n")
     stub_elastic_ping
     stub_elastic
     ts = DateTime.new(2001,2,3).to_s
@@ -1263,7 +1264,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
   def test_uses_custom_time_key_with_format
     driver.configure("logstash_format true
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
-                      time_key vtm\n")
+                      time_key vtm
+                      time_precision 0\n")
     stub_elastic_ping
     stub_elastic
     ts = "2001-02-03 13:14:01.673+02:00"
@@ -1279,7 +1281,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.configure("include_timestamp true
                       index_name test
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
-                      time_key vtm\n")
+                      time_key vtm
+                      time_precision 0\n")
     stub_elastic_ping
     stub_elastic
     ts = "2001-02-03 13:14:01.673+02:00"


### PR DESCRIPTION
Fix time precision in tests:
time_precision default value in plugin is 9, and tests use default "tostring" of time which uses time precision of 0.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
