### PR TITLE
Pass chunk for built in placeholders

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = Gem::Requirement.new(">= 2.0".freeze)
 
-  s.add_runtime_dependency 'fluentd', '>= 0.14.20'
+  s.add_runtime_dependency 'fluentd', '>= 0.14.22'
   s.add_runtime_dependency 'excon', '>= 0'
   s.add_runtime_dependency 'elasticsearch'
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -500,10 +500,10 @@ EOC
       ret
     end
 
-    def expand_placeholders(metadata)
-      logstash_prefix = extract_placeholders(@logstash_prefix, metadata)
-      index_name = extract_placeholders(@index_name, metadata)
-      type_name = extract_placeholders(@type_name, metadata)
+    def expand_placeholders(chunk)
+      logstash_prefix = extract_placeholders(@logstash_prefix, chunk)
+      index_name = extract_placeholders(@index_name, chunk)
+      type_name = extract_placeholders(@type_name, chunk)
       return logstash_prefix, index_name, type_name
     end
 
@@ -518,7 +518,7 @@ EOC
       meta = {}
 
       tag = chunk.metadata.tag
-      extracted_values = expand_placeholders(chunk.metadata)
+      extracted_values = expand_placeholders(chunk)
 
       chunk.msgpack_each do |time, record|
         next unless record.is_a? Hash


### PR DESCRIPTION
Pass chunk instead of chunk#metadata for built-in placeholders.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
