### PR TITLE
Avoid NoMethodError on unknown Elasticsearch error responses

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -63,8 +63,8 @@ class Fluent::ElasticsearchErrorHandler
         stats[:bad_argument] += 1
         @plugin.router.emit_error_event(tag, time, rawrecord, ElasticsearchError.new('400 - Rejected by Elasticsearch'))
       else
-        if item[write_operation].has_key?('error') && item[write_operation]['error'].has_key?('type')
-          type = item[write_operation]['error']['type']
+        type = item[write_operation].fetch('error', {})['type']
+        if type
           stats[type] += 1
           retry_stream.add(time, rawrecord)
         else


### PR DESCRIPTION
Current error handling can cause `NoMethodError` on unkown Elasticsearch
response because it assumes error responses include `type` or `reason`
members. But error responses of old Elasticsearch(1.X) can be just string.

Use `fetch('error', {})` so that it can avoid unrecoverable NoMethodError.

- [x] tests added
- [x] tests passing
- [-] README updated (if needed)
- [-] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [-] feature works in `elasticsearch_dynamic` (not required but recommended)

----

### Changes from https://github.com/uken/fluent-plugin-elasticsearch/pull/483

- Target branch changed / Rebased on `v0.12`
