### PR TITLE
Avoid NoMethodError on unknown Elasticsearch error responses

### DIFF
--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -400,4 +400,26 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
 
   end
 
+  def test_old_es_1_X_responses
+    records = [{time: 123, record: {"foo" => "bar", '_id' => 'abc'}}]
+    response = parse_response(%({
+      "took" : 0,
+      "errors" : true,
+      "items" : [
+        {
+          "create" : {
+            "_index" : "foo",
+            "status" : 429,
+            "_type"  : "bar",
+            "error" : "some unrecognized error"
+          }
+        }
+      ]
+     }))
+    chunk = MockChunk.new(records)
+    dummy_extracted_values = []
+    @handler.handle_error(response, 'atag', chunk, records.length, dummy_extracted_values)
+    assert_equal(1, @plugin.error_events.size)
+    assert_true(@plugin.error_events[0][:error].respond_to?(:backtrace))
+  end
 end


### PR DESCRIPTION
Current error handling can cause `NoMethodError` on unkown Elasticsearch
response because it assumes error responses include `type` or `reason`
members. But error responses of old Elasticsearch(1.X) can be just string.

Use `fetch('error', {})` so that it can avoid unrecoverable NoMethodError.

- [x] tests added
- [x] tests passing
- [-] README updated (if needed)
- [-] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [-] feature works in `elasticsearch_dynamic` (not required but recommended)
