### PR TITLE
Add an option `include_index_in_url` to allow URL-based conrtrols

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Current maintainers: @cosmo0920
   + [reconnect_on_error](#reconnect_on_error)
   + [with_transporter_log](#with_transporter_log)
   + [content_type](#content_type)
+  + [include_index_in_url](#include_index_in_url)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffer options](#buffer-options)
@@ -612,6 +613,17 @@ If you will not use template, it recommends to set `content_type application/x-n
 
 ```
 content_type application/x-ndjson
+```
+
+### include_index_in_url
+
+With this option set to true, Fluentd manifests the index name in the request URL (rather than in the request body).
+You can use this option to enforce an URL-based access control.
+
+This option is currently available only for `elasticsearch_dynamic`.
+
+```
+include_index_in_url true
 ```
 
 ### Client/host certificate options

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -34,6 +34,8 @@ module Fluent::Plugin
       end
     end
 
+    RequestInfo = Struct.new(:host, :index)
+
     helpers :event_emitter, :compat_parameters, :record_accessor
 
     Fluent::Plugin.register_output('elasticsearch', self)

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -990,4 +990,18 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     end
     assert(index_cmds[0].has_key?("create"))
   end
+
+  def test_include_index_in_url
+    stub_elastic_ping
+    stub_elastic('http://localhost:9200/logstash-2018.01.01/_bulk')
+
+    driver.configure("index_name logstash-2018.01.01
+                      include_index_in_url true")
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+
+    assert_equal(index_cmds.length, 2)
+    assert_equal(index_cmds.first['index']['_index'], nil)
+  end
 end


### PR DESCRIPTION
This patch is the first cut at fixing the issue #444.

### What's this option all about?

This option tells Fluentd to manifest the name of the target index in
the request URL (rather than in the request body). For example:

    POST /logstash-20180501/_bulk

And without this option, Fluentd just uses the general endpoint:

    POST /_bulk

We need this option in order to enforce URL-based access controls on
Elasticsearch endpoints. For details, read the following article:

https://www.elastic.co/guide/en/elasticsearch/reference/1.5/url-access-control.html

### Checklist

- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
