### PR TITLE
Remove outdated generating hash_id_key code

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -199,9 +199,6 @@ EOC
         @password = URI.encode_www_form_component(m["password"])
       end
 
-      if @hash_config
-        raise Fluent::ConfigError, "@hash_config.hash_id_key and id_key must be equal." unless @hash_config.hash_id_key == @id_key
-      end
       @transport_logger = nil
       if @with_transporter_log
         @transport_logger = log
@@ -526,10 +523,6 @@ EOC
 
       if @flatten_hashes
         record = flatten_record(record)
-      end
-
-      if @hash_config
-        record = generate_hash_id_key(record)
       end
 
       dt = nil

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -136,10 +136,6 @@ module Fluent::Plugin
       chunk.msgpack_each do |time, record|
         next unless record.is_a? Hash
 
-        if @hash_config
-          record = generate_hash_id_key(record)
-        end
-
         begin
           # evaluate all configurations here
           DYNAMIC_PARAM_SYMBOLS.each_with_index { |var, i|


### PR DESCRIPTION
This mechanism is separated into filter_elasticsearch_genid plugin.

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
