### PR TITLE
Remove needless Elasticsearch version detection

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -504,7 +504,6 @@ EOC
 
       tag = chunk.metadata.tag
       extracted_values = expand_placeholders(chunk.metadata)
-      @last_seen_major_version = detect_es_major_version rescue @default_elasticsearch_version
 
       chunk.msgpack_each do |time, record|
         next unless record.is_a? Hash


### PR DESCRIPTION
Currently, `#detect_es_major_version` is useful in `#configure`.
We can remove it safely.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
