### PR TITLE
Revert content type header default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,12 +573,13 @@ with_transporter_log true
 
 ### content_type
 
-With `content_type application/json`, elasticsearch plugin adds `application/json` as `Content-Type` in payload.
+With `content_type application/x-ndjson`, elasticsearch plugin adds `application/x-ndjson` as `Content-Type` in payload.
 
-Default value is `application/x-ndjson` which is encourage to use Elasticsearch bulk request.
+Default value is `application/json` which is default Content-Type of Elasticsearch requests.
+If you will not use template, it recommends to set `content_type application/x-ndjson`.
 
 ```
-content_type application/json
+content_type application/x-ndjson
 ```
 
 ### Client/host certificate options

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -80,7 +80,7 @@ EOC
     config_param :reconnect_on_error, :bool, :default => false
     config_param :pipeline, :string, :default => nil
     config_param :with_transporter_log, :bool, :default => false
-    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson"], :default => :"application/x-ndjson"
+    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson"], :default => :"application/json"
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -223,16 +223,16 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
     assert_false instance.with_transporter_log
-    assert_equal :"application/x-ndjson", instance.content_type
+    assert_equal :"application/json", instance.content_type
     assert_equal "fluentd", default_type_name
   end
 
   test 'configure Content-Type' do
     config = %{
-      content_type application/json
+      content_type application/x-ndjson
     }
     instance = driver(config).instance
-    assert_equal :"application/json", instance.content_type
+    assert_equal :"application/x-ndjson", instance.content_type
   end
 
   test 'invalid Content-Type' do
@@ -648,7 +648,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_request(:head, "http://localhost:9200/").
       to_return(:status => 200, :body => "", :headers => {})
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-      with(headers: { "Content-Type" => "application/x-ndjson" })
+      with(headers: { "Content-Type" => "application/json" })
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -96,15 +96,15 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass
     assert_false instance.with_transporter_log
-    assert_equal :"application/x-ndjson", instance.content_type
+    assert_equal :"application/json", instance.content_type
   end
 
   test 'configure Content-Type' do
     config = %{
-      content_type application/json
+      content_type application/x-ndjson
     }
     instance = driver(config).instance
-    assert_equal :"application/json", instance.content_type
+    assert_equal :"application/x-ndjson", instance.content_type
   end
 
   test 'invalid Content-Type' do
@@ -257,7 +257,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     stub_request(:head, "http://localhost:9200/").
       to_return(:status => 200, :body => "", :headers => {})
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-      with(headers: { "Content-Type" => "application/x-ndjson" })
+      with(headers: { "Content-Type" => "application/json" })
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end


### PR DESCRIPTION
Fixes #382.
Content-Type in Bulk API discussion is delegated to https://github.com/elastic/elasticsearch-ruby/issues/512.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
