### PR TITLE
Check es major version

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -482,6 +482,7 @@ EOC
         if retries < 2
           retries += 1
           @_es = nil
+          @_es_info = nil
           log.warn "Could not push logs to Elasticsearch, resetting connection and trying again. #{e.message}"
           sleep 2**retries
           retry
@@ -489,6 +490,7 @@ EOC
         raise ConnectionFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
       rescue Exception
         @_es = nil if @reconnect_on_error
+        @_es_info = nil if @reconnect_on_error
         raise
       end
     end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -414,11 +414,12 @@ EOC
         end
 
         target_type_parent, target_type_child_key = @target_type_key ? get_parent_of(record, @target_type_key) : nil
-        if @last_seen_major_version >= 6
-          log.warn "Detected a 6.x and above: `@type_name` will be used as the document `_type`."
-        end
         if target_type_parent && target_type_parent[target_type_child_key]
           target_type = target_type_parent.delete(target_type_child_key)
+          if @last_seen_major_version >= 6
+            log.warn "Detected ES 6.x and above: `@type_name` will be used as the document `_type`."
+            target_type = type_name
+          end
         else
           target_type = type_name
         end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -157,7 +157,7 @@ EOC
         log.warn "Consider to specify log_level with @log_level." unless log_level
       end
 
-      @last_seen_major_version = DEFAULT_ELASTICSEARCH_VERSION
+      @last_seen_major_version = detect_es_major_version rescue DEFAULT_ELASTICSEARCH_VERSION
       if @last_seen_major_version >= 7 && @type_name != DEFAULT_TYPE_NAME
         log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
         @type_name = '_doc'.freeze

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -416,9 +416,12 @@ EOC
         target_type_parent, target_type_child_key = @target_type_key ? get_parent_of(record, @target_type_key) : nil
         if target_type_parent && target_type_parent[target_type_child_key]
           target_type = target_type_parent.delete(target_type_child_key)
-          if @last_seen_major_version >= 6
-            log.warn "Detected ES 6.x and above: `@type_name` will be used as the document `_type`."
+          if @last_seen_major_version == 6
+            log.warn "Detected ES 6.x: `@type_name` will be used as the document `_type`."
             target_type = type_name
+          elsif @last_seen_major_version >= 7
+            log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
+            target_type = '_doc'
           end
         else
           target_type = type_name

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -356,12 +356,7 @@ EOC
     def expand_placeholders(metadata)
       logstash_prefix = extract_placeholders(@logstash_prefix, metadata)
       index_name = extract_placeholders(@index_name, metadata)
-      if @last_seen_major_version >= 7
-        log.warn "Detected ES 7.x or above: `type_name` will be used as the document `_type`."
-        type_name = '_doc'.freeze
-      else
-        type_name = extract_placeholders(@type_name, metadata)
-      end
+      type_name = extract_placeholders(@type_name, metadata)
       return logstash_prefix, index_name, type_name
     end
 
@@ -434,7 +429,12 @@ EOC
             target_type = '_doc'.freeze
           end
         else
-          target_type = type_name
+          if @last_seen_major_version >= 7 && target_type != DEFAULT_TYPE_NAME
+            log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
+            target_type = '_doc'.freeze
+          else
+            target_type = type_name
+          end
         end
 
         meta.clear

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -27,6 +27,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
           [time, record].to_msgpack
         end
       end
+      # For request stub to detect compatibility.
+      def detect_es_major_version
+        6
+      end
     }.configure(conf)
   end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -868,7 +868,11 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('@target_type' => 'local-override'))
     end
-    assert_equal('local-override', index_cmds.first['index']['_type'])
+    if driver.instance.detect_es_major_version >= 6
+      assert_equal('fluentd', index_cmds.first['index']['_type'])
+    else
+      assert_equal('local-override', index_cmds.first['index']['_type'])
+    end
     assert_nil(index_cmds[1]['@target_type'])
   end
 
@@ -904,7 +908,11 @@ class ElasticsearchOutput < Test::Unit::TestCase
         }
       }))
     end
-    assert_equal('local-override', index_cmds.first['index']['_type'])
+    if driver.instance.detect_es_major_version >= 6
+      assert_equal('fluentd', index_cmds.first['index']['_type'])
+    else
+      assert_equal('local-override', index_cmds.first['index']['_type'])
+    end
     assert_nil(index_cmds[1]['kubernetes']['labels']['log_type'])
   end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -851,24 +851,30 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 
-  def test_writes_to_speficied_type
-    driver.configure("type_name mytype\n")
+  data("border"        => {"es_version" => 6, "_type" => "mytype"},
+       "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
+      )
+  def test_writes_to_speficied_type(data)
+    driver('', data["es_version"]).configure("type_name mytype\n")
     stub_elastic_ping
     stub_elastic
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('mytype', index_cmds.first['index']['_type'])
+    assert_equal(data['_type'], index_cmds.first['index']['_type'])
   end
 
-  def test_writes_to_speficied_type_with_placeholders
-    driver.configure("type_name mytype.${tag}\n")
+  data("border"        => {"es_version" => 6, "_type" => "mytype.test"},
+       "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
+      )
+  def test_writes_to_speficied_type_with_placeholders(data)
+    driver('', data["es_version"]).configure("type_name mytype.${tag}\n")
     stub_elastic_ping
     stub_elastic
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('mytype.test', index_cmds.first['index']['_type'])
+    assert_equal(data['_type'], index_cmds.first['index']['_type'])
   end
 
   data("old"           => {"es_version" => 2, "_type" => "local-override"},

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -29,7 +29,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       end
       # For request stub to detect compatibility.
       def detect_es_major_version
-        6
+        [2, 5, 6].sample
       end
     }.configure(conf)
   end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -673,7 +673,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal('_doc', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_speficied_index
@@ -866,7 +866,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   data("old"           => {"es_version" => 2, "_type" => "local-override"},
        "old_behavior"  => {"es_version" => 5, "_type" => "local-override"},
-       "border"        => {"es_version" => 6, "_type" => "fluentd"},
+       "border"        => {"es_version" => 6, "_type" => "_doc"},
        "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
       )
   def test_writes_to_target_type_key(data)
@@ -888,7 +888,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal('_doc', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_target_type_key_fallack_to_type_name
@@ -904,7 +904,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   data("old"           => {"es_version" => 2, "_type" => "local-override"},
        "old_behavior"  => {"es_version" => 5, "_type" => "local-override"},
-       "border"        => {"es_version" => 6, "_type" => "fluentd"},
+       "border"        => {"es_version" => 6, "_type" => "_doc"},
        "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
       )
   def test_writes_to_target_type_key_nested(data)
@@ -933,7 +933,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
         }
       }))
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal('_doc', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_speficied_host

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -260,7 +260,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal('_doc', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_specified_index

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -16,7 +16,14 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     @driver = nil
   end
 
-  def driver(conf='')
+  def driver(conf='', es_version=5)
+    # For request stub to detect compatibility.
+    @es_version ||= es_version
+    Fluent::Plugin::ElasticsearchOutputDynamic.module_eval(<<-CODE)
+      def detect_es_major_version
+        #{@es_version}
+      end
+    CODE
     @driver ||= Fluent::Test::Driver::Output.new(Fluent::Plugin::ElasticsearchOutputDynamic) {
       # v0.12's test driver assume format definition. This simulates ObjectBufferedOutput format
       if !defined?(Fluent::Plugin::Output)
@@ -103,6 +110,14 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_raise(Fluent::ConfigError) {
       instance = driver(config).instance
     }
+  end
+
+  test 'Detected Elasticsearch 7' do
+    config = %{
+      type_name changed
+    }
+    instance = driver(config, 7).instance
+    assert_equal '_doc', instance.type_name
   end
 
   def test_defaults


### PR DESCRIPTION
Currently, ES 6.x cannot handle documents without `_type`.
But, Elasticsearch 6.0 supports a single mapping type per index only.
And referring https://github.com/logstash-plugins/logstash-output-elasticsearch/pull/712,
current ES accepts single fixed type name in `_type` field.

We should follow this logstash-output-elasticsearch behavior. 

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
