### PR TITLE
Follow application/x-ndjson Content-Type in elasticsearch v6.0.2 change

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -647,8 +647,13 @@ class ElasticsearchOutput < Test::Unit::TestCase
   def test_content_type_header
     stub_request(:head, "http://localhost:9200/").
       to_return(:status => 200, :body => "", :headers => {})
-    elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-      with(headers: { "Content-Type" => "application/json" })
+    if Elasticsearch::VERSION >= "6.0.2"
+      elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+                          with(headers: { "Content-Type" => "application/x-ndjson" })
+    else
+      elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+                          with(headers: { "Content-Type" => "application/json" })
+    end
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -256,8 +256,13 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_content_type_header
     stub_request(:head, "http://localhost:9200/").
       to_return(:status => 200, :body => "", :headers => {})
-    elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-      with(headers: { "Content-Type" => "application/json" })
+    if Elasticsearch::VERSION >= "6.0.2"
+      elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+                          with(headers: { "Content-Type" => "application/x-ndjson" })
+    else
+      elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+                          with(headers: { "Content-Type" => "application/json" })
+    end
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end


### PR DESCRIPTION
Follow up upstream https://github.com/elastic/elasticsearch-ruby/pull/514 change.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
