### PR TITLE
Handle error not to acquire version information

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -210,8 +210,8 @@ EOC
       @last_seen_major_version =
         begin
           detect_es_major_version
-        rescue ConnectionFailure
-          log.warn "Could not connect Elasticsearch. Assuming Elasticsearch 5."
+        rescue
+          log.warn "Could not connect Elasticsearch or obtain version. Assuming Elasticsearch 5."
           DEFAULT_ELASTICSEARCH_VERSION
         end
       if @last_seen_major_version == 6 && @type_name != DEFAULT_TYPE_NAME_ES_7x


### PR DESCRIPTION
Humio's Elasticsearch does not return version information.
So, we should assume ES version to 5 even if version information cannot
obtain from there.

Fixes #478.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
