### PR TITLE
Don't validate ES cliuent version under dry-run mode

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -249,7 +249,7 @@ EOC
         @type_name = '_doc'.freeze
       end
 
-      if @validate_client_version
+      if @validate_client_version && !Fluent::Engine.dry_run_mode
         if @last_seen_major_version != client_library_version.to_i
           raise Fluent::ConfigError, <<-EOC
             Detected ES #{@last_seen_major_version} but you use ES client #{client_library_version}.


### PR DESCRIPTION
Follows up #543.
Only #543 patch, users got an error when using `validate_client_version true` and `verify_es_version_at_startup true` parameters.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
