### PR TITLE
evaluate bulk request failures and reroute failed messages

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -1,23 +1,41 @@
+require 'fluent/event'
 require_relative 'elasticsearch_constants'
 
 class Fluent::ElasticsearchErrorHandler
   include Fluent::ElasticsearchConstants
 
-  attr_accessor :records, :bulk_message_count
-  class BulkIndexQueueFull < StandardError; end
-  class ElasticsearchOutOfMemory < StandardError; end
+  attr_accessor :bulk_message_count
   class ElasticsearchVersionMismatch < StandardError; end
-  class UnrecognizedElasticsearchError < StandardError; end
   class ElasticsearchError < StandardError; end
-  def initialize(plugin, records = 0, bulk_message_count = 0)
+
+  def initialize(plugin)
     @plugin = plugin
-    @records = records
-    @bulk_message_count = bulk_message_count
   end
 
-  def handle_error(response)
+  def handle_error(response, tag, chunk, bulk_message_count)
+    items = response['items']
+    if items.nil? || !items.is_a?(Array) 
+      raise ElasticsearchVersionMismatch, "The response format was unrecognized: #{response}"
+    end
+    if bulk_message_count != items.length
+        raise ElasticsearchError, "The number of records submitted #{bulk_message_count} do not match the number returned #{items.length}. Unable to process bulk response."
+    end
+    retry_stream = Fluent::MultiEventStream.new
     stats = Hash.new(0)
-    response['items'].each do |item|
+    meta = {}
+    header = {}
+    chunk.msgpack_each do |time, rawrecord|
+      bulk_message = ''
+      next unless rawrecord.is_a? Hash
+      begin
+        # we need a deep copy for process_message to alter
+        processrecord = Marshal.load(Marshal.dump(rawrecord))
+        @plugin.process_message(tag, meta, header, time, processrecord, bulk_message)
+      rescue => e
+        stats[:bad_chunk_record] += 1
+        next
+      end
+      item = items.shift
       if item.has_key?(@plugin.write_operation)
         write_operation = @plugin.write_operation
       elsif INDEX_OP == @plugin.write_operation && item.has_key?(CREATE_OP)
@@ -41,13 +59,19 @@ class Fluent::ElasticsearchErrorHandler
         stats[:successes] += 1
       when CREATE_OP == write_operation && 409 == status
         stats[:duplicates] += 1
+      when 400 == status
+        stats[:bad_argument] += 1
+        @plugin.router.emit_error_event(tag, time, rawrecord, '400 - Rejected by Elasticsearch')
       else
         if item[write_operation].has_key?('error') && item[write_operation]['error'].has_key?('type')
           type = item[write_operation]['error']['type']
+          stats[type] += 1
+          retry_stream.add(time, rawrecord)
         else
           # When we don't have a type field, something changed in the API
           # expected return values (ES 2.x)
           stats[:errors_bad_resp] += 1
+          @plugin.router.emit_error_event(tag, time, rawrecord, "#{status} - No error type provided in the response")
           next
         end
         stats[type] += 1
@@ -58,19 +82,6 @@ class Fluent::ElasticsearchErrorHandler
       stats.each_pair { |key, value| msg << "#{value} #{key}" }
       @plugin.log.debug msg.join(', ')
     end
-    case
-    when stats[:errors_bad_resp] > 0
-      @plugin.log.on_debug { @plugin.log.debug("Unable to parse response from elasticsearch, likely an API version mismatch:  #{response}") }
-      raise ElasticsearchVersionMismatch, "Unable to parse error response from Elasticsearch, likely an API version mismatch. Add '@log_level debug' to your config to see the full response"
-    when stats[:successes] + stats[:duplicates] == bulk_message_count
-      @plugin.log.info("retry succeeded - successes=#{stats[:successes]} duplicates=#{stats[:duplicates]}")
-    when stats['es_rejected_execution_exception'] > 0
-      raise BulkIndexQueueFull, 'Bulk index queue is full, retrying'
-    when stats['out_of_memory_error'] > 0
-      raise ElasticsearchOutOfMemory, 'Elasticsearch has exhausted its heap, retrying'
-    else
-      @plugin.log.on_debug { @plugin.log.debug("Elasticsearch errors returned, retrying:  #{response}") }
-      raise ElasticsearchError, "Elasticsearch returned errors, retrying. Add '@log_level debug' to your config to see the full response"
-    end
+    raise Fluent::ElasticsearchOutput::RetryStreamError.new(retry_stream) unless retry_stream.empty?
   end
 end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -10,12 +10,23 @@ rescue LoadError
 end
 
 require 'fluent/output'
+require 'fluent/event'
 require_relative 'elasticsearch_constants'
 require_relative 'elasticsearch_error_handler'
 require_relative 'elasticsearch_index_template'
 
 class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   class ConnectionFailure < StandardError; end
+
+  # RetryStreamError privides a stream to be
+  # put back in the pipeline for cases where a bulk request
+  # failed (e.g some records succeed while others failed)
+  class RetryStreamError < StandardError
+    attr_reader :retry_stream
+    def initialize(retry_stream)
+      @retry_stream = retry_stream
+    end
+  end
 
   Fluent::Plugin.register_output('elasticsearch', self)
 
@@ -314,22 +325,21 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   end
 
   def write_objects(tag, chunk)
+    bulk_message_count = 0
     bulk_message = ''
     header = {}
     meta = {}
-    @error = Fluent::ElasticsearchErrorHandler.new(self)
-
     chunk.msgpack_each do |time, record|
-      @error.records += 1
       next unless record.is_a? Hash
       begin
         process_message(tag, meta, header, time, record, bulk_message)
+        bulk_message_count += 1
       rescue=>e
         router.emit_error_event(tag, time, record, e)
       end
     end
 
-    send_bulk(bulk_message) unless bulk_message.empty?
+    send_bulk(bulk_message, tag, chunk, bulk_message_count) unless bulk_message.empty?
     bulk_message.clear
   end
 
@@ -398,7 +408,6 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     end
 
     append_record_to_messages(@write_operation, meta, header, record, bulk_message)
-    @error.bulk_message_count += 1
   end
 
   # returns [parent, child_key] of child described by path array in record's tree
@@ -408,11 +417,18 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
     [parent_object, path[-1]]
   end
 
-  def send_bulk(data)
+  # send_bulk given a specific bulk request, the original tag,
+  # chunk, and bulk_message_count
+  def send_bulk(data, tag, chunk, bulk_message_count)
     retries = 0
     begin
       response = client.bulk body: data
-      @error.handle_error(response) if response['errors']
+      if response['errors']
+        error = Fluent::ElasticsearchErrorHandler.new(self)
+        error.handle_error(response, tag, chunk, bulk_message_count) 
+      end
+    rescue RetryStreamError => e
+      router.emit_stream(tag, e.retry_stream)
     rescue *client.transport.host_unreachable_exceptions => e
       if retries < 2
         retries += 1

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -150,33 +150,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
   end
 
-  def stub_elastic_unrecognized_error(url="http://localhost:9200/_bulk")
-    error = {
-      "status" => 500,
-      "type" => "some-other-type",
-      "reason" => "some-other-reason"
-    }
-    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 504, error), :headers => { 'Content-Type' => 'json' } } })
-  end
-
-  def stub_elastic_version_mismatch(url="http://localhost:9200/_bulk")
-    error = {
-      "status" => 500,
-      "category" => "some-other-type",
-      "reason" => "some-other-reason"
-    }
-    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 1, 500, error), :headers => { 'Content-Type' => 'json' } } })
-  end
-
-  def stub_elastic_index_to_create(url="http://localhost:9200/_bulk")
-    error = {
-      "category" => "some-other-type",
-      "reason" => "some-other-reason",
-      "type" => "some-other-type"
-    }
-    stub_request(:post, url).to_return(lambda { |req| { :status => 200, :body => make_response_body(req, 0, 500, error), :headers => { 'Content-Type' => 'json' } } })
-  end
-
   def stub_elastic_unexpected_response_op(url="http://localhost:9200/_bulk")
     error = {
       "category" => "some-other-type",
@@ -1377,47 +1350,68 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   def test_bulk_error
     stub_elastic_ping
-    stub_elastic_bulk_error
+    stub_request(:post, 'http://localhost:9200/_bulk')
+        .to_return(lambda do |req|
+      { :status => 200,
+        :headers => { 'Content-Type' => 'json' },
+        :body => %({
+          "took" : 1,
+          "errors" : true,
+          "items" : [
+            {
+              "create" : {
+                "_index" : "foo",
+                "_type"  : "bar",
+                "_id" : "abc",
+                "status" : 500,
+                "error" : {
+                  "type" : "some unrecognized type",
+                  "reason":"some error to cause version mismatch"
+                }
+              }
+            },
+            {
+              "create" : {
+                "_index" : "foo",
+                "_type"  : "bar",
+                "_id" : "abc",
+                "status" : 201
+              }
+            },
+            {
+              "create" : {
+                "_index" : "foo",
+                "_type"  : "bar",
+                "_id" : "abc",
+                "status" : 500,
+                "error" : {
+                  "type" : "some unrecognized type",
+                  "reason":"some error to cause version mismatch"
+                }
+              }
+            },
+            {
+              "create" : {
+                "_index" : "foo",
+                "_type"  : "bar",
+                "_id" : "abc",
+                "_id" : "abc",
+                "status" : 409
+              }
+            }
+           ]
+        })
+     }
+    end)
 
-    assert_raise(Fluent::ElasticsearchErrorHandler::ElasticsearchError) {
-      driver.emit(sample_record)
-      driver.emit(sample_record)
-      driver.emit(sample_record)
-      driver.run
-    }
-  end
+    driver.emit(sample_record, 1)
+    driver.emit(sample_record, 2)
+    driver.emit(sample_record, 3)
+    driver.emit(sample_record, 4)
 
-  def test_bulk_error_version_mismatch
-    stub_elastic_ping
-    stub_elastic_version_mismatch
-
-    assert_raise(Fluent::ElasticsearchErrorHandler::ElasticsearchVersionMismatch) {
-      driver.emit(sample_record)
-      driver.emit(sample_record)
-      driver.emit(sample_record)
-      driver.run
-    }
-  end
-
-  def test_bulk_index_into_a_create
-    stub_elastic_ping
-    stub_elastic_index_to_create
-
-    assert_raise(Fluent::ElasticsearchErrorHandler::ElasticsearchError) {
-      driver.emit(sample_record)
-      driver.run
-    }
-    assert(index_cmds[0].has_key?("create"))
-  end
-
-  def test_bulk_unexpected_response_op
-    stub_elastic_ping
-    stub_elastic_unexpected_response_op
-
-    assert_raise(Fluent::ElasticsearchErrorHandler::ElasticsearchVersionMismatch) {
-      driver.emit(sample_record)
-      driver.run
-    }
+    driver.expect_emit('test', 1, sample_record)
+    driver.expect_emit('test', 3, sample_record)
+    driver.run
   end
 
   def test_update_should_not_write_if_theres_no_id
@@ -1592,4 +1586,5 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run
     assert(index_cmds[0].has_key?("create"))
   end
+
 end


### PR DESCRIPTION
instead of resubmitting the entire request

This PR add logic to evaluate a bulk request failure and to resubmit to the pipeline only those records that failed.  Previously, all records in a bulk submission were resubmitted to Elastic even if there was only one failure in the entire request.  This causes undue processing on both the collector and aggregator

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
