### PR TITLE
Merge pull request #394 from fujimotos/sf/auth-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,19 +90,13 @@ This plugin creates Elasticsearch indices by merely writing to them. Consider us
 
 ```
 hosts host1:port1,host2:port2,host3:port3
-# or
-hosts https://customhost.com:443/path,https://username:password@host-failover.com:443
 ```
 
 You can specify multiple Elasticsearch hosts with separator ",".
 
 If you specify multiple hosts, this plugin will load balance updates to Elasticsearch. This is an [elasticsearch-ruby](https://github.com/elasticsearch/elasticsearch-ruby) feature, the default strategy is round-robin.
 
-And this plugin will escape required URL encoded characters within `%{}` placeholders.
-
-```
-hosts https://%{j+hn}:%{passw@rd}@host1:443/elastic/,http://host2
-```
+**Note:** Up until v1.13.3, it was allowed to embed the username/password in the URL. However, this syntax is deprecated as of v1.13.4 because it was found to cause serious connection problems (See #394). Please migrate your settings to use the `user` and `password` field (described below) instead.
 
 ### user, password, path, scheme, ssl_verify
 
@@ -115,7 +109,7 @@ path /elastic_search/
 scheme https
 ```
 
-You can specify user and password for HTTP basic auth. If used in conjunction with a hosts list, then these options will be used by default i.e. if you do not provide any of these options within the hosts listed.
+You can specify user and password for HTTP Basic authentication.
 
 And this plugin will escape required URL encoded characters within `%{}` placeholders.
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -182,6 +182,10 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
                                                                               headers: { 'Content-Type' => 'application/json' },
                                                                               request: { timeout: @request_timeout },
                                                                               ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
+                                                                            },
+                                                                            http: {
+                                                                              user: @user,
+                                                                              password: @password
                                                                             }
                                                                           }), &adapter_conf)
       es = Elasticsearch::Client.new transport: transport

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -52,6 +52,10 @@ class Fluent::ElasticsearchOutputDynamic < Fluent::ElasticsearchOutput
                                                                               headers: { 'Content-Type' => 'application/json' },
                                                                               request: { timeout: @request_timeout },
                                                                               ssl: { verify: @ssl_verify, ca_file: @ca_file }
+                                                                            },
+                                                                            http: {
+                                                                              user: @user,
+                                                                              password: @password
                                                                             }
                                                                           }), &adapter_conf)
       es = Elasticsearch::Client.new transport: transport


### PR DESCRIPTION
auth: Fix missing auth tokens after reloading connections

Backport #394.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
