### PR TITLE
Loosen ConnectionRetryFailure condition when flush_thread_count > 1 and depends on Fluentd core retrying mechanism

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -661,14 +661,6 @@ EOC
         emit_tag = @retry_tag ? @retry_tag : tag
         router.emit_stream(emit_tag, e.retry_stream)
       rescue *client.transport.host_unreachable_exceptions => e
-        if retries < 2
-          retries += 1
-          @_es = nil
-          @_es_info = nil
-          log.warn "Could not push logs to Elasticsearch, resetting connection and trying again. #{e.message}"
-          sleep 2**retries
-          retry
-        end
         raise @unreachable_exception, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
       rescue Exception
         @_es = nil if @reconnect_on_error

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -227,14 +227,7 @@ module Fluent::Plugin
           log.error "Could not push log to Elasticsearch: #{response}"
         end
       rescue *client(host).transport.host_unreachable_exceptions => e
-        if retries < 2
-          retries += 1
-          @_es = nil
-          log.warn "Could not push logs to Elasticsearch, resetting connection and trying again. #{e.message}"
-          sleep 2**retries
-          retry
-        end
-        raise ConnectionRetryFailure, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
+        raise @unreachable_exception, "Could not push logs to Elasticsearch after #{retries} retries. #{e.message}"
       rescue Exception
         @_es = nil if @reconnect_on_error
         raise

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1987,7 +1987,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal(connection_resets, 3)
+    assert_equal(connection_resets, 1)
   end
 
   def test_reconnect_on_error_enabled

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -333,6 +333,47 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'connection exceptions' do
+    test 'default connection exception' do
+      driver(Fluent::Config::Element.new(
+               'ROOT', '', {
+                 '@type' => 'elasticsearch',
+                 'host' => 'log.google.com',
+                 'port' => 777,
+                 'scheme' => 'https',
+                 'path' => '/es/',
+                 'user' => 'john',
+                 'pasword' => 'doe',
+               }, [
+                 Fluent::Config::Element.new('buffer', 'tag', {
+                                             }, [])
+               ]
+             ))
+      assert_equal Fluent::Plugin::ElasticsearchOutput::ConnectionRetryFailure,
+                   driver.instance.instance_variable_get(:@unreachable_exception)
+    end
+
+    test 'flush_thread_count > 1' do
+      driver(Fluent::Config::Element.new(
+               'ROOT', '', {
+                 '@type' => 'elasticsearch',
+                 'host' => 'log.google.com',
+                 'port' => 777,
+                 'scheme' => 'https',
+                 'path' => '/es/',
+                 'user' => 'john',
+                 'pasword' => 'doe',
+               }, [
+                 Fluent::Config::Element.new('buffer', 'tag', {
+                                               'flush_thread_count' => 4
+                                             }, [])
+               ]
+             ))
+      assert_equal Fluent::Plugin::ElasticsearchOutput::ConnectionFailure,
+                   driver.instance.instance_variable_get(:@unreachable_exception)
+    end
+  end
+
   def test_template_already_present
     config = %{
       host            logs.google.com


### PR DESCRIPTION
From Slack:


 > I think the plugin should rely on Fluentd retry mechanism for these cases as these are recoverable to me and should raise unrecoverable errors only for truly unrecoverable errors (API mismatch for example). If I understand correctly, using several flush threads should prevent Fluentd from blocking new records when retrying to send old ones.

ref: https://fluent-all.slack.com/archives/C0CTT63EE/p1545319788134800

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
