### PR TITLE
Make configurable unrecoverable types

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -16,7 +16,7 @@ class Fluent::Plugin::ElasticsearchErrorHandler
   end
 
   def unrecoverable_error_types
-    ["out_of_memory_error", "es_rejected_execution_exception"]
+    @plugin.unrecoverable_error_types
   end
 
   def unrecoverable_error?(type)

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -123,6 +123,7 @@ EOC
     config_param :http_backend, :enum, list: [:excon, :typhoeus], :default => :excon
     config_param :validate_client_version, :bool, :default => false
     config_param :prefer_oj_serializer, :bool, :default => false
+    config_param :unrecoverable_error_types, :array, :default => ["out_of_memory_error", "es_rejected_execution_exception"]
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE


### PR DESCRIPTION
Really Fixes #446 

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
