### PR TITLE
Fix support for host, hosts placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ host user-custom-host.domain # default localhost
 
 You can specify Elasticsearch host by this parameter.
 
-**Note:** Since v3.3.0, `host` parameter supports builtin placeholders. If you want to send events dinamically into different hosts at runtime with `elasticsearch_dynamic` output plugin, please consider to switch to use plain `elasticsearch` output plugin. In more detail for builtin placeholders, please refer to [Placeholders](#placeholders) section.
+**Note:** Since v3.3.2, `host` parameter supports builtin placeholders. If you want to send events dynamically into different hosts at runtime with `elasticsearch_dynamic` output plugin, please consider to switch to use plain `elasticsearch` output plugin. In more detail for builtin placeholders, please refer to [Placeholders](#placeholders) section.
 
 ### emit_error_for_missing_id
 

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -28,7 +28,6 @@ module Fluent::Plugin
         @dynamic_config[key] = value.to_s
       }
       # end eval all configs
-      @current_config = nil
     end
 
     def create_meta_config_map
@@ -258,21 +257,6 @@ module Fluent::Plugin
     def is_valid_expand_param_type(param)
       return false if [:@buffer_type].include?(param)
       return self.instance_variable_get(param).is_a?(String)
-    end
-
-    def is_existing_connection(host)
-      # check if the host provided match the current connection
-      return false if @_es.nil?
-      return false if @current_config.nil?
-      return false if host.length != @current_config.length
-
-      for i in 0...host.length
-        if !host[i][:host].eql? @current_config[i][:host] || host[i][:port] != @current_config[i][:port]
-          return false
-        end
-      end
-
-      return true
     end
   end
 end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1535,12 +1535,16 @@ class ElasticsearchOutput < Test::Unit::TestCase
                          ]
                        ))
       time = Time.parse Date.today.iso8601
-      pipeline_id = "5"
-      elastic_request = stub_elastic("http://myhost-5:9200/_bulk")
+      first_pipeline_id = "1"
+      second_pipeline_id = "2"
+      first_request = stub_elastic("http://myhost-1:9200/_bulk")
+      second_request = stub_elastic("http://myhost-2:9200/_bulk")
       driver.run(default_tag: 'test') do
-        driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
+        driver.feed(time.to_i, sample_record.merge({"pipeline_id" => first_pipeline_id}))
+        driver.feed(time.to_i, sample_record.merge({"pipeline_id" => second_pipeline_id}))
       end
-      assert_requested(elastic_request)
+      assert_requested(first_request)
+      assert_requested(second_request)
     end
   end
 
@@ -1558,7 +1562,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 
-    def test_writes_to_logstash_index_with_specified_dateformat
+  def test_writes_to_logstash_index_with_specified_dateformat
     driver.configure("logstash_format true
                       logstash_dateformat %Y.%m")
     time = Time.parse Date.today.iso8601


### PR DESCRIPTION
DESCRIPTION HERE

Currently the placeholder support for host, hosts introduced with #554 in unusable. The elastic client currently is now being cached in instance variable and the client is not dynamically configured. This PR fixes this issue.

##### Steps to reproduce

1. Start elasticsearch on localhost
2. Start fluentd with dynamic host
```
<match elastic.**>
  @id elasticsearch_shoot
  @type elasticsearch
  @log_level debug
  host ${key1}

  port 9200

  <!-- omitted -->
</match>
```
3. Send a valid message
```bash
$ echo '{"key1":"localhost"}' | fluent-cat elastic.localhost
```

4. Ensure that the doc in elastic is saved successfully
5. Send invalid host
```bash
$  echo '{"key1":"foo"}' | fluent-cat elastic.foo
```
6. Ensure that the invalid message also goes to host `localhost`, but not host `foo` (because the elastic client is cached from the previous call and not recreated with the newly passed host).

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
