### PR TITLE
Restore default value of type name

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -157,6 +157,9 @@ EOC
       end
 
       @last_seen_major_version = detect_es_major_version rescue DEFAULT_ELASTICSEARCH_VERSION
+      if @last_seen_major_version == 6 && @type_name != DEFAULT_TYPE_NAME_ES_7x
+        log.info "Detected ES 6.x: ES 7.x will only accept `_doc` in type_name."
+      end
       if @last_seen_major_version >= 7 && @type_name != DEFAULT_TYPE_NAME_ES_7x
         log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
         @type_name = '_doc'.freeze

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -24,7 +24,6 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
     DEFAULT_ELASTICSEARCH_VERSION = 5 # For compatibility.
-    DEFAULT_TYPE_NAME = "_doc".freeze
 
     config_param :host, :string,  :default => 'localhost'
     config_param :port, :integer, :default => 9200
@@ -46,7 +45,7 @@ EOC
     config_param :logstash_prefix_separator, :string, :default => '-'
     config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
     config_param :utc_index, :bool, :default => true
-    config_param :type_name, :string, :default => DEFAULT_TYPE_NAME
+    config_param :type_name, :string, :default => "fluentd"
     config_param :index_name, :string, :default => "fluentd"
     config_param :id_key, :string, :default => nil
     config_param :write_operation, :string, :default => "index"
@@ -160,6 +159,7 @@ EOC
         log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
         @type_name = '_doc'.freeze
       end
+      @last_seen_major_version = DEFAULT_ELASTICSEARCH_VERSION
     end
 
     def detect_es_major_version
@@ -424,7 +424,7 @@ EOC
             target_type = type_name
           elsif @last_seen_major_version >= 7
             log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
-            target_type = '_doc'.freeze
+            target_type = '_doc'
           end
         else
           if @last_seen_major_version >= 7 && target_type != DEFAULT_TYPE_NAME

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -24,6 +24,7 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
     DEFAULT_ELASTICSEARCH_VERSION = 5 # For compatibility.
+    DEFAULT_TYPE_NAME_ES_7x = "_doc".freeze
     DEFAULT_TYPE_NAME = "fluentd".freeze
 
     config_param :host, :string,  :default => 'localhost'
@@ -156,11 +157,10 @@ EOC
       end
 
       @last_seen_major_version = detect_es_major_version rescue DEFAULT_ELASTICSEARCH_VERSION
-      if @last_seen_major_version >= 7 && @type_name != DEFAULT_TYPE_NAME
+      if @last_seen_major_version >= 7 && @type_name != DEFAULT_TYPE_NAME_ES_7x
         log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
         @type_name = '_doc'.freeze
       end
-      @last_seen_major_version = DEFAULT_ELASTICSEARCH_VERSION
     end
 
     def detect_es_major_version
@@ -425,10 +425,10 @@ EOC
             target_type = type_name
           elsif @last_seen_major_version >= 7
             log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
-            target_type = '_doc'
+            target_type = '_doc'.freeze
           end
         else
-          if @last_seen_major_version >= 7 && target_type != DEFAULT_TYPE_NAME
+          if @last_seen_major_version >= 7 && target_type != DEFAULT_TYPE_NAME_ES_7x
             log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
             target_type = '_doc'.freeze
           else

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -24,6 +24,7 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
     DEFAULT_ELASTICSEARCH_VERSION = 5 # For compatibility.
+    DEFAULT_TYPE_NAME = "fluentd".freeze
 
     config_param :host, :string,  :default => 'localhost'
     config_param :port, :integer, :default => 9200
@@ -45,7 +46,7 @@ EOC
     config_param :logstash_prefix_separator, :string, :default => '-'
     config_param :logstash_dateformat, :string, :default => "%Y.%m.%d"
     config_param :utc_index, :bool, :default => true
-    config_param :type_name, :string, :default => "fluentd"
+    config_param :type_name, :string, :default => DEFAULT_TYPE_NAME
     config_param :index_name, :string, :default => "fluentd"
     config_param :id_key, :string, :default => nil
     config_param :write_operation, :string, :default => "index"

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -665,7 +665,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('_doc', index_cmds.first['index']['_type'])
+    assert_equal('fluentd', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_speficied_index
@@ -843,7 +843,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   data("old"           => {"es_version" => 2, "_type" => "local-override"},
        "old_behavior"  => {"es_version" => 5, "_type" => "local-override"},
-       "border"        => {"es_version" => 6, "_type" => "_doc"},
+       "border"        => {"es_version" => 6, "_type" => "fluentd"},
        "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
       )
   def test_writes_to_target_type_key(data)
@@ -865,7 +865,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('_doc', index_cmds.first['index']['_type'])
+    assert_equal('fluentd', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_target_type_key_fallack_to_type_name
@@ -881,7 +881,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   data("old"           => {"es_version" => 2, "_type" => "local-override"},
        "old_behavior"  => {"es_version" => 5, "_type" => "local-override"},
-       "border"        => {"es_version" => 6, "_type" => "_doc"},
+       "border"        => {"es_version" => 6, "_type" => "fluentd"},
        "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
       )
   def test_writes_to_target_type_key_nested(data)
@@ -910,7 +910,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
         }
       }))
     end
-    assert_equal('_doc', index_cmds.first['index']['_type'])
+    assert_equal('fluentd', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_speficied_host

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -37,6 +37,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
     }.configure(conf)
   end
 
+  def default_type_name
+    Fluent::Plugin::ElasticsearchOutput::DEFAULT_TYPE_NAME
+  end
+
   def sample_record
     {'age' => 26, 'request_id' => '42', 'parent_id' => 'parent', 'routing_id' => 'routing'}
   end
@@ -220,6 +224,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_nil instance.client_key_pass
     assert_false instance.with_transporter_log
     assert_equal :"application/x-ndjson", instance.content_type
+    assert_equal "fluentd", default_type_name
   end
 
   test 'configure Content-Type' do
@@ -665,7 +670,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal(default_type_name, index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_speficied_index
@@ -865,7 +870,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal(default_type_name, index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_target_type_key_fallack_to_type_name
@@ -910,7 +915,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
         }
       }))
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal(default_type_name, index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_speficied_host

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -34,6 +34,10 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }.configure(conf)
   end
 
+  def default_type_name
+    Fluent::Plugin::ElasticsearchOutput::DEFAULT_TYPE_NAME
+  end
+
   def sample_record
     {'age' => 26, 'request_id' => '42', 'parent_id' => 'parent', 'routing_id' => 'routing'}
   end
@@ -275,7 +279,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('fluentd', index_cmds.first['index']['_type'])
+    assert_equal(default_type_name, index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_specified_index

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -275,7 +275,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal('_doc', index_cmds.first['index']['_type'])
+    assert_equal('fluentd', index_cmds.first['index']['_type'])
   end
 
   def test_writes_to_specified_index


### PR DESCRIPTION
This is mainly reverting change to fix #376 .
Currently, Elasticsearch in AWS Elasticsearch service does not accept `_doc` like type.
We should consider to restore default value of `type_name`.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
