### PR TITLE
Add deprecated option into content_type parameter

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -80,7 +80,11 @@ EOC
     config_param :reconnect_on_error, :bool, :default => false
     config_param :pipeline, :string, :default => nil
     config_param :with_transporter_log, :bool, :default => false
-    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson"], :default => :"application/json"
+    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson"], :default => :"application/json",
+                 :deprecated => <<EOC
+elasticsearch gem v6.0.2 starts to use correct Content-Type. Please upgrade elasticserach gem and stop to use this option.
+see: https://github.com/elastic/elasticsearch-ruby/pull/514
+EOC
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE


### PR DESCRIPTION
`content_type` parameter should be marked as deprecated.
elasticsearch-ruby v6.0.2 start to use correct Content-Type in bulk operations.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
