### PR TITLE
Add retry mechanism for template installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Current maintainers: @cosmo0920
   + [template_file](#template_file)
   + [template_overwrite](#template_overwrite)
   + [templates](#templates)
+  + [max_retry_putting_template](#max_retry_putting_template)
   + [request_timeout](#request_timeout)
   + [reload_connections](#reload_connections)
   + [reload_on_failure](#reload_on_failure)
@@ -325,6 +326,17 @@ template_overwrite true # defaults to false
 ```
 
 One of [template_file](#template_file) or [templates](#templates) must also be specified if this is set.
+
+### max_retry_putting_template
+
+You can specify times of retry putting template.
+
+This is useful when Elasticsearch plugin cannot connect Elasticsearch to put template.
+Usually, booting up clustered Elasticsearch containers are much slower than launching Fluentd container.
+
+```
+max_retry_putting_template 15 # defaults to 10
+```
 
 ### request_timeout
 

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -15,6 +15,24 @@ module Fluent::ElasticsearchIndexTemplate
     return false
   end
 
+  def retry_install(max_retries)
+    return unless block_given?
+    retries = 0
+    begin
+      yield
+    rescue Fluent::Plugin::ElasticsearchOutput::ConnectionFailure, Timeout::Error => e
+      @_es = nil
+      @_es_info = nil
+      if retries < max_retries
+        retries += 1
+        sleep 2**retries
+        log.warn "Could not push template(s) to Elasticsearch, resetting connection and trying again. #{e.message}"
+        retry
+      end
+      raise Fluent::Plugin::ElasticsearchOutput::ConnectionFailure, "Could not push template(s) to Elasticsearch after #{retries} retries. #{e.message}"
+    end
+  end
+
   def template_put(name, template)
     client.indices.put_template(:name => name, :body => template)
   end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -86,6 +86,7 @@ EOC
     config_param :template_file, :string, :default => nil
     config_param :template_overwrite, :bool, :default => false
     config_param :templates, :hash, :default => nil
+    config_param :max_retry_putting_template, :integer, :default => 10
     config_param :include_tag_key, :bool, :default => false
     config_param :tag_key, :string, :default => 'tag'
     config_param :time_parse_error_tag, :string, :default => 'Fluent::ElasticsearchOutput::TimeParser.error'
@@ -136,9 +137,13 @@ EOC
       end
 
       if @template_name && @template_file
-        template_install(@template_name, @template_file, @template_overwrite)
+        retry_install(@max_retry_putting_template) do
+          template_install(@template_name, @template_file, @template_overwrite)
+        end
       elsif @templates
-        templates_hash_install(@templates, @template_overwrite)
+        retry_install(@max_retry_putting_template) do
+          templates_hash_install(@templates, @template_overwrite)
+        end
       end
 
       # Consider missing the prefix of "$." in nested key specifiers.


### PR DESCRIPTION
I added retrying mechanism for template installation. Fixes #198

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
