### PR TITLE
Add correct link for include_timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Current maintainers: @cosmo0920
   + [time_precision](#time_precision)
   + [time_key](#time_key)
   + [time_key_exclude_timestamp](#time_key_exclude_timestamp)
-  + [include_timestamp](#time_key_exclude_timestamp)
+  + [include_timestamp](#include_timestamp)
   + [utc_index](#utc_index)
   + [target_index_key](#target_index_key)
   + [target_type_key](#target_type_key)


### PR DESCRIPTION
Adds correct link for include_timestamp in README

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
