### PR TITLE
#506 Rollover index will be in effect in case of template overwrite also.

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -81,6 +81,7 @@ module Fluent::ElasticsearchIndexTemplate
         log.info("Template configured and already installed.")
       end
     end
+
     if rollover_index
       if !client.indices.exists_alias(:name => deflector_alias_name)
         index_name_temp='<'+index_prefix.downcase+'-'+app_name.downcase+'-{'+index_date_pattern+'}-000001>'

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -73,13 +73,13 @@ module Fluent::ElasticsearchIndexTemplate
     if overwrite
       template_put(template_custom_name, get_custom_template(template_file, customize_template))
       log.info("Template '#{template_custom_name}' overwritten with #{template_file}.")
-      return
-    end
-    if !template_exists?(template_custom_name)
-      template_put(template_custom_name, get_custom_template(template_file, customize_template))
-      log.info("Template configured, but no template installed. Installed '#{template_custom_name}' from #{template_file}.")
     else
-      log.info("Template configured and already installed.")
+      if !template_exists?(template_custom_name)
+        template_put(template_custom_name, get_custom_template(template_file, customize_template))
+        log.info("Template configured, but no template installed. Installed '#{template_custom_name}' from #{template_file}.")
+      else
+        log.info("Template configured and already installed.")
+      end
     end
     if rollover_index
       if !client.indices.exists_alias(:name => deflector_alias_name)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -529,6 +529,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       template_overwrite true
       customize_template {"--appid--": "myapp-logs","--index_prefix--":"mylogs"}
       deflector_alias myapp_deflector
+      rollover_index  true
       index_prefix    mylogs
       application_name myapp
     }


### PR DESCRIPTION
In case of template overwrite, the rollover settings were ignored. To handle this, the conditions have been modified. 
Reference - https://github.com/uken/fluent-plugin-elasticsearch/issues/506

(check all that apply)
- [x] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
