### PR TITLE
Follow removal of _routing field change on recent Elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,8 @@ rvm:
 gemfile:
  - Gemfile
 
+before_install:
+  - gem update --system=2.7.8
+
 script: bundle exec rake test
 sudo: false

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -268,6 +268,8 @@ EOC
       if @buffer_config.flush_thread_count < 2
         log.warn "To prevent events traffic jam, you should specify 2 or more 'flush_thread_count'."
       end
+
+      @routing_key_name = configure_routing_key_name
     end
 
     def backend_options
@@ -291,6 +293,14 @@ EOC
       Elasticsearch::VERSION
     end
 
+    def configure_routing_key_name
+      if @last_seen_major_version >= 7
+        'routing'
+      else
+        '_routing'
+      end
+    end
+
     def convert_compat_id_key(key)
       if key.include?('.') && !key.start_with?('$[')
         key = "$.#{key}" unless key.start_with?('$.')
@@ -302,7 +312,7 @@ EOC
       result = []
       result << [record_accessor_create(@id_key), '_id'] if @id_key
       result << [record_accessor_create(@parent_key), '_parent'] if @parent_key
-      result << [record_accessor_create(@routing_key), '_routing'] if @routing_key
+      result << [record_accessor_create(@routing_key), @routing_key_name] if @routing_key
       result
     end
 

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -32,7 +32,7 @@ module Fluent::Plugin
     end
 
     def create_meta_config_map
-      {'id_key' => '_id', 'parent_key' => '_parent', 'routing_key' => '_routing'}
+      {'id_key' => '_id', 'parent_key' => '_parent', 'routing_key' => @routing_key_name}
     end
 
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1764,13 +1764,24 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert(!index_cmds[0]['index'].has_key?('_parent'))
   end
 
-  def test_adds_routing_key_when_configured
-    driver.configure("routing_key routing_id\n")
-    stub_elastic
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
+  class AddsRoutingKeyWhenConfiguredTest < self
+    def test_es6
+      driver('', 6).configure("routing_key routing_id\n")
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
     end
-    assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+
+    def test_es7
+      driver('', 7).configure("routing_key routing_id\n")
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['routing'], 'routing')
+    end
   end
 
   class NestedRoutingKeyTest < self

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -735,13 +735,24 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert(!index_cmds[0]['index'].has_key?('_parent'))
   end
 
-  def test_adds_routing_key_when_configured
-    driver.configure("routing_key routing_id\n")
-    stub_elastic
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
+  class AddsRoutingKeyWhenConfiguredTest < self
+    def test_es6
+      driver('', 6).configure("routing_key routing_id\n")
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
     end
-    assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+
+    def test_es7
+      driver('', 7).configure("routing_key routing_id\n")
+      stub_elastic
+      driver.run(default_tag: 'test') do
+        driver.feed(sample_record)
+      end
+      assert_equal(index_cmds[0]['index']['routing'], 'routing')
+    end
   end
 
   class NestedRoutingKeyTest < self


### PR DESCRIPTION
Follow removal of `_routing` field change.

(check all that apply)
- [x] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
