### PR TITLE
allow configure of retry_tag so messages can be routed through a

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [remove_keys](#remove_keys)
   + [remove_keys_on_update](#remove_keys_on_update)
   + [remove_keys_on_update_key](#remove_keys_on_update_key)
+  + [retry_tag](#retry_tag)
   + [write_operation](#write_operation)
   + [time_parse_error_tag](#time_parse_error_tag)
   + [reconnect_on_error](#reconnect_on_error)
@@ -434,6 +435,21 @@ present in the record then the keys in record are used, if the `remove_keys_on_u
 ```
 remove_keys_on_update_key keys_to_skip
 ```
+
+### retry_tag
+
+This setting allows custom routing of messages in response to bulk request failures.  The default behavior is to emit
+failed records using the same tag that was provided.  When set to a value other then `nil`, failed messages are emitted
+with the specified tag:
+
+```
+retry_tag 'retry_es'
+```
+**NOTE:** `retry_tag` is optional. If you would rather use labels to reroute retries, add a label (e.g '@label @SOMELABEL') to your fluent
+elasticsearch plugin configuration. Retry records are, by default, submitted for retry to the ROOT label, which means
+records will flow through your fluentd pipeline from the beginning.  This may nor may not be a problem if the pipeline
+is idempotent - that is - you can process a record again with no changes.  Use tagging or labeling to ensure your retry
+records are not processed again by your fluentd processing pipeline.
 
 ### write_operation
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -56,6 +56,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :request_timeout, :time, :default => 5
   config_param :reload_connections, :bool, :default => true
   config_param :reload_on_failure, :bool, :default => false
+  config_param :retry_tag, :string, :default=>nil
   config_param :resurrect_after, :time, :default => 60
   config_param :time_key, :string, :default => nil
   config_param :time_key_exclude_timestamp, :bool, :default => false
@@ -428,7 +429,8 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
         error.handle_error(response, tag, chunk, bulk_message_count) 
       end
     rescue RetryStreamError => e
-      router.emit_stream(tag, e.retry_stream)
+      emit_tag = @retry_tag ? @retry_tag : tag
+      router.emit_stream(emit_tag, e.retry_stream)
     rescue *client.transport.host_unreachable_exceptions => e
       if retries < 2
         retries += 1


### PR DESCRIPTION
This PR provides a configuration option to allow retagging messages that are being retried do to bulk index failures. 

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
