### PR TITLE
Add note for insecure security

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,8 @@ If you want to configure SSL/TLS version, you can specify ssl\_version parameter
 ssl_version TLSv1_2 # or [SSLv23, TLSv1, TLSv1_1]
 ```
 
+:warning: If SSL/TLS enabled, it might have to be required to set ssl\_version.
+
 ### Proxy Support
 
 Starting with version 0.8.0, this gem uses excon, which supports proxy with environment variables - https://github.com/excon/excon#proxy-support

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -192,6 +192,14 @@ EOC
         log.warn "Detected ES 7.x or above: `_doc` will be used as the document `_type`."
         @type_name = '_doc'.freeze
       end
+
+      if @last_seen_major_version >= 6
+        case @ssl_version
+        when :SSLv23, :TLSv1, :TLSv1_1
+          log.warn "Detected ES 6.x or above and enabled insecure security:
+                    You might have to specify `ssl_version TLSv1_2` in configuration."
+        end
+      end
     end
 
     def detect_es_major_version

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -243,6 +243,26 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal '_doc', instance.type_name
   end
 
+  test 'Detected Elasticsearch 6 and insecure security' do
+    config = %{
+      ssl_version TLSv1_1
+      @log_level warn
+    }
+    instance = driver(config, 6).instance
+    logs = driver.logs
+    assert_logs_include(logs, /Detected ES 6.x or above and enabled insecure security/, 1)
+  end
+
+  test 'Detected Elasticsearch 7 and secure security' do
+    config = %{
+      ssl_version TLSv1_2
+      @log_level warn
+    }
+    instance = driver(config, 7).instance
+    logs = driver.logs
+    assert_logs_include(logs, /Detected ES 6.x or above and enabled insecure security/, 0)
+  end
+
   test 'lack of tag in chunk_keys' do
     assert_raise_message(/'tag' in chunk_keys is required./) do
       driver(Fluent::Config::Element.new(


### PR DESCRIPTION
Closes #439

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
