### PR TITLE
add new option to suppress doc wrapping (porting to v0.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Note: For Amazon Elasticsearch Service please consider using [fluent-plugin-aws-
   + [reload_after](#reload_after)
   + [Not seeing a config you need?](#not-seeing-a-config-you-need)
   + [Dynamic configuration](#dynamic-configuration)
+  + [suppress_doc_wrap](#suppress_doc_wrap)
 * [Contact](#contact)
 * [Contributing](#contributing)
 * [Running tests](#running-tests)
@@ -637,6 +638,12 @@ If you want configurations to depend on information in messages, you can use `el
 ```
 
 **Please note, this uses Ruby's `eval` for every message, so there are performance and security implications.**
+
+### suppress_doc_wrap
+
+By default, record body is wrapped by 'doc'. This behavior can not handle update script requests. You can set this to suppress doc wrapping and allow record body to be untouched.
+￼
+Default value is `false`.
 
 ## Contact
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -90,6 +90,7 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
   config_param :emit_error_for_missing_id, :bool, :default => false
   config_param :sniffer_class_name, :string, :default => nil
   config_param :reload_after, :integer, :default => DEFAULT_RELOAD_AFTER
+  config_param :suppress_doc_wrap, :bool, :default => false
 
   include Fluent::ElasticsearchIndexTemplate
   include Fluent::ElasticsearchConstants
@@ -322,6 +323,9 @@ class Fluent::ElasticsearchOutput < Fluent::ObjectBufferedOutput
 
   def update_body(record, op)
     update = remove_keys(record)
+    if @suppress_doc_wrap
+      return update
+    end
     body = {"doc".freeze => update}
     if op == UPSERT_OP
       if update == record


### PR DESCRIPTION
This patch is #557 porting to v0.12.


(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
