### PR TITLE
355 customize template

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Current maintainers: @cosmo0920
   + [template_file](#template_file)
   + [template_overwrite](#template_overwrite)
   + [templates](#templates)
+  + [customize_template](#customize_template)
   + [request_timeout](#request_timeout)
   + [reload_connections](#reload_connections)
   + [reload_on_failure](#reload_on_failure)
@@ -319,6 +320,17 @@ templates { "templane_name_1": "path_to_template_1_file", "templane_name_2": "pa
 ```
 
 If `template_file` and `template_name` are set, then this parameter will be ignored.
+
+### customize_template
+
+Specify the string and its value to be replaced in form of hash. Can contain multiple templates.
+
+```
+customize_template {"string_1": "subs_value_1", "string_2": "subs_value_2"}
+```
+
+If `template_file` and `template_name` are set, then this parameter will be in effect otherwise ignored.
+
 
 ### template_overwrite
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Current maintainers: @cosmo0920
   + [template_name](#template_name)
   + [template_file](#template_file)
   + [template_overwrite](#template_overwrite)
-  + [templates](#templates)
   + [customize_template](#customize_template)
+  + [index_prefix](#index_prefix)
+  + [templates](#templates)
   + [request_timeout](#request_timeout)
   + [reload_connections](#reload_connections)
   + [reload_on_failure](#reload_on_failure)
@@ -330,6 +331,14 @@ customize_template {"string_1": "subs_value_1", "string_2": "subs_value_2"}
 ```
 
 If `template_file` and `template_name` are set, then this parameter will be in effect otherwise ignored.
+
+### index_prefix
+
+```
+index_prefix mylogs # defaults to "logstash"
+```
+
+If `customize_template` is set, then this parameter will be in effect otherwise ignored.
 
 
 ### template_overwrite

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -4,7 +4,18 @@ module Fluent::ElasticsearchIndexTemplate
     if !File.exists?(template_file)
       raise "If you specify a template_name you must specify a valid template file (checked '#{template_file}')!"
     end
+    file_contents = IO.read(template_file).gsub(/\n/,'').gsub(/##alias_name##/,name)
+    JSON.parse(file_contents)
+  end
+
+  def get_custom_template(template_file, customize_template)
+    if !File.exists?(template_file)
+      raise "If you specify a template_name you must specify a valid template file (checked '#{template_file}')!"
+    end
     file_contents = IO.read(template_file).gsub(/\n/,'')
+    customize_template.each do |key, value|
+      file_contents = file_contents.gsub(/key/,value)
+    end
     JSON.parse(file_contents)
   end
 
@@ -27,6 +38,20 @@ module Fluent::ElasticsearchIndexTemplate
     end
     if !template_exists?(name)
       template_put(name, get_template(template_file))
+      log.info("Template configured, but no template installed. Installed '#{name}' from #{template_file}.")
+    else
+      log.info("Template configured and already installed.")
+    end
+  end
+
+  def template_custom_install(name, template_file, overwrite, customize_template)
+    if overwrite
+      template_put(name, get_custom_template(template_file, customize_template))
+      log.info("Template '#{name}' overwritten with #{template_file}.")
+      return
+    end
+    if !template_exists?(name)
+      template_put(name, get_custom_template(template_file, customize_template))
       log.info("Template configured, but no template installed. Installed '#{name}' from #{template_file}.")
     else
       log.info("Template configured and already installed.")

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -14,7 +14,7 @@ module Fluent::ElasticsearchIndexTemplate
     end
     file_contents = IO.read(template_file).gsub(/\n/,'')
     customize_template.each do |key, value|
-      file_contents = file_contents.gsub(/key/,value)
+      file_contents = file_contents.gsub(key,value.downcase)
     end
     JSON.parse(file_contents)
   end
@@ -44,17 +44,28 @@ module Fluent::ElasticsearchIndexTemplate
     end
   end
 
-  def template_custom_install(name, template_file, overwrite, customize_template)
+  def template_custom_install(name, template_file, overwrite, customize_template, index_prefix)
+    template_custom_name=name.downcase+'_alias_template'
+    alias_name=name.downcase+'-current'
     if overwrite
-      template_put(name, get_custom_template(template_file, customize_template))
-      log.info("Template '#{name}' overwritten with #{template_file}.")
+      template_put(template_custom_name, get_custom_template(template_file, customize_template))
+      log.info("Template '#{template_custom_name}' overwritten with #{template_file}.")
       return
     end
-    if !template_exists?(name)
-      template_put(name, get_custom_template(template_file, customize_template))
-      log.info("Template configured, but no template installed. Installed '#{name}' from #{template_file}.")
+    if !template_exists?(template_custom_name)
+      template_put(template_custom_name, get_custom_template(template_file, customize_template))
+      log.info("Template configured, but no template installed. Installed '#{template_custom_name}' from #{template_file}.")
     else
       log.info("Template configured and already installed.")
+    end
+    
+    if !client.indices.exists_alias(:name => alias_name)
+      index_name='<'+index_prefix.downcase+'-'+name.downcase+'-{now/d}-000001>'
+      indexcreation(index_name)
+      client.indices.put_alias(:index => index_name, :name => alias_name)
+      log.info("The alias '#{alias_name}' is created for the index '#{index_name}'")
+    else
+      log.info("The alias '#{alias_name}' is already present")
     end
   end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -115,7 +115,12 @@ module Fluent::Plugin
       end
 
       if @template_name && @template_file
-        template_install(@template_name, @template_file, @template_overwrite)
+        if @customize_template
+          template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template)
+        else
+          templates_hash_install(@templates, @template_overwrite)
+        end
+        #template_install(@template_name, @template_file, @template_overwrite)
       elsif @templates
         templates_hash_install(@templates, @template_overwrite)
       end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -68,6 +68,8 @@ module Fluent::Plugin
     config_param :template_name, :string, :default => nil
     config_param :template_file, :string, :default => nil
     config_param :template_overwrite, :bool, :default => false
+    config_param :customize_template, :hash, :default => nil
+    config_param :index_prefix, :string, :default => "logstash"
     config_param :templates, :hash, :default => nil
     config_param :include_tag_key, :bool, :default => false
     config_param :tag_key, :string, :default => 'tag'
@@ -116,11 +118,10 @@ module Fluent::Plugin
 
       if @template_name && @template_file
         if @customize_template
-          template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template)
+          template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @index_prefix)
         else
-          templates_hash_install(@templates, @template_overwrite)
+          template_install(@template_name, @template_file, @template_overwrite)
         end
-        #template_install(@template_name, @template_file, @template_overwrite)
       elsif @templates
         templates_hash_install(@templates, @template_overwrite)
       end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -117,10 +117,12 @@ module Fluent::Plugin
       end
 
       if @template_name && @template_file
-        if @customize_template
-          template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @index_prefix)
-        else
-          template_install(@template_name, @template_file, @template_overwrite)
+        retry_install(@max_retry_putting_template) do
+          if @customize_template
+            template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @index_prefix)
+          else
+            template_install(@template_name, @template_file, @template_overwrite)
+          end
         end
       elsif @templates
         templates_hash_install(@templates, @template_overwrite)


### PR DESCRIPTION
To support dynamic template support, 2 new settings _**customize_template**_ and _**index_prefix**_ have been added. With this change, the users can use a dynamic template containing some identifiers which would be mentioned in the configuration and can be replaced during the boot of the plugin.
**NOTE:** _The above changes have been tested using the plugin in combination with the forest plugin_


- README updated 
- README Table of Contents updated 
- History.md and `version` in gemspec are untouched
