### PR TITLE
Merge pull request #399 from jcantrill/dont_log_full_response

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -484,10 +484,7 @@ EOC
       retries = 0
       begin
         response = client.bulk body: data
-        if response['errors']
-          @error.handle_error(response)
-          log.error "Could not push log to Elasticsearch: #{response}"
-        end
+        @error.handle_error(response) if response['errors']
       rescue *client.transport.host_unreachable_exceptions => e
         if retries < 2
           retries += 1

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -1,0 +1,122 @@
+require 'helper'
+require 'fluent/plugin/elasticsearch_error_handler'
+require 'json'
+
+class TestElasticsearchErrorHandler < Test::Unit::TestCase
+
+  class TestPlugin
+    attr_reader :log
+    def initialize(log)
+      @log = log
+    end
+
+    def write_operation
+      'index'
+    end
+  end
+
+  def setup
+    Fluent::Test.setup
+    @log = Fluent::Engine.log
+    plugin = TestPlugin.new(@log)
+    @handler =  Fluent::Plugin::ElasticsearchErrorHandler.new(plugin)
+  end
+
+  def parse_response(value)
+    JSON.parse(value)
+  end
+
+  def test_errors
+    response = parse_response(%({
+      "took" : 0,
+      "errors" : true,
+      "items" : [
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 500,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"some error to cause version mismatch"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 500,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"some error to cause version mismatch"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 201
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 409
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 400,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"some error to cause version mismatch"
+            }
+          }
+        }
+      ]
+    }))
+
+    assert_raise Fluent::Plugin::ElasticsearchErrorHandler::ElasticsearchError do
+        @handler.handle_error(response)
+    end
+
+  end
+
+  def test_elasticsearch_version_mismatch_raises_error
+    response = parse_response(%(
+      {
+      "took" : 0,
+      "errors" : true,
+      "items" : [
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 500,
+            "error" : {
+              "reason":"some error to cause version mismatch"
+            }
+          }
+        }
+      ]
+      }
+    ))
+
+    assert_raise Fluent::Plugin::ElasticsearchErrorHandler::ElasticsearchVersionMismatch do
+        @handler.handle_error(response)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Don't log full response on error

This is uplifted patch which was merged into v0.12: https://github.com/uken/fluent-plugin-elasticsearch/pull/399

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
