### PR TITLE
Merge pull request #410 from richm/v0.12-consistent-errors-and-tests

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -53,29 +53,24 @@ class Fluent::Plugin::ElasticsearchErrorHandler
         stats[type] += 1
       end
     end
-    if stats[:errors_bad_resp] > 0
-      @plugin.log.on_debug { @plugin.log.debug("Unable to parse response from elasticsearch, likely an API version mismatch:  #{response}") }
-      raise ElasticsearchVersionMismatch, "Unable to parse error response from Elasticsearch, likely an API version mismatch. Add '@log_level debug' to your config to see the full response"
-    end
     @plugin.log.on_debug do
       msg = ["Indexed (op = #{@plugin.write_operation})"]
       stats.each_pair { |key, value| msg << "#{value} #{key}" }
       @plugin.log.debug msg.join(', ')
     end
-    if stats[:successes] + stats[:duplicates] == bulk_message_count
-      @plugin.log.debug("retry succeeded - all #{bulk_message_count} records were successfully sent")
-      return
-    end
-    stats.each_key do |key|
-      case key
-      when 'out_of_memory_error'
-        raise ElasticsearchOutOfMemory, 'Elasticsearch has exhausted its heap, retrying'
-      when 'es_rejected_execution_exception'
-        raise BulkIndexQueueFull, 'Bulk index queue is full, retrying'
-      else
-        @plugin.log.on_debug { @plugin.log.debug("Elasticsearch errors returned, retrying:  #{response}") }
-        raise ElasticsearchError, "Elasticsearch returned errors, retrying. Add '@log_level debug' to your config to see the full response"
-      end
+    case
+    when stats[:errors_bad_resp] > 0
+      @plugin.log.on_debug { @plugin.log.debug("Unable to parse response from elasticsearch, likely an API version mismatch:  #{response}") }
+      raise ElasticsearchVersionMismatch, "Unable to parse error response from Elasticsearch, likely an API version mismatch. Add '@log_level debug' to your config to see the full response"
+    when stats[:successes] + stats[:duplicates] == bulk_message_count
+      @plugin.log.info("retry succeeded - successes=#{stats[:successes]} duplicates=#{stats[:duplicates]}")
+    when stats['es_rejected_execution_exception'] > 0
+      raise BulkIndexQueueFull, 'Bulk index queue is full, retrying'
+    when stats['out_of_memory_error'] > 0
+      raise ElasticsearchOutOfMemory, 'Elasticsearch has exhausted its heap, retrying'
+    else
+      @plugin.log.on_debug { @plugin.log.debug("Elasticsearch errors returned, retrying:  #{response}") }
+      raise ElasticsearchError, "Elasticsearch returned errors, retrying. Add '@log_level debug' to your config to see the full response"
     end
   end
 end

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -6,20 +6,21 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
 
   class TestPlugin
     attr_reader :log
+    attr_reader :write_operation
     def initialize(log)
       @log = log
-    end
-
-    def write_operation
-      'index'
+      @write_operation = 'index'
     end
   end
 
   def setup
     Fluent::Test.setup
-    @log = Fluent::Engine.log
-    plugin = TestPlugin.new(@log)
-    @handler =  Fluent::Plugin::ElasticsearchErrorHandler.new(plugin)
+    @log_device = Fluent::Test::DummyLogDevice.new
+    dl_opts = {:log_level => ServerEngine::DaemonLogger::INFO}
+    logger = ServerEngine::DaemonLogger.new(@log_device, dl_opts)
+    @log = Fluent::Log.new(logger)
+    @plugin = TestPlugin.new(@log)
+    @handler = Fluent::Plugin::ElasticsearchErrorHandler.new(@plugin)
   end
 
   def parse_response(value)
@@ -39,7 +40,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
             "status" : 500,
             "error" : {
               "type" : "some unrecognized type",
-              "reason":"some error to cause version mismatch"
+              "reason":"unrecognized error"
             }
           }
         },
@@ -51,7 +52,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
             "status" : 500,
             "error" : {
               "type" : "some unrecognized type",
-              "reason":"some error to cause version mismatch"
+              "reason":"unrecognized error"
             }
           }
         },
@@ -79,7 +80,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
             "status" : 400,
             "error" : {
               "type" : "some unrecognized type",
-              "reason":"some error to cause version mismatch"
+              "reason":"unrecognized error"
             }
           }
         }
@@ -114,6 +115,173 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
     ))
 
     assert_raise Fluent::Plugin::ElasticsearchErrorHandler::ElasticsearchVersionMismatch do
+        @handler.handle_error(response)
+    end
+
+  end
+
+  def test_retry_with_successes_and_duplicates
+    response = parse_response(%(
+      {
+      "took" : 0,
+      "errors" : true,
+      "items" : [
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 409,
+            "error" : {
+              "reason":"duplicate ID"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 201
+          }
+        }
+      ]
+      }
+    ))
+
+    @plugin.instance_variable_set(:@write_operation, 'create')
+    @handler.instance_variable_set(:@bulk_message_count, 2)
+    @handler.handle_error(response)
+    assert_match /retry succeeded - successes=1 duplicates=1/, @log.out.logs[0]
+  end
+
+  def test_bulk_rejection_errors
+    response = parse_response(%({
+      "took" : 0,
+      "errors" : true,
+      "items" : [
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 500,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"unrecognized error"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 500,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"unrecognized error"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 201
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 409
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 429,
+            "error" : {
+              "type" : "es_rejected_execution_exception",
+              "reason":"Elasticsearch could not process bulk index request"
+            }
+          }
+        }
+      ]
+    }))
+
+    assert_raise Fluent::Plugin::ElasticsearchErrorHandler::BulkIndexQueueFull do
+        @handler.handle_error(response)
+    end
+
+  end
+
+  def test_out_of_memory_errors
+    response = parse_response(%({
+      "took" : 0,
+      "errors" : true,
+      "items" : [
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 500,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"unrecognized error"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 500,
+            "error" : {
+              "type" : "some unrecognized type",
+              "reason":"unrecognized error"
+            }
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 201
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 409
+          }
+        },
+        {
+          "create" : {
+            "_index" : "foo",
+            "_type"  : "bar",
+            "_id" : "abc",
+            "status" : 400,
+            "error" : {
+              "type" : "out_of_memory_error",
+              "reason":"Elasticsearch exhausted its heap"
+            }
+          }
+        }
+      ]
+    }))
+
+    assert_raise Fluent::Plugin::ElasticsearchErrorHandler::ElasticsearchOutOfMemory do
         @handler.handle_error(response)
     end
 


### PR DESCRIPTION
handle case where stats not processed in order; add testing
Uplift #410.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
