### PR TITLE
Handle non-String value on parse_time

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -368,10 +368,7 @@ EOC
         end
       else
         Proc.new { |value|
-          if value.is_a?(Numeric)
-            numeric_time_parser = Fluent::NumericTimeParser.new(:float)
-            value = Time.at(numeric_time_parser.parse(value).to_r).strftime("%Y-%m-%d %H:%M:%S.%N %z")
-          end
+          value = convert_numeric_time_into_string(value) if value.is_a?(Numeric)
           DateTime.parse(value)
         }
       end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -12,6 +12,7 @@ end
 require 'fluent/plugin/output'
 require 'fluent/event'
 require 'fluent/error'
+require 'fluent/time'
 require_relative 'elasticsearch_constants'
 require_relative 'elasticsearch_error'
 require_relative 'elasticsearch_error_handler'
@@ -366,7 +367,13 @@ EOC
           Proc.new { |value| DateTime.strptime(value, @time_key_format) }
         end
       else
-        Proc.new { |value| DateTime.parse(value) }
+        Proc.new { |value|
+          if value.is_a?(Numeric)
+            numeric_time_parser = Fluent::NumericTimeParser.new(:float)
+            value = Time.at(numeric_time_parser.parse(value).to_r).strftime("%Y-%m-%d %H:%M:%S.%N %z")
+          end
+          DateTime.parse(value)
+        }
       end
     end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -359,12 +359,18 @@ EOC
           # Strptime doesn't support all formats, but for those it does it's
           # blazingly fast.
           strptime = Strptime.new(@time_key_format)
-          Proc.new { |value| strptime.exec(value).to_datetime }
+          Proc.new { |value|
+            value = convert_numeric_time_into_string(value, @time_key_format) if value.is_a?(Numeric)
+            strptime.exec(value).to_datetime
+          }
         rescue
           # Can happen if Strptime doesn't recognize the format; or
           # if strptime couldn't be required (because it's not installed -- it's
           # ruby 2 only)
-          Proc.new { |value| DateTime.strptime(value, @time_key_format) }
+          Proc.new { |value|
+            value = convert_numeric_time_into_string(value, @time_key_format) if value.is_a?(Numeric)
+            DateTime.strptime(value, @time_key_format)
+          }
         end
       else
         Proc.new { |value|

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -377,6 +377,11 @@ EOC
       end
     end
 
+    def convert_numeric_time_into_string(numeric_time, time_key_format = "%Y-%m-%d %H:%M:%S.%N%z")
+      numeric_time_parser = Fluent::NumericTimeParser.new(:float)
+      Time.at(numeric_time_parser.parse(numeric_time).to_r).strftime(time_key_format)
+    end
+
     def parse_time(value, event_time, tag)
       @time_parser.call(value)
     rescue => e

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1711,6 +1711,20 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal(index_cmds[1]['@timestamp'], ts)
   end
 
+  def test_uses_custom_time_key_with_float_record
+    driver.configure("logstash_format true
+                      time_precision 3
+                      time_key vtm\n")
+    stub_elastic
+    time = Time.now
+    float_time = time.to_f
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record.merge!('vtm' => float_time))
+    end
+    assert(index_cmds[1].has_key? '@timestamp')
+    assert_equal(index_cmds[1]['@timestamp'], time.to_datetime.iso8601(3))
+  end
+
   def test_uses_custom_time_key_with_format
     driver.configure("logstash_format true
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1739,6 +1739,22 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal("logstash-2001.02.03", index_cmds[0]['index']['_index'])
   end
 
+  def test_uses_custom_time_key_with_float_record_and_format
+    driver.configure("logstash_format true
+                      time_key_format %Y-%m-%d %H:%M:%S.%N%z
+                      time_key vtm\n")
+    stub_elastic
+    ts = "2001-02-03 13:14:01.673+02:00"
+    time = Time.parse(ts)
+    current_zone_offset = Time.now.to_datetime.offset
+    float_time = time.to_f
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record.merge!('vtm' => float_time))
+    end
+    assert(index_cmds[1].has_key? '@timestamp')
+    assert_equal(index_cmds[1]['@timestamp'], DateTime.parse(ts).new_offset(current_zone_offset).iso8601(9))
+  end
+
   def test_uses_custom_time_key_with_format_without_logstash
     driver.configure("include_timestamp true
                       index_name test


### PR DESCRIPTION
Related to #423.

Could you take a look, @mattheworiordan @pathikritmodak @bderickson  ?

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
