### PR TITLE
Use more meaningful values of subseconds in test cases

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1395,7 +1395,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.configure("logstash_format true\n")
     stub_elastic_ping
     stub_elastic
-    time = Fluent::EventTime.new(Time.now.to_i, 000000000)
+    time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
     end
@@ -1408,7 +1408,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
                       time_precision 3\n")
     stub_elastic_ping
     stub_elastic
-    time = Fluent::EventTime.new(Time.now.to_i, 000000000)
+    time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
     end

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -479,7 +479,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("logstash_format true\n")
     stub_elastic_ping
     stub_elastic
-    time = Fluent::EventTime.new(Time.now.to_i, 000000000)
+    time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
     end
@@ -492,7 +492,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
                       time_precision 3\n")
     stub_elastic_ping
     stub_elastic
-    time = Fluent::EventTime.new(Time.now.to_i, 000000000)
+    time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
     end


### PR DESCRIPTION
Because epochtime.000000000 equals to epochtime and using non-zero value can
 be easy to recognize where is malformed.

Follows up #387.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
