### PR TITLE
appveyor: Remove Ruby 2.1 CI targets on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,11 +25,6 @@ environment:
       devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "22-x64"
       devkit: C:\Ruby23-x64\DevKit
-    - ruby_version: "21-x64"
-      devkit: C:\Ruby23-x64\DevKit
-    - ruby_version: "21"
-      devkit: C:\Ruby23\DevKit
-      WIN_RAPID: true
 matrix:
   allow_failures:
     - ruby_version: "21"


### PR DESCRIPTION
Ruby 2.1 is EOL and no reason to maintain Ruby 2.1 target on Windows.

ref: https://github.com/fluent/fluentd/issues/2255

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
