### PR TITLE
Implement the `include_index_in_url` option for out_elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,8 +620,6 @@ content_type application/x-ndjson
 With this option set to true, Fluentd manifests the index name in the request URL (rather than in the request body).
 You can use this option to enforce an URL-based access control.
 
-This option is currently available only for `elasticsearch_dynamic`.
-
 ```
 include_index_in_url true
 ```

--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -32,7 +32,8 @@ class Fluent::Plugin::ElasticsearchErrorHandler
       begin
         # we need a deep copy for process_message to alter
         processrecord = Marshal.load(Marshal.dump(rawrecord))
-        next unless @plugin.process_message(tag, meta, header, time, processrecord, bulk_message, extracted_values)
+        meta, header, record = @plugin.process_message(tag, meta, header, time, processrecord, extracted_values)
+        next unless @plugin.append_record_to_messages(@plugin.write_operation, meta, header, record, bulk_message)
       rescue => e
         stats[:bad_chunk_record] += 1
         next

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -9,7 +9,6 @@ module Fluent::Plugin
     helpers :event_emitter
 
     config_param :delimiter, :string, :default => "."
-    config_param :include_index_in_url, :bool, :default => false
 
     DYNAMIC_PARAM_NAMES = %W[hosts host port include_timestamp logstash_format logstash_prefix logstash_dateformat time_key utc_index index_name tag_key type_name id_key parent_key routing_key write_operation]
     DYNAMIC_PARAM_SYMBOLS = DYNAMIC_PARAM_NAMES.map { |n| "@#{n}".to_sym }

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -22,7 +22,11 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
        @error_events << {:tag => tag, :time=>time, :record=>record, :error=>e}
     end
 
-    def process_message(tag, meta, header, time, record, bulk_message, extracted_values)
+    def process_message(tag, meta, header, time, record, extracted_values)
+      return [meta, header, record]
+    end
+
+    def append_record_to_messages(op, meta, header, record, msgs)
       if record.has_key?('raise') && record['raise']
         raise Exception('process_message')
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -2174,4 +2174,18 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert(index_cmds[0].has_key?("create"))
   end
 
+  def test_include_index_in_url
+    stub_elastic_ping
+    stub_elastic('http://localhost:9200/logstash-2018.01.01/_bulk')
+
+    driver.configure("index_name logstash-2018.01.01
+                      include_index_in_url true")
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+
+    assert_equal(index_cmds.length, 2)
+    assert_equal(index_cmds.first['index']['_index'], nil)
+  end
+
 end


### PR DESCRIPTION
This is a sequel to the previous patch #450.

### What's this patch?

With this patch applied, you can use this option with the normal elasticsearch plugin.

The nasty thing here is that we cannot assume all events in a single
chunk share the same index name even under a non-dynamic plugin. Why?
Because Elasticsearch's index names usually contain a timestamp (e.g.
'logstash-2018.01.01') and these timestamps are generated from each
record's time field.

This is why we had to convert `bulk_message` into a hash, and do all
the work to get the other methods working fine with it.

(Original issue: #444)

### Checklist

- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
