### PR TITLE
add new option to suppress doc wrapping 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Current maintainers: @cosmo0920
   + [Placeholders](#placeholders)
   + [Multi workers](#multi-workers)
   + [log_es_400_reason](#log_es_400_reason)
+  + [suppress_doc_wrap](#suppress_doc_wrap)
 * [Troubleshooting](#troubleshooting)
   + [Cannot send events to elasticsearch](#cannot-send-events-to-elasticsearch)
   + [Cannot see detailed failure log](#cannot-see-detailed-failure-log)
@@ -1022,6 +1023,12 @@ Since Fluentd v0.14, multi workers feature had been implemented to increase thro
 ## log_es_400_reason
 
 By default, the error logger won't record the reason for a 400 error from the Elasticsearch API unless you set log_level to debug. However, this results in a lot of log spam, which isn't desirable if all you want is the 400 error reasons. You can set this `true` to capture the 400 error reasons without all the other debug logs.
+
+Default value is `false`.
+
+## suppress_doc_wrap
+
+By default, record body is wrapped by 'doc'. This behavior can not handle update script requests. You can set this to suppress doc wrapping and allow record body to be untouched.
 
 Default value is `false`.
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -132,6 +132,7 @@ EOC
     config_param :default_elasticsearch_version, :integer, :default => DEFAULT_ELASTICSEARCH_VERSION
     config_param :log_es_400_reason, :bool, :default => false
     config_param :custom_headers, :hash, :default => {}
+    config_param :suppress_doc_wrap, :bool, :default => false
 
     config_section :buffer do
       config_set_default :@type, DEFAULT_BUFFER_TYPE
@@ -468,6 +469,9 @@ EOC
 
     def update_body(record, op)
       update = remove_keys(record)
+      if @suppress_doc_wrap
+        return update
+      end
       body = {"doc".freeze => update}
       if op == UPSERT_OP
         if update == record


### PR DESCRIPTION
### What I want to do
To post script record as described at elasticsearch official docs.
Please see below.
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-update

### Problem
fluent-plugin-elasticsearch wraps update record with 'doc' and can not handle script.
https://github.com/uken/fluent-plugin-elasticsearch/blob/master/lib/fluent/plugin/out_elasticsearch.rb#L471

### What I did
Add option that suppresses doc wrapping and allows record to pass through as is.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
