### PR TITLE
Check exclusive feature on #configure

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -176,6 +176,12 @@ EOC
 
       raise Fluent::ConfigError, "'max_retry_putting_template' must be positive number." if @max_retry_putting_template < 0
 
+      # Raise error when using host placeholders and template features at same time.
+      valid_host_placeholder = placeholder?(:host_placeholder, @host)
+      if valid_host_placeholder && (@template_name && @template_file || @templates)
+        raise Fluent::ConfigError, "host placeholder and template installation are exclusive features."
+      end
+
       if !Fluent::Engine.dry_run_mode
         if @template_name && @template_file
           retry_operate(@max_retry_putting_template) do
@@ -287,6 +293,15 @@ EOC
           Object.const_get(exception)
         end
       end.compact
+    end
+
+    def placeholder?(name, param)
+      begin
+        placeholder_validate!(name, param)
+        true
+      rescue Fluent::ConfigError
+        false
+      end
     end
 
     def backend_options

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -659,6 +659,26 @@ class ElasticsearchOutput < Test::Unit::TestCase
     }
   end
 
+  def test_template_installation_exclusive_for_host_placeholder
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_template.json')
+
+    config = %{
+      host            logs-${tag}.google.com
+      port            777
+      scheme          https
+      path            /es/
+      user            john
+      password        doe
+      template_name   logstash
+      template_file   #{template_file}
+    }
+
+    assert_raise(Fluent::ConfigError) do
+      driver(config)
+    end
+  end
+
   def test_template_retry_install
     cwd = File.dirname(__FILE__)
     template_file = File.join(cwd, 'test_template.json')


### PR DESCRIPTION
Template installation and dynamic host with built-in placeholders are
exclusive.

This should be treated as a "plugin limitation" **for now**.

Because ES plugin's in `#configure` does not have host information and they are provided from chunk metadata on `#write`.
Thus, ES plugin cannot support dynamic host and template installation at same time with current implementation.

Related to https://github.com/uken/fluent-plugin-elasticsearch/issues/565.


(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
