### PR TITLE
successful operation if all duplicates

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -62,6 +62,10 @@ class Fluent::ElasticsearchErrorHandler
       stats.each_pair { |key, value| msg << "#{value} #{key}" }
       @plugin.log.debug msg.join(', ')
     end
+    if stats[:successes] + stats[:duplicates] == bulk_message_count
+      @plugin.log.debug("retry succeeded - all #{bulk_message_count} records were successfully sent")
+      return
+    end
     stats.each_key do |key|
       case key
       when 'out_of_memory_error'


### PR DESCRIPTION
When processing an error return, if we find that all responses
were either successful or a duplicate, treat this as a successful
operation.
@jcantrill @portante