### PR TITLE
Update rubies for CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3
+  - 2.4.4
+  - 2.5.1
 
 gemfile:
  - Gemfile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,15 +23,10 @@ environment:
       devkit: C:\Ruby23\DevKit
     - ruby_version: "23-x64"
       devkit: C:\Ruby23-x64\DevKit
-    - ruby_version: "23"
-      devkit: C:\Ruby23\DevKit
     - ruby_version: "22-x64"
       devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "21-x64"
       devkit: C:\Ruby23-x64\DevKit
-    - ruby_version: "22"
-      devkit: C:\Ruby23\DevKit
-      WIN_RAPID: true
     - ruby_version: "21"
       devkit: C:\Ruby23\DevKit
       WIN_RAPID: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ test_script:
 # https://www.appveyor.com/docs/installed-software/#ruby
 environment:
   matrix:
+    - ruby_version: "25-x64"
+      devkit: C:\Ruby23-x64\DevKit
+    - ruby_version: "25"
+      devkit: C:\Ruby23\DevKit
     - ruby_version: "24-x64"
       devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "24"


### PR DESCRIPTION
We should run CI on Ruby 2.5 and some tweaks.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
