### PR TITLE
Added log_es_400_reason configuration item

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Current maintainers: @cosmo0920
   + [Dynamic configuration](#dynamic-configuration)
   + [Placeholders](#placeholders)
   + [Multi workers](#multi-workers)
+  + [log_es_400_reason](#log-es-400-reason)
 * [Troubleshooting](#troubleshooting)
   + [Cannot send events to elasticsearch](#cannot-send-events-to-elasticsearch)
   + [Cannot see detailed failure log](#cannot-see-detailed-failure-log)
@@ -969,6 +970,12 @@ Since Fluentd v0.14, multi workers feature had been implemented to increase thro
   workers N # where N is a natural number (N >= 1).
 </system>
 ```
+
+## log_es_400_reason
+
+By default, the error logger won't record the reason for a 400 error from the Elasticsearch API unless you set log_level to debug. However, this results in a lot of log spam, which isn't desirable if all you want is the 400 error reasons. You can set this `true` to capture the 400 error reasons without all the other debug logs.
+
+Default value is `false`.
 
 ## Troubleshooting
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -126,6 +126,7 @@ EOC
     config_param :unrecoverable_error_types, :array, :default => ["out_of_memory_error", "es_rejected_execution_exception"]
     config_param :verify_es_version_at_startup, :bool, :default => true
     config_param :default_elasticsearch_version, :integer, :default => DEFAULT_ELASTICSEARCH_VERSION
+    config_param :log_es_400_reason, :bool, :default => false
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -112,6 +112,7 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
       @log = Fluent::Log.new(logger)
       @plugin = TestPlugin.new(@log)
       @handler = Fluent::Plugin::ElasticsearchErrorHandler.new(@plugin)
+      @plugin.log_es_400_reason = true
     end
 
     def test_400_responses_reason_log

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -220,6 +220,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal ["out_of_memory_error", "es_rejected_execution_exception"], instance.unrecoverable_error_types
     assert_true instance.verify_es_version_at_startup
     assert_equal Fluent::Plugin::ElasticsearchOutput::DEFAULT_ELASTICSEARCH_VERSION, instance.default_elasticsearch_version
+    assert_false instance.log_es_400_reason
   end
 
   test 'configure Content-Type' do


### PR DESCRIPTION
https://github.com/uken/fluent-plugin-elasticsearch/issues/507

- This new config enables logging of the reason/type for a 400 error from elasticsearch without needing to enable a debug log_level.

One of the tests isn't passing and I'm not sure why. Hopefully someone with a little more ruby knowledge can help.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
