### PR TITLE
add simple sniffer for simple proxy/lb cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [Buffered output options](#buffered-output-options)
   + [Hash flattening](#hash-flattening)
   + [Generate Hash ID](#generate-hash-id)
+  + [sniffer_class_name](#sniffer_class_name)
+  + [reload_after](#reload_after)
   + [Not seeing a config you need?](#not-seeing-a-config-you-need)
   + [Dynamic configuration](#dynamic-configuration)
 * [Contact](#contact)
@@ -575,6 +577,29 @@ Here is a sample config:
   # other settings are ommitted.
 </match>
 ```
+
+### Sniffer Class Name
+
+The default Sniffer used by the `Elasticsearch::Transport` class works well when Fluentd has a direct connection
+to all of the Elasticsearch servers and can make effective use of the `_nodes` API.  This doesn't work well
+when Fluentd must connect through a load balancer or proxy.  The parameter `sniffer_class_name` gives you the
+ability to provide your own Sniffer class to implement whatever connection reload logic you require.  In addition,
+there is a new `Fluent::ElasticsearchSimpleSniffer` class which reuses the hosts given in the configuration, which
+is typically the hostname of the load balancer or proxy.  For example, a configuration like this would cause
+connections to `logging-es` to reload every 100 operations:
+
+```
+host logging-es
+port 9200
+reload_connections true
+sniffer_class_name Fluent::ElasticsearchSimpleSniffer
+reload_after 100
+```
+
+### Reload After
+
+When `reload_connections true`, this is the integer number of operations after which the plugin will
+reload the connections.  The default value is 10000.
 
 ### Not seeing a config you need?
 

--- a/lib/fluent/plugin/elasticsearch_simple_sniffer.rb
+++ b/lib/fluent/plugin/elasticsearch_simple_sniffer.rb
@@ -1,0 +1,10 @@
+require 'elasticsearch'
+
+class Fluent::ElasticsearchSimpleSniffer < Elasticsearch::Transport::Transport::Sniffer
+
+  def hosts
+    @transport.logger.debug "In Fluent::ElasticsearchSimpleSniffer hosts #{@transport.hosts}" if @transport.logger
+    @transport.hosts
+  end
+
+end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1716,4 +1716,20 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert(index_cmds[0].has_key?("create"))
   end
 
+  def test_use_simple_sniffer
+    require 'fluent/plugin/elasticsearch_simple_sniffer'
+    driver.configure("sniffer_class_name Fluent::ElasticsearchSimpleSniffer
+                      log_level debug
+                      with_transporter_log true
+                      reload_connections true
+                      reload_after 1")
+    stub_elastic_ping
+    stub_elastic
+    driver.emit(sample_record)
+    driver.run
+    log = driver.instance.router.emit_error_handler.log
+    # 2 - one for the ping, one for the _bulk
+    assert_logs_include(log.out.logs, /In Fluent::ElasticsearchSimpleSniffer hosts/, 2)
+  end
+
 end


### PR DESCRIPTION
When going through a proxy or load balancer to Elasticsearch,
do not try to use the _nodes discovery mechanism - instead, just
assume the given host(s) are the only hostnames to use.
This is useful e.g. in the case of Kubernetes going through an
Elasticsearch Service, where you want to periodically reconnect
the long-lived http connections to evenly spread the load throughout
the cluster.

(check all that apply)
- [X] tests added
- [X] tests passing
- [X] README updated (if needed)
- [X] README Table of Contents updated (if needed)
- [X] History.md and `version` in gemspec are untouched
- [X] backward compatible
- [X] feature works in `elasticsearch_dynamic` (not required but recommended)