### PR TITLE
fix #417. emit_error_event using an exception

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -61,7 +61,7 @@ class Fluent::ElasticsearchErrorHandler
         stats[:duplicates] += 1
       when 400 == status
         stats[:bad_argument] += 1
-        @plugin.router.emit_error_event(tag, time, rawrecord, '400 - Rejected by Elasticsearch')
+        @plugin.router.emit_error_event(tag, time, rawrecord, ElasticsearchError.new('400 - Rejected by Elasticsearch'))
       else
         if item[write_operation].has_key?('error') && item[write_operation]['error'].has_key?('type')
           type = item[write_operation]['error']['type']
@@ -71,7 +71,7 @@ class Fluent::ElasticsearchErrorHandler
           # When we don't have a type field, something changed in the API
           # expected return values (ES 2.x)
           stats[:errors_bad_resp] += 1
-          @plugin.router.emit_error_event(tag, time, rawrecord, "#{status} - No error type provided in the response")
+          @plugin.router.emit_error_event(tag, time, rawrecord, ElasticsearchError.new("#{status} - No error type provided in the response"))
           next
         end
         stats[type] += 1

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -11,7 +11,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
     def initialize(log)
       @log = log
       @write_operation = 'index'
-      @error_events = Fluent::MultiEventStream.new
+      @error_events = []
     end
 
     def router
@@ -19,7 +19,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
     end
 
     def emit_error_event(tag, time, record, e)
-       @error_events.add(time, record)
+       @error_events << {:tag => tag, :time=>time, :record=>record, :error=>e}
     end
 
     def process_message(tag, meta, header, time, record, bulk_message)
@@ -75,7 +75,8 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
      }))
     chunk = MockChunk.new(records)
     @handler.handle_error(response, 'atag', chunk, records.length)
-    assert_equal(1, @plugin.error_events.instance_variable_get(:@time_array).size)
+    assert_equal(1, @plugin.error_events.size)
+    assert_true(@plugin.error_events[0][:error].respond_to?(:backtrace))
   end
 
   def test_retry_error
@@ -181,10 +182,13 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
       assert_equal 2, records[0]['_id']
       assert_equal 6, records[1]['_id']
       assert_equal 8, records[2]['_id']
-      errors = @plugin.error_events.collect {|time, record| record}
-      assert_equal 2, errors.length
-      assert_equal 5, errors[0]['_id']
-      assert_equal 7, errors[1]['_id']
+      error_ids = @plugin.error_events.collect {|h| h[:record]['_id']}
+      assert_equal 2, error_ids.length
+      assert_equal 5, error_ids[0]
+      assert_equal 7, error_ids[1]
+      @plugin.error_events.collect {|h| h[:error]}.each do |e|
+        assert_true e.respond_to?(:backtrace)
+      end
     end
     assert_true failed
 


### PR DESCRIPTION
Fixes #417

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
