### PR TITLE
Ensure sniffer class constants definition before calling #client

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -218,6 +218,14 @@ EOC
         log_level = conf['@log_level'] || conf['log_level']
         log.warn "Consider to specify log_level with @log_level." unless log_level
       end
+      # Specify @sniffer_class before calling #client.
+      # #detect_es_major_version uses #client.
+      @sniffer_class = nil
+      begin
+        @sniffer_class = Object.const_get(@sniffer_class_name) if @sniffer_class_name
+      rescue Exception => ex
+        raise Fluent::ConfigError, "Could not load sniffer class #{@sniffer_class_name}: #{ex}"
+      end
 
       @last_seen_major_version =
         if @verify_es_version_at_startup
@@ -255,12 +263,6 @@ EOC
                       You might have to specify `ssl_version TLSv1_2` in configuration."
           end
         end
-      end
-      @sniffer_class = nil
-      begin
-        @sniffer_class = Object.const_get(@sniffer_class_name) if @sniffer_class_name
-      rescue Exception => ex
-        raise Fluent::ConfigError, "Could not load sniffer class #{@sniffer_class_name}: #{ex}"
       end
     end
 


### PR DESCRIPTION
Fixes https://github.com/uken/fluent-plugin-elasticsearch/issues/514.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
