### PR TITLE
auth: Fix missing auth tokens after reloading connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,19 +106,12 @@ This plugin creates Elasticsearch indices by merely writing to them. Consider us
 
 ```
 hosts host1:port1,host2:port2,host3:port3
-# or
-hosts https://customhost.com:443/path,https://username:password@host-failover.com:443
 ```
 
 You can specify multiple Elasticsearch hosts with separator ",".
 
 If you specify multiple hosts, this plugin will load balance updates to Elasticsearch. This is an [elasticsearch-ruby](https://github.com/elasticsearch/elasticsearch-ruby) feature, the default strategy is round-robin.
 
-And this plugin will escape required URL encoded characters within `%{}` placeholders.
-
-```
-hosts https://%{j+hn}:%{passw@rd}@host1:443/elastic/,http://host2
-```
 
 ### user, password, path, scheme, ssl_verify
 
@@ -131,7 +124,7 @@ path /elastic_search/
 scheme https
 ```
 
-You can specify user and password for HTTP basic auth. If used in conjunction with a hosts list, then these options will be used by default i.e. if you do not provide any of these options within the hosts listed.
+You can specify user and password for HTTP Basic authentication.
 
 And this plugin will escape required URL encoded characters within `%{}` placeholders.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You can specify multiple Elasticsearch hosts with separator ",".
 
 If you specify multiple hosts, this plugin will load balance updates to Elasticsearch. This is an [elasticsearch-ruby](https://github.com/elasticsearch/elasticsearch-ruby) feature, the default strategy is round-robin.
 
+**Note:** Up until v2.8.5, it was allowed to embed the username/password in the URL. However, this syntax is deprecated as of v2.8.6 because it was found to cause serious connection problems (See #394). Please migrate your settings to use the `user` and `password` field (described below) instead.
 
 ### user, password, path, scheme, ssl_verify
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -233,6 +233,10 @@ EOC
                                                                                 headers: { 'Content-Type' => @content_type.to_s },
                                                                                 request: { timeout: @request_timeout },
                                                                                 ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
+                                                                              },
+                                                                              http: {
+                                                                                user: @user,
+                                                                                password: @password
                                                                               }
                                                                             }), &adapter_conf)
         es = Elasticsearch::Client.new transport: transport

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -55,6 +55,10 @@ module Fluent::Plugin
                                                                                 headers: { 'Content-Type' => @content_type.to_s },
                                                                                 request: { timeout: @request_timeout },
                                                                                 ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
+                                                                              },
+                                                                              http: {
+                                                                                user: @user,
+                                                                                password: @password
                                                                               }
                                                                             }), &adapter_conf)
         es = Elasticsearch::Client.new transport: transport


### PR DESCRIPTION
This patch fixes the "401 not authorized" issue reported by #257, #277 and #307.

### Problem

Essentially, elasticsearch-ruby treats the array of ES nodes (`hosts`) as something
ephemeral and try to reconstruct it periodically using the latest information fetched
from the target cluster.

Since above, as to the settings which should be persistent across the refresh, clients
are supposed to pass them through the `options` parameter, not the `hosts` parameter.

However, fluent-plugin-elasticsearch pass auth tokens as a part of the `hosts` parameter.
Therefore these bits are not retained across a refresh of connections.

### Solution

This patch fixes the issue by making the auth token passed to the client though `options`.


### Checksheet

- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
