### PR TITLE
out_elasticsearch: Add custom_headers parameter

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -128,6 +128,7 @@ EOC
     config_param :verify_es_version_at_startup, :bool, :default => true
     config_param :default_elasticsearch_version, :integer, :default => DEFAULT_ELASTICSEARCH_VERSION
     config_param :log_es_400_reason, :bool, :default => false
+    config_param :custom_headers, :hash, :default => {}
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -351,6 +352,7 @@ EOC
         if local_reload_connections && @reload_after > DEFAULT_RELOAD_AFTER
           local_reload_connections = @reload_after
         end
+        headers = { 'Content-Type' => @content_type.to_s }.merge(@custom_headers)
         transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(get_connection_options.merge(
                                                                             options: {
                                                                               reload_connections: local_reload_connections,
@@ -358,7 +360,7 @@ EOC
                                                                               resurrect_after: @resurrect_after,
                                                                               logger: @transport_logger,
                                                                               transport_options: {
-                                                                                headers: { 'Content-Type' => @content_type.to_s },
+                                                                                headers: headers,
                                                                                 request: { timeout: @request_timeout },
                                                                                 ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
                                                                               },

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -921,6 +921,18 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_requested(elastic_request)
   end
 
+  def test_custom_headers
+    stub_request(:head, "http://localhost:9200/").
+      to_return(:status => 200, :body => "", :headers => {})
+    elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+                        with(headers: {'custom' => 'header1','and_others' => 'header2' })
+    driver.configure(%[custom_headers {"custom":"header1", "and_others":"header2"}])
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+    assert_requested(elastic_request)
+  end
+
   def test_write_message_with_bad_chunk
     driver.configure("target_index_key bad_value\n@log_level debug\n")
     stub_elastic


### PR DESCRIPTION
ref: #526

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
