### PR TITLE
Decoupling the custom template and rollover index creation #485

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,13 +341,14 @@ If `template_file` and `template_name` are set, then this parameter will be igno
 
 ### customize_template
 
-Specify the string and its value to be replaced in form of hash. Can contain multiple templates.
+Specify the string and its value to be replaced in form of hash. Can contain multiple key value pair that would be replaced in the specified template_file.
+This setting only creates template and to add rollover index please check the [rollover_index](#rollover_index) configuration.
 
 ```
 customize_template {"string_1": "subs_value_1", "string_2": "subs_value_2"}
 ```
 
-If `template_file` and `template_name` are set, then this parameter will be in effect otherwise ignored.
+If [template_file](#template_file) and [template_name](#template_name) are set, then this parameter will be in effect otherwise ignored.
 
 ### rollover_index
 
@@ -358,7 +359,7 @@ Specify this as true when an index with rollover capability needs to be created.
 rollover_index true # defaults to false
 ```
 
-If `customize_template` is set, then this parameter will be in effect otherwise ignored.
+If [customize_template](#customize_template) is set, then this parameter will be in effect otherwise ignored.
 
 ### deflector_alias
 
@@ -367,7 +368,7 @@ Specify the deflector alias which would be assigned to the rollover index create
 deflector_alias test-current
 ```
 
-If `rollover_index` is set, then this parameter will be in effect otherwise ignored.
+If [rollover_index](#rollover_index) is set, then this parameter will be in effect otherwise ignored.
 
 ### index_prefix
 
@@ -376,7 +377,7 @@ Specify the index prefix for the rollover index to be created.
 index_prefix mylogs # defaults to "logstash"
 ```
 
-If `rollover_index` is set, then this parameter will be in effect otherwise ignored.
+If [rollover_index](#rollover_index) is set, then this parameter will be in effect otherwise ignored.
 
 ### application_name
 
@@ -385,7 +386,7 @@ Specify the application name for the rollover index to be created.
 application_name default # defaults to "default"
 ```
 
-If `rollover_index` is set, then this parameter will be in effect otherwise ignored.
+If [rollover_index](#rollover_index) is set, then this parameter will be in effect otherwise ignored.
 
 ### template_overwrite
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Current maintainers: @cosmo0920
   + [template_file](#template_file)
   + [template_overwrite](#template_overwrite)
   + [customize_template](#customize_template)
+  + [rollover_index](#rollover_index)
+  + [deflector_alias](#deflector_alias)
+  + [application_name](#application_name)
   + [index_prefix](#index_prefix)
   + [templates](#templates)
   + [max_retry_putting_template](#max_retry_putting_template)
@@ -346,14 +349,43 @@ customize_template {"string_1": "subs_value_1", "string_2": "subs_value_2"}
 
 If `template_file` and `template_name` are set, then this parameter will be in effect otherwise ignored.
 
-### index_prefix
+### rollover_index
 
+Specify this as true when an index with rollover capability needs to be created. It creates an index with the format <logstash-default-{now/d}-000001> where logstash denotes the index_prefix and default denotes the application_name which can be set.
+'deflector_alias' is a required field for rollover_index set to true.
+'index_prefix' and 'application_name' are optional and defaults to logstash and default respectively.
 ```
-index_prefix mylogs # defaults to "logstash"
+rollover_index true # defaults to false
 ```
 
 If `customize_template` is set, then this parameter will be in effect otherwise ignored.
 
+### deflector_alias
+
+Specify the deflector alias which would be assigned to the rollover index created. This is useful in case of using the Elasticsearch rollover API 
+```
+deflector_alias test-current
+```
+
+If `rollover_index` is set, then this parameter will be in effect otherwise ignored.
+
+### index_prefix
+
+Specify the index prefix for the rollover index to be created.
+```
+index_prefix mylogs # defaults to "logstash"
+```
+
+If `rollover_index` is set, then this parameter will be in effect otherwise ignored.
+
+### application_name
+
+Specify the application name for the rollover index to be created.
+```
+application_name default # defaults to "default"
+```
+
+If `rollover_index` is set, then this parameter will be in effect otherwise ignored.
 
 ### template_overwrite
 

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -68,9 +68,8 @@ module Fluent::ElasticsearchIndexTemplate
     end
   end
 
-  def template_custom_install(name, template_file, overwrite, customize_template, index_prefix)
-    template_custom_name=name.downcase+'_alias_template'
-    alias_name=name.downcase+'-current'
+  def template_custom_install(template_name, template_file, overwrite, customize_template, index_prefix, rollover_index, deflector_alias_name, app_name)
+    template_custom_name=template_name.downcase
     if overwrite
       template_put(template_custom_name, get_custom_template(template_file, customize_template))
       log.info("Template '#{template_custom_name}' overwritten with #{template_file}.")
@@ -82,14 +81,17 @@ module Fluent::ElasticsearchIndexTemplate
     else
       log.info("Template configured and already installed.")
     end
-    
-    if !client.indices.exists_alias(:name => alias_name)
-      index_name='<'+index_prefix.downcase+'-'+name.downcase+'-{now/d}-000001>'
-      indexcreation(index_name)
-      client.indices.put_alias(:index => index_name, :name => alias_name)
-      log.info("The alias '#{alias_name}' is created for the index '#{index_name}'")
+    if rollover_index
+      if !client.indices.exists_alias(:name => deflector_alias_name)
+        index_name_temp='<'+index_prefix.downcase+'-'+app_name.downcase+'-{now/d}-000001>'
+        indexcreation(index_name_temp)
+        client.indices.put_alias(:index => index_name_temp, :name => deflector_alias_name)
+        log.info("The alias '#{deflector_alias_name}' is created for the index '#{index_name_temp}'")
+      else
+        log.info("The alias '#{deflector_alias_name}' is already present")
+      end
     else
-      log.info("The alias '#{alias_name}' is already present")
+      log.info("No index and alias creation action performed because rollover_index is set to '#{rollover_index}'")
     end
   end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -177,7 +177,7 @@ EOC
         end
       elsif @templates
         retry_install(@max_retry_putting_template) do
-          templates_hash_install(@templates, @template_overwrite, @rollover_index, @deflector_alias, @application_name)
+          templates_hash_install(@templates, @template_overwrite)
         end
       end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -96,6 +96,9 @@ EOC
     config_param :flatten_hashes, :bool, :default => false
     config_param :flatten_hashes_separator, :string, :default => "_"
     config_param :template_name, :string, :default => nil
+    config_param :application_name, :string, :default => "default"
+    config_param :rollover_index, :string, :default => false
+    config_param :deflector_alias, :string, :default => nil
     config_param :template_file, :string, :default => nil
     config_param :template_overwrite, :bool, :default => false
     config_param :customize_template, :hash, :default => nil
@@ -160,17 +163,21 @@ EOC
       end
 
       raise Fluent::ConfigError, "'max_retry_putting_template' must be positive number." if @max_retry_putting_template < 0
+      
       if @template_name && @template_file
         retry_install(@max_retry_putting_template) do
           if @customize_template
-            template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @index_prefix)
+            if @rollover_index
+              raise Fluent::ConfigError, "'deflector_alias' must be provided if 'rollover_index' is set true ." if not @deflector_alias
+            end
+            template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @index_prefix, @rollover_index, @deflector_alias, @application_name)
           else
             template_install(@template_name, @template_file, @template_overwrite)
           end
         end
       elsif @templates
         retry_install(@max_retry_putting_template) do
-          templates_hash_install(@templates, @template_overwrite)
+          templates_hash_install(@templates, @template_overwrite, @rollover_index, @deflector_alias, @application_name)
         end
       end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -96,13 +96,13 @@ EOC
     config_param :flatten_hashes, :bool, :default => false
     config_param :flatten_hashes_separator, :string, :default => "_"
     config_param :template_name, :string, :default => nil
-    config_param :application_name, :string, :default => "default"
-    config_param :rollover_index, :string, :default => false
-    config_param :deflector_alias, :string, :default => nil
     config_param :template_file, :string, :default => nil
     config_param :template_overwrite, :bool, :default => false
     config_param :customize_template, :hash, :default => nil
+    config_param :rollover_index, :string, :default => false
+    config_param :deflector_alias, :string, :default => nil
     config_param :index_prefix, :string, :default => "logstash"
+    config_param :application_name, :string, :default => "default"
     config_param :templates, :hash, :default => nil
     config_param :max_retry_putting_template, :integer, :default => 10
     config_param :include_tag_key, :bool, :default => false

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -380,7 +380,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       path            /es/
       user            john
       password        doe
-      template_name   myapp
+      template_name   myapp_alias_template
       template_file   #{template_file}
       customize_template {"--appid--": "myapp-logs","--index_prefix--":"mylogs"}
     }

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -383,7 +383,41 @@ class ElasticsearchOutput < Test::Unit::TestCase
       template_name   myapp
       template_file   #{template_file}
       customize_template {"--appid--": "myapp-logs","--index_prefix--":"mylogs"}
+    }
+
+    # connection start
+    stub_request(:head, "https://john:doe@logs.google.com:777/es//").
+      to_return(:status => 200, :body => "", :headers => {})
+    # check if template exists
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template").
+      to_return(:status => 404, :body => "", :headers => {})
+    # creation
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template").
+      to_return(:status => 200, :body => "", :headers => {})
+    
+    driver(config)
+
+    assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template", times: 1)
+  end
+
+  def test_custom_template_with_rollover_index_create
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_alias_template.json')
+
+    config = %{
+      host            logs.google.com
+      port            777
+      scheme          https
+      path            /es/
+      user            john
+      password        doe
+      template_name   myapp_alias_template
+      template_file   #{template_file}
+      customize_template {"--appid--": "myapp-logs","--index_prefix--":"mylogs"}
+      rollover_index  true
+      deflector_alias myapp_deflector
       index_prefix    mylogs
+      application_name myapp
     }
 
     # connection start
@@ -399,16 +433,17 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E").
       to_return(:status => 200, :body => "", :headers => {})
     # check if alias exists
-    stub_request(:head, "https://john:doe@logs.google.com:777/es//_alias/myapp-current").
+    stub_request(:head, "https://john:doe@logs.google.com:777/es//_alias/myapp_deflector").
       to_return(:status => 404, :body => "", :headers => {})
     # put the alias for the index
-    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E/_alias/myapp-current").
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E/_alias/myapp_deflector").
       to_return(:status => 200, :body => "", :headers => {})
     
     driver(config)
 
     assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template", times: 1)
   end
+
 
   def test_template_overwrite
     cwd = File.dirname(__FILE__)
@@ -452,11 +487,45 @@ class ElasticsearchOutput < Test::Unit::TestCase
       path            /es/
       user            john
       password        doe
-      template_name   myapp
+      template_name   myapp_alias_template
       template_file   #{template_file}
       template_overwrite true
       customize_template {"--appid--": "myapp-logs","--index_prefix--":"mylogs"}
+    }
+
+    # connection start
+    stub_request(:head, "https://john:doe@logs.google.com:777/es//").
+      to_return(:status => 200, :body => "", :headers => {})
+    # check if template exists
+    stub_request(:get, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template").
+      to_return(:status => 200, :body => "", :headers => {})
+    # creation
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template").
+      to_return(:status => 200, :body => "", :headers => {})
+    
+    driver(config)
+
+    assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template", times: 1)
+  end
+
+  def test_custom_template_with_rollover_index_overwrite
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_template.json')
+
+    config = %{
+      host            logs.google.com
+      port            777
+      scheme          https
+      path            /es/
+      user            john
+      password        doe
+      template_name   myapp_alias_template
+      template_file   #{template_file}
+      template_overwrite true
+      customize_template {"--appid--": "myapp-logs","--index_prefix--":"mylogs"}
+      deflector_alias myapp_deflector
       index_prefix    mylogs
+      application_name myapp
     }
 
     # connection start
@@ -472,10 +541,10 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E").
       to_return(:status => 200, :body => "", :headers => {})
     # check if alias exists
-    stub_request(:head, "https://john:doe@logs.google.com:777/es//_alias/myapp-current").
+    stub_request(:head, "https://john:doe@logs.google.com:777/es//_alias/myapp_deflector").
       to_return(:status => 404, :body => "", :headers => {})
     # put the alias for the index
-    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E/_alias/myapp-current").
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E/_alias/myapp_deflector").
       to_return(:status => 200, :body => "", :headers => {})
   
     driver(config)


### PR DESCRIPTION
As per the feature request #355, we had added the capability to customize the templates. But the creation of rollover index(without any option to customize it) was introduced in it.
So whenever the customize template feature was used, default rollover was created in the format <logstash-default-{now/d}-000001> and a deflector alias <template_name>-current was assigned to the index.
I am trying to decouple this, so that users can have an option to customize this.

(check all that apply)
- [x] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
