### PR TITLE
Allow a user to specify the rollover index date pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Current maintainers: @cosmo0920
   + [template_overwrite](#template_overwrite)
   + [customize_template](#customize_template)
   + [rollover_index](#rollover_index)
+  + [index_date_pattern](#index_date_pattern)
   + [deflector_alias](#deflector_alias)
   + [application_name](#application_name)
   + [index_prefix](#index_prefix)
@@ -363,6 +364,19 @@ Specify this as true when an index with rollover capability needs to be created.
 'index_prefix' and 'application_name' are optional and defaults to logstash and default respectively.
 ```
 rollover_index true # defaults to false
+```
+
+If [customize_template](#customize_template) is set, then this parameter will be in effect otherwise ignored.
+
+### index_date_pattern
+
+Specify this to override the index date pattern for creating a rollover index. The default is to use "now/d",
+for example: <logstash-default-{now/d}-000001>. Overriding this changes the rollover time period. Setting
+"now/w{xxxx.ww}" would create weekly rollover indexes instead of daily.
+
+This setting only takes effect when combined with the [rollover_index](#rollover_index) setting.
+```
+index_date_pattern "now/w{xxxx.ww}" # defaults to "now/d"
 ```
 
 If [customize_template](#customize_template) is set, then this parameter will be in effect otherwise ignored.

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -68,7 +68,7 @@ module Fluent::ElasticsearchIndexTemplate
     end
   end
 
-  def template_custom_install(template_name, template_file, overwrite, customize_template, index_prefix, rollover_index, deflector_alias_name, app_name)
+  def template_custom_install(template_name, template_file, overwrite, customize_template, index_prefix, rollover_index, deflector_alias_name, app_name, index_date_pattern)
     template_custom_name=template_name.downcase
     if overwrite
       template_put(template_custom_name, get_custom_template(template_file, customize_template))
@@ -83,7 +83,7 @@ module Fluent::ElasticsearchIndexTemplate
     end
     if rollover_index
       if !client.indices.exists_alias(:name => deflector_alias_name)
-        index_name_temp='<'+index_prefix.downcase+'-'+app_name.downcase+'-{now/d}-000001>'
+        index_name_temp='<'+index_prefix.downcase+'-'+app_name.downcase+'-{'+index_date_pattern+'}-000001>'
         indexcreation(index_name_temp)
         client.indices.put_alias(:index => index_name_temp, :name => deflector_alias_name)
         log.info("The alias '#{deflector_alias_name}' is created for the index '#{index_name_temp}'")

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -100,6 +100,7 @@ EOC
     config_param :template_overwrite, :bool, :default => false
     config_param :customize_template, :hash, :default => nil
     config_param :rollover_index, :string, :default => false
+    config_param :index_date_pattern, :string, :default => "now/d"
     config_param :deflector_alias, :string, :default => nil
     config_param :index_prefix, :string, :default => "logstash"
     config_param :application_name, :string, :default => "default"
@@ -166,14 +167,14 @@ EOC
       end
 
       raise Fluent::ConfigError, "'max_retry_putting_template' must be positive number." if @max_retry_putting_template < 0
-      
+
       if @template_name && @template_file
         retry_install(@max_retry_putting_template) do
           if @customize_template
             if @rollover_index
               raise Fluent::ConfigError, "'deflector_alias' must be provided if 'rollover_index' is set true ." if not @deflector_alias
             end
-            template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @index_prefix, @rollover_index, @deflector_alias, @application_name)
+            template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @index_prefix, @rollover_index, @deflector_alias, @application_name, @index_date_pattern)
           else
             template_install(@template_name, @template_file, @template_overwrite)
           end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -418,6 +418,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       template_file   #{template_file}
       customize_template {"--appid--": "myapp-logs","--index_prefix--":"mylogs"}
       rollover_index  true
+      index_date_pattern now/w{xxxx.ww}
       deflector_alias myapp_deflector
       index_prefix    mylogs
       application_name myapp
@@ -433,13 +434,13 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template").
       to_return(:status => 200, :body => "", :headers => {})
     # creation of index which can rollover
-    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E").
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E").
       to_return(:status => 200, :body => "", :headers => {})
     # check if alias exists
     stub_request(:head, "https://john:doe@logs.google.com:777/es//_alias/myapp_deflector").
       to_return(:status => 404, :body => "", :headers => {})
     # put the alias for the index
-    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E/_alias/myapp_deflector").
+    stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/_alias/myapp_deflector").
       to_return(:status => 200, :body => "", :headers => {})
     
     driver(config)


### PR DESCRIPTION
Currently `now/d` is the only allowed index date pattern. Elasticsearch supports many varied date patterns, and we use a particular one (by week). This pattern will allow the user to specify any date pattern.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended) __I think it should work__
