### PR TITLE
Strictness scheme

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -48,7 +48,7 @@ module Fluent::Plugin
     config_param :user, :string, :default => nil
     config_param :password, :string, :default => nil, :secret => true
     config_param :path, :string, :default => nil
-    config_param :scheme, :string, :default => 'http'
+    config_param :scheme, :enum, :list => [:https, :http], :default => :http
     config_param :hosts, :string, :default => nil
     config_param :target_index_key, :string, :default => nil
     config_param :target_type_key, :string, :default => nil,

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -308,7 +308,7 @@ EOC
             {
               host:   host_str.split(':')[0],
               port:   (host_str.split(':')[1] || @port).to_i,
-              scheme: @scheme
+              scheme: @scheme.to_s
             }
           else
             # New hosts format expects URLs such as http://logs.foo.com,https://john:pass@logs2.foo.com/elastic
@@ -320,7 +320,7 @@ EOC
           end
         end.compact
       else
-        [{host: @host, port: @port, scheme: @scheme}]
+        [{host: @host, port: @port, scheme: @scheme.to_s}]
       end.each do |host|
         host.merge!(user: @user, password: @password) if !host[:user] && @user
         host.merge!(path: @path) if !host[:path] && @path

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -196,8 +196,10 @@ EOC
       if @last_seen_major_version >= 6
         case @ssl_version
         when :SSLv23, :TLSv1, :TLSv1_1
-          log.warn "Detected ES 6.x or above and enabled insecure security:
-                    You might have to specify `ssl_version TLSv1_2` in configuration."
+          if @scheme == :https
+            log.warn "Detected ES 6.x or above and enabled insecure security:
+                      You might have to specify `ssl_version TLSv1_2` in configuration."
+          end
         end
       end
     end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -84,7 +84,7 @@ module Fluent::Plugin
             {
               host:   host_str.split(':')[0],
               port:   (host_str.split(':')[1] || @port).to_i,
-              scheme: @scheme
+              scheme: @scheme.to_s
             }
           else
             # New hosts format expects URLs such as http://logs.foo.com,https://john:pass@logs2.foo.com/elastic
@@ -96,7 +96,7 @@ module Fluent::Plugin
           end
         end.compact
       else
-        [{host: @host, port: @port.to_i, scheme: @scheme}]
+        [{host: @host, port: @port.to_i, scheme: @scheme.to_s}]
       end.each do |host|
         host.merge!(user: @user, password: @password) if !host[:user] && @user
         host.merge!(path: @path) if !host[:path] && @path

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -196,7 +196,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', instance.host
     assert_equal 777, instance.port
-    assert_equal 'https', instance.scheme
+    assert_equal :https, instance.scheme
     assert_equal '/es/', instance.path
     assert_equal 'john', instance.user
     assert_equal 'doe', instance.password
@@ -247,6 +247,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     config = %{
       ssl_version TLSv1_1
       @log_level warn
+      scheme https
     }
     instance = driver(config, 6).instance
     logs = driver.logs
@@ -257,6 +258,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     config = %{
       ssl_version TLSv1_2
       @log_level warn
+      scheme https
     }
     instance = driver(config, 7).instance
     logs = driver.logs
@@ -594,11 +596,11 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal 'host1', host1[:host]
     assert_equal 50, host1[:port]
-    assert_equal 'https', host1[:scheme]
+    assert_equal :https, host1[:scheme]
     assert_equal '/es/', host2[:path]
     assert_equal 'host3', host3[:host]
     assert_equal 123, host3[:port]
-    assert_equal 'https', host3[:scheme]
+    assert_equal :https, host3[:scheme]
     assert_equal '/es/', host3[:path]
   end
 
@@ -667,7 +669,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal 'http', host1[:scheme]
+    assert_equal :http, host1[:scheme]
     assert_equal 'john', host1[:user]
     assert_equal 'doe', host1[:password]
     assert_equal nil, host1[:path]
@@ -686,7 +688,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal 'http', host1[:scheme]
+    assert_equal :http, host1[:scheme]
     assert_equal 'j%2Bhn', host1[:user]
     assert_equal 'd%40e', host1[:password]
     assert_equal nil, host1[:path]

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -596,11 +596,11 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal 'host1', host1[:host]
     assert_equal 50, host1[:port]
-    assert_equal :https, host1[:scheme]
+    assert_equal 'https', host1[:scheme]
     assert_equal '/es/', host2[:path]
     assert_equal 'host3', host3[:host]
     assert_equal 123, host3[:port]
-    assert_equal :https, host3[:scheme]
+    assert_equal 'https', host3[:scheme]
     assert_equal '/es/', host3[:path]
   end
 
@@ -669,7 +669,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal :http, host1[:scheme]
+    assert_equal 'http', host1[:scheme]
     assert_equal 'john', host1[:user]
     assert_equal 'doe', host1[:password]
     assert_equal nil, host1[:path]
@@ -688,7 +688,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal :http, host1[:scheme]
+    assert_equal 'http', host1[:scheme]
     assert_equal 'j%2Bhn', host1[:user]
     assert_equal 'd%40e', host1[:password]
     assert_equal nil, host1[:path]

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -155,11 +155,11 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
     assert_equal 'host1', host1[:host]
     assert_equal 50, host1[:port]
-    assert_equal 'https', host1[:scheme]
+    assert_equal :https, host1[:scheme]
     assert_equal '/es/', host2[:path]
     assert_equal 'host3', host3[:host]
     assert_equal 123, host3[:port]
-    assert_equal 'https', host3[:scheme]
+    assert_equal :https, host3[:scheme]
     assert_equal '/es/', host3[:path]
   end
 
@@ -228,7 +228,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal 'http', host1[:scheme]
+    assert_equal :http, host1[:scheme]
     assert_equal 'john', host1[:user]
     assert_equal 'doe', host1[:password]
     assert_equal nil, host1[:path]
@@ -247,7 +247,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal 'http', host1[:scheme]
+    assert_equal :http, host1[:scheme]
     assert_equal 'j%2Bhn', host1[:user]
     assert_equal 'd%40e', host1[:password]
     assert_equal nil, host1[:path]

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -155,11 +155,11 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
     assert_equal 'host1', host1[:host]
     assert_equal 50, host1[:port]
-    assert_equal :https, host1[:scheme]
+    assert_equal 'https', host1[:scheme]
     assert_equal '/es/', host2[:path]
     assert_equal 'host3', host3[:host]
     assert_equal 123, host3[:port]
-    assert_equal :https, host3[:scheme]
+    assert_equal 'https', host3[:scheme]
     assert_equal '/es/', host3[:path]
   end
 
@@ -228,7 +228,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal :http, host1[:scheme]
+    assert_equal 'http', host1[:scheme]
     assert_equal 'john', host1[:user]
     assert_equal 'doe', host1[:password]
     assert_equal nil, host1[:path]
@@ -247,7 +247,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
-    assert_equal :http, host1[:scheme]
+    assert_equal 'http', host1[:scheme]
     assert_equal 'j%2Bhn', host1[:user]
     assert_equal 'd%40e', host1[:password]
     assert_equal nil, host1[:path]

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -88,6 +88,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     conf = instance.dynamic_config
     assert_equal 'logs.google.com', conf['host']
     assert_equal "777", conf['port']
+    assert_equal :https, instance.scheme
     assert_equal 'john', instance.user
     assert_equal 'doe', instance.password
     assert_equal '/es/', instance.path


### PR DESCRIPTION
We can validate scheme with `:enum` configuration type.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
