### PR TITLE
Use ConnectionRetryFailure in plugin specific retrying for consistency

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -637,7 +637,7 @@ EOC
           sleep 2**retries
           retry
         end
-        raise ConnectionFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
+        raise ConnectionRetryFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
       rescue Exception
         @_es = nil if @reconnect_on_error
         @_es_info = nil if @reconnect_on_error

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -234,7 +234,7 @@ module Fluent::Plugin
           sleep 2**retries
           retry
         end
-        raise ConnectionFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
+        raise ConnectionRetryFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
       rescue Exception
         @_es = nil if @reconnect_on_error
         raise


### PR DESCRIPTION
Follows up #465.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
