### PR TITLE
Configureable content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Current maintainers: @cosmo0920
   + [time_parse_error_tag](#time_parse_error_tag)
   + [reconnect_on_error](#reconnect_on_error)
   + [with_transporter_log](#with_transporter_log)
+  + [content_type](#content_type)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffer options](#buffer-options)
@@ -568,6 +569,16 @@ We recommend to set this true if you start to debug this plugin.
 
 ```
 with_transporter_log true
+```
+
+### content_type
+
+With `content_type application/json`, elasticsearch plugin adds `application/json` as `Content-Type` in payload.
+
+Default value is `application/x-ndjson` which is encourage to use Elasticsearch bulk request.
+
+```
+content_type application/json
 ```
 
 ### Client/host certificate options

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -75,6 +75,7 @@ module Fluent::Plugin
     config_param :reconnect_on_error, :bool, :default => false
     config_param :pipeline, :string, :default => nil
     config_param :with_transporter_log, :bool, :default => false
+    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson"], :default => :"application/x-ndjson"
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -207,7 +208,7 @@ module Fluent::Plugin
                                                                               retry_on_failure: 5,
                                                                               logger: @transport_logger,
                                                                               transport_options: {
-                                                                                headers: { 'Content-Type' => 'application/json' },
+                                                                                headers: { 'Content-Type' => @content_type.to_s },
                                                                                 request: { timeout: @request_timeout },
                                                                                 ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
                                                                               }

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -54,7 +54,7 @@ module Fluent::Plugin
                                                                               retry_on_failure: 5,
                                                                               logger: @transport_logger,
                                                                               transport_options: {
-                                                                                headers: { 'Content-Type' => 'application/json' },
+                                                                                headers: { 'Content-Type' => @content_type.to_s },
                                                                                 request: { timeout: @request_timeout },
                                                                                 ssl: { verify: @ssl_verify, ca_file: @ca_file }
                                                                               }

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -212,6 +212,24 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
     assert_false instance.with_transporter_log
+    assert_equal :"application/x-ndjson", instance.content_type
+  end
+
+  test 'configure Content-Type' do
+    config = %{
+      content_type application/json
+    }
+    instance = driver(config).instance
+    assert_equal :"application/json", instance.content_type
+  end
+
+  test 'invalid Content-Type' do
+    config = %{
+      content_type nonexistent/invalid
+    }
+    assert_raise(Fluent::ConfigError) {
+      instance = driver(config).instance
+    }
   end
 
   test 'lack of tag in chunk_keys' do

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -643,7 +643,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_request(:head, "http://localhost:9200/").
       to_return(:status => 200, :body => "", :headers => {})
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-      with(headers: { "Content-Type" => "application/json" })
+      with(headers: { "Content-Type" => "application/x-ndjson" })
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -85,6 +85,24 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
     assert_false instance.with_transporter_log
+    assert_equal :"application/x-ndjson", instance.content_type
+  end
+
+  test 'configure Content-Type' do
+    config = %{
+      content_type application/json
+    }
+    instance = driver(config).instance
+    assert_equal :"application/json", instance.content_type
+  end
+
+  test 'invalid Content-Type' do
+    config = %{
+      content_type nonexistent/invalid
+    }
+    assert_raise(Fluent::ConfigError) {
+      instance = driver(config).instance
+    }
   end
 
   def test_defaults
@@ -220,7 +238,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     stub_request(:head, "http://localhost:9200/").
       to_return(:status => 200, :body => "", :headers => {})
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-      with(headers: { "Content-Type" => "application/json" })
+      with(headers: { "Content-Type" => "application/x-ndjson" })
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end


### PR DESCRIPTION
Fixes: #366.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
