### PR TITLE
Add ignore_exceptions config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Current maintainers: @cosmo0920
   + [Multi workers](#multi-workers)
   + [log_es_400_reason](#log_es_400_reason)
   + [suppress_doc_wrap](#suppress_doc_wrap)
+  + [ignore_exceptions](#ignore_exceptions)
+  + [exception_backup](#exception_backup)
 * [Troubleshooting](#troubleshooting)
   + [Cannot send events to elasticsearch](#cannot-send-events-to-elasticsearch)
   + [Cannot see detailed failure log](#cannot-see-detailed-failure-log)
@@ -1031,6 +1033,24 @@ Default value is `false`.
 By default, record body is wrapped by 'doc'. This behavior can not handle update script requests. You can set this to suppress doc wrapping and allow record body to be untouched.
 
 Default value is `false`.
+
+## ignore_exceptions
+
+A list of exception that will be ignored - when the exception occurs the chunk will be discarded and the buffer retry mechanism won't be called. It is possible also to specify classes at higher level in the hierarchy. For example
+
+```
+ignore_exceptions ["Elasticsearch::Transport::Transport::ServerError"]
+```
+
+will match all subclasses of `ServerError` - `Elasticsearch::Transport::Transport::Errors::BadRequest`, `Elasticsearch::Transport::Transport::Errors::ServiceUnavailable`, etc.
+
+Default value is empty list (no exception is ignored).
+
+## exception_backup
+
+Indicates whether to backup chunk when ignore exception occurs.
+
+Default value is `true`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
As discussed in [fluent/fluentd#2280](https://github.com/fluent/fluentd/issues/2280) this PR adds possibility to ignore configurable exceptions. This is useful in cases when you have dynamic host config like:
```
<match **>
  @type elasticsearch
  host ${key1}
 
  // omitted
</match>
```

In this config when you send dynamically to n elastic instances, and if some of them are unavailable this will result in:
```
failed to flush the buffer, and hit limit for retries. dropping all chunks in the buffer queue.
```
and in this buffer queue there could be some potentially successful chunks. 
The mechanism now check the exception that occurred in `ignore_exceptions` list and if a match is found, then the chunks is discarded and the retry mechanism is not called.


DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
