### PR TITLE
Tweak behavior for UnrecoverableError and #detect_es_major_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,8 @@ The value for option `buffer_chunk_limit` should not exceed value `http.max_cont
 
 **Note**: If you use or evaluate Fluentd v0.14, you can use `<buffer>` directive to specify buffer configuration, too. In more detail, please refer to the [buffer configuration options for v0.14](https://docs.fluentd.org/v0.14/articles/buffer-plugin-overview#configuration-parameters)
 
+**Note**: If you use `disable_retry_limit` in v0.12 or `retry_forever` in v0.14 or later, please be careful to consume memory inexhaustibly.
+
 ### Hash flattening
 
 Elasticsearch will complain if you send object and concrete values to the same field. For example, you might have logs that look this, from different places:

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -22,7 +22,8 @@ end
 
 module Fluent::Plugin
   class ElasticsearchOutput < Output
-    class ConnectionFailure < Fluent::UnrecoverableError; end
+    class ConnectionFailure < StandardError; end
+    class ConnectionRetryFailure < Fluent::UnrecoverableError; end
 
     # MissingIdFieldError is raised for records that do not
     # include the field for the unique record identifier

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -209,7 +209,13 @@ EOC
         log.warn "Consider to specify log_level with @log_level." unless log_level
       end
 
-      @last_seen_major_version = detect_es_major_version rescue DEFAULT_ELASTICSEARCH_VERSION
+      @last_seen_major_version =
+        begin
+          detect_es_major_version
+        rescue ConnectionFailure
+          log.warn "Could not connect Elasticsearch. Assuming Elasticsearch 5."
+          DEFAULT_ELASTICSEARCH_VERSION
+        end
       if @last_seen_major_version == 6 && @type_name != DEFAULT_TYPE_NAME_ES_7x
         log.info "Detected ES 6.x: ES 7.x will only accept `_doc` in type_name."
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -69,6 +69,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_request(:post, url).to_return(:status => [503, "Service Unavailable"])
   end
 
+  def stub_elastic_timeout(url="http://localhost:9200/_bulk")
+    stub_request(:post, url).to_timeout
+  end
+
   def stub_elastic_with_store_index_command_counts(url="http://localhost:9200/_bulk")
     if @index_command_counts == nil
        @index_command_counts = {}
@@ -1819,6 +1823,24 @@ class ElasticsearchOutput < Test::Unit::TestCase
         driver.feed(sample_record)
       end
     }
+  end
+
+  def test_request_forever
+    stub_elastic_ping
+    stub_elastic
+    driver.configure(Fluent::Config::Element.new(
+               'ROOT', '', {
+                 '@type' => 'elasticsearch',
+               }, [
+                 Fluent::Config::Element.new('buffer', '', {
+                                               'retry_forever' => true
+                                             }, [])
+               ]
+             ))
+    stub_elastic_timeout
+    driver.run(default_tag: 'test', timeout: 10) do
+      driver.feed(sample_record)
+    end
   end
 
   def test_connection_failed_retry


### PR DESCRIPTION
Really fixes https://github.com/uken/fluent-plugin-elasticsearch/issues/446.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
