### PR TITLE
Expose exception backtrace for typhoeus gem loading error

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -283,8 +283,9 @@ EOC
         require 'typhoeus'
         { sslkey: @client_key, sslcert: @client_cert, keypasswd: @client_key_pass }
       end
-    rescue LoadError
-      raise Fluent::ConfigError, "You must install #{@http_backend} gem."
+    rescue LoadError => ex
+      log.error_backtrace(ex.backtrace)
+      raise Fluent::ConfigError, "You must install #{@http_backend} gem. Exception: #{ex}"
     end
 
     def detect_es_major_version


### PR DESCRIPTION
@chapitos suggested in https://github.com/fluent/fluentd-kubernetes-daemonset/issues/195.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
