### PR TITLE
Use Fluent::UnrecoverableError as unrecoverable error class ancestors

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -11,13 +11,14 @@ end
 
 require 'fluent/plugin/output'
 require 'fluent/event'
+require 'fluent/error'
 require_relative 'elasticsearch_constants'
 require_relative 'elasticsearch_error_handler'
 require_relative 'elasticsearch_index_template'
 
 module Fluent::Plugin
   class ElasticsearchOutput < Output
-    class ConnectionFailure < StandardError; end
+    class ConnectionFailure < Fluent::UnrecoverableError; end
 
     # RetryStreamError privides a stream to be
     # put back in the pipeline for cases where a bulk request


### PR DESCRIPTION
Related to https://github.com/uken/fluent-plugin-elasticsearch/issues/424 and https://github.com/uken/fluent-plugin-elasticsearch/issues/432.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
