### PR TITLE
Use nanosecond precision

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -160,7 +160,7 @@ module Fluent::Plugin
             time = Time.parse record[dynamic_conf['time_key']]
             record['@timestamp'] = record[dynamic_conf['time_key']] unless time_key_exclude_timestamp
           else
-            record.merge!({"@timestamp" => Time.at(time).to_datetime.to_s})
+            record.merge!({"@timestamp" => Time.at(time).iso8601(@time_precision)})
           end
         end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1395,13 +1395,9 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.configure("logstash_format true\n")
     stub_elastic_ping
     stub_elastic
-    begin
-      time = Fluent::EventTime.new(Time.now.to_i, 000000000)
-    rescue
-      time = Fluent::Engine.now
-    end
+    time = Fluent::EventTime.new(Time.now.to_i, 000000000)
     driver.run(default_tag: 'test') do
-      driver.feed(time.to_i, sample_record)
+      driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
     assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(9))
@@ -1412,13 +1408,9 @@ class ElasticsearchOutput < Test::Unit::TestCase
                       time_precision 3\n")
     stub_elastic_ping
     stub_elastic
-    begin
     time = Fluent::EventTime.new(Time.now.to_i, 000000000)
-    rescue
-      time = Fluent::Engine.now
-    end
     driver.run(default_tag: 'test') do
-      driver.feed(time.to_i, sample_record)
+      driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
     assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(3))

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -479,13 +479,33 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("logstash_format true\n")
     stub_elastic_ping
     stub_elastic
-    ts = DateTime.now
-    time = Fluent::EventTime.from_time(ts.to_time)
+    begin
+      time = Fluent::EventTime.new(Time.now.to_i, 000000000)
+    rescue
+      time = Fluent::Engine.now
+    end
     driver.run(default_tag: 'test') do
-      driver.feed(time, sample_record)
+      driver.feed(time.to_i, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601)
+    assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(9))
+  end
+
+  def test_uses_subsecond_precision_when_configured
+    driver.configure("logstash_format true
+                      time_precision 3\n")
+    stub_elastic_ping
+    stub_elastic
+    begin
+    time = Fluent::EventTime.new(Time.now.to_i, 000000000)
+    rescue
+      time = Fluent::Engine.now
+    end
+    driver.run(default_tag: 'test') do
+      driver.feed(time.to_i, sample_record)
+    end
+    assert(index_cmds[1].has_key? '@timestamp')
+    assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(3))
   end
 
   def test_uses_custom_timestamp_when_included_in_record
@@ -852,7 +872,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     stub_request(:post, "http://localhost:9200/_bulk").with do |req|
       raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
-    
+
     driver.configure("reconnect_on_error true\n")
 
     assert_raise(ZeroDivisionError) {

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -479,13 +479,9 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("logstash_format true\n")
     stub_elastic_ping
     stub_elastic
-    begin
-      time = Fluent::EventTime.new(Time.now.to_i, 000000000)
-    rescue
-      time = Fluent::Engine.now
-    end
+    time = Fluent::EventTime.new(Time.now.to_i, 000000000)
     driver.run(default_tag: 'test') do
-      driver.feed(time.to_i, sample_record)
+      driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
     assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(9))
@@ -496,13 +492,9 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
                       time_precision 3\n")
     stub_elastic_ping
     stub_elastic
-    begin
     time = Fluent::EventTime.new(Time.now.to_i, 000000000)
-    rescue
-      time = Fluent::Engine.now
-    end
     driver.run(default_tag: 'test') do
-      driver.feed(time.to_i, sample_record)
+      driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
     assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(3))


### PR DESCRIPTION
This change adds ability to specify `time_precision` when using `elasticsearch_dynamic`.

Adding sub-second precision does change the default `@timestamp` value, thus might be considered non backwards compatible change, but given the value should be accepted by elastic I think it should be fine.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
