### PR TITLE
Add parameter validation for retrying template installation

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -136,6 +136,7 @@ EOC
         @remove_keys_on_update = @remove_keys_on_update.split ','
       end
 
+      raise Fluent::ConfigError, "'max_retry_putting_template' must be positive number." if @max_retry_putting_template < 0
       if @template_name && @template_file
         retry_install(@max_retry_putting_template) do
           template_install(@template_name, @template_file, @template_overwrite)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -226,6 +226,15 @@ class ElasticsearchOutput < Test::Unit::TestCase
     }
   end
 
+  test 'invalid specification of times of retrying template installation' do
+    config = %{
+      max_retry_putting_template -3
+    }
+    assert_raise(Fluent::ConfigError) {
+      instance = driver(config).instance
+    }
+  end
+
   test 'Detected Elasticsearch 7' do
     config = %{
       type_name changed


### PR DESCRIPTION
Follows up #428.

(check all that apply)
- [X] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
