### PR TITLE
introduce dead letter queue to handle issues unpacking file buffer chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 .DS_Store
+vendor/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [time_parse_error_tag](#time_parse_error_tag)
   + [reconnect_on_error](#reconnect_on_error)
   + [with_transporter_log](#with_transporter_log)
+  + [dlq_handler](#dlq_handler)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffered output options](#buffered-output-options)
@@ -472,6 +473,17 @@ We recommend to set this true if you start to debug this plugin.
 
 ```
 with_transporter_log true
+```
+
+### dlq_handler
+Adds an error handler for processing corrupt messages from message buffers.
+There are [known cases](https://bugzilla.redhat.com/show_bug.cgi?id=1562004) where
+fluentd is stuck processing messages because the file buffer is corrupt.  Fluentd
+is unable to clear faulty buffer chunks.
+
+```
+dlq_handler {'type':'drop'}        #default is to log and drop messages
+dlq_handler {'type':'file', 'dir':'/tmp/fluentd/dlq', 'max_files':5, 'max_file_size':104857600}
 ```
 
 ### Client/host certificate options

--- a/lib/fluent/plugin/dead_letter_queue_drop_handler.rb
+++ b/lib/fluent/plugin/dead_letter_queue_drop_handler.rb
@@ -1,0 +1,10 @@
+
+module Fluent::DeadLetterQueueDropHandler
+  def handle_chunk_error(out_plugin, tag, error, time, record)
+    begin
+      log.error("Dropping record from '#{tag}': error:#{error} time:#{time} record:#{record}")
+    rescue=>e
+      log.error("Error while trying to log and drop message from chunk '#{tag}' #{e.message}")
+    end
+  end
+end

--- a/lib/fluent/plugin/dead_letter_queue_file_handler.rb
+++ b/lib/fluent/plugin/dead_letter_queue_file_handler.rb
@@ -1,0 +1,14 @@
+# encoding: UTF-8
+
+module Fluent::DeadLetterQueueFileHandler
+
+  def handle_chunk_error(out_plugin, tag, error, time, record)
+      begin
+        @dlq_file.info({processed_at: Time.now.utc, tag: tag, error: "#{error.message}", time: time, record: record}.to_json)
+      rescue=>e
+        log.error("Error while trying to log and drop message from chunk '#{tag}' #{e.message}")
+      end
+  end
+
+end
+

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -69,6 +69,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :reconnect_on_error, :bool, :default => false
   config_param :pipeline, :string, :default => nil
   config_param :with_transporter_log, :bool, :default => false
+  config_param :dlq_handler, :hash, :default => { 'type' =>'drop' }
 
   include Fluent::ElasticsearchIndexTemplate
   include Fluent::ElasticsearchConstants
@@ -128,6 +129,44 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
       @transport_logger = log
       log_level = conf['@log_level'] || conf['log_level']
       log.warn "Consider to specify log_level with @log_level." unless log_level
+    end
+
+    configure_dlq_handler
+
+  end
+
+  def configure_dlq_handler
+    dlq_type = @dlq_handler && @dlq_handler.is_a?(Hash) ? dlq_type = @dlq_handler['type'] : nil
+    return unless dlq_type
+
+    case dlq_type.downcase
+    when 'drop'
+      log.info('Configuring the DROP dead letter queue handler')
+      require_relative 'dead_letter_queue_drop_handler'
+      extend Fluent::DeadLetterQueueDropHandler
+    when 'file'
+      log.info("Configuring the File dead letter queue handler: ")
+      dir = @dlq_handler ['dir'] || '/var/lib/fluentd/dlq'
+      shift_age = @dlq_handler['max_files'] || 0
+      shift_size = @dlq_handler['max_file_size'] || 1048576
+      log.info("Configuring the File dead letter queue handler: ")
+      log.info("                Directory: #{dir}")
+      log.info("  Max number of DLQ files: #{shift_age}")
+      log.info("            Max file size: #{shift_size}")
+      unless Dir.exists?(dir)
+        Dir.mkdir(dir)
+        log.info("Created DLQ directory: '#{dir}'")
+      end
+      require 'logger'
+      require 'json'
+      file = File.join(dir, 'dlq')
+      @dlq_file = Logger.new(file, shift_age, shift_size)
+      @dlq_file.level = Logger::INFO
+      @dlq_file.formatter = proc { |severity, datetime, progname, msg| "#{msg.dump}\n" }
+      log.info ("Created DLQ file #{file}")
+
+      require_relative 'dead_letter_queue_file_handler'
+      extend Fluent::DeadLetterQueueFileHandler
     end
   end
 
@@ -321,7 +360,11 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     chunk.msgpack_each do |time, record|
       @error.records += 1
       next unless record.is_a? Hash
-      process_message(tag, meta, header, time, record, bulk_message)
+      begin
+        process_message(tag, meta, header, time, record, bulk_message)
+      rescue=>e
+        handle_chunk_error(self, tag, e, time, record)
+      end
     end
 
     send_bulk(bulk_message) unless bulk_message.empty?


### PR DESCRIPTION
DESCRIPTION HERE
There are [cases](https://bugzilla.redhat.com/show_bug.cgi?id=1562004) where file buffer chunks become corrupt and block fluentd from processing either good messages or good chunks.  This PR introduces a 'dead letter queue' to drop those messages from the chunk or write them to an 'dlq' file.


(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
