### PR TITLE
Make the retry_on_failure setting configurable

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -56,6 +56,7 @@ EOC
     config_param :request_timeout, :time, :default => 5
     config_param :reload_connections, :bool, :default => true
     config_param :reload_on_failure, :bool, :default => false
+    config_param :retry_on_failure, :integer, :default => 5
     config_param :resurrect_after, :time, :default => 60
     config_param :time_key, :string, :default => nil
     config_param :time_key_exclude_timestamp, :bool, :default => false
@@ -227,7 +228,7 @@ EOC
                                                                               reload_connections: @reload_connections,
                                                                               reload_on_failure: @reload_on_failure,
                                                                               resurrect_after: @resurrect_after,
-                                                                              retry_on_failure: 5,
+                                                                              retry_on_failure: @retry_on_failure,
                                                                               logger: @transport_logger,
                                                                               transport_options: {
                                                                                 headers: { 'Content-Type' => @content_type.to_s },


### PR DESCRIPTION
We really don't want to retry 5 times on failure.  This can result in 5x the number of bulk requests to Elasticsearch, causing the bulk queues to overflow when you have enough clients.  By making this configurable, folks can correct this behavior by setting the value to zero (0).

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
