### PR TITLE
Prevent error when using template in elasticsearch_dynamic for elementally use case

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -36,7 +36,7 @@ module Fluent::Plugin
     end
 
 
-    def client(host = @host)
+    def client(host = nil)
       # check here to see if we already have a client connection for the given host
       connection_options = get_connection_options(host)
 

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -35,8 +35,8 @@ module Fluent::Plugin
       {'id_key' => '_id', 'parent_key' => '_parent', 'routing_key' => '_routing'}
     end
 
-    def client(host)
 
+    def client(host = @host)
       # check here to see if we already have a client connection for the given host
       connection_options = get_connection_options(host)
 
@@ -277,6 +277,7 @@ module Fluent::Plugin
     def is_existing_connection(host)
       # check if the host provided match the current connection
       return false if @_es.nil?
+      return false if @current_config.nil?
       return false if host.length != @current_config.length
 
       for i in 0...host.length


### PR DESCRIPTION
This patch works for an elasticsearch host which is specified in `@host` parameter.
refs: #241

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
