### PR TITLE
Add fail_on_putting_template_retry_exceed config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Current maintainers: @cosmo0920
   + [index_prefix](#index_prefix)
   + [templates](#templates)
   + [max_retry_putting_template](#max_retry_putting_template)
+  + [fail_on_putting_template_retry_exceed](#fail_on_putting_template_retry_exceed)
   + [max_retry_get_es_version](#max_retry_get_es_version)
   + [request_timeout](#request_timeout)
   + [reload_connections](#reload_connections)
@@ -448,6 +449,15 @@ Usually, booting up clustered Elasticsearch containers are much slower than laun
 
 ```
 max_retry_putting_template 15 # defaults to 10
+```
+
+### fail_on_putting_template_retry_exceed
+
+Indicates whether to fail when `max_retry_putting_template` is exceeded.
+If you have multiple output plugin, you could use this property to do not fail on fluentd statup.
+
+```
+fail_on_putting_template_retry_exceed false # defaults to true
 ```
 
 ### max_retry_get_es_version

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -28,7 +28,7 @@ module Fluent::ElasticsearchIndexTemplate
     return false
   end
 
-  def retry_operate(max_retries)
+  def retry_operate(max_retries, fail_on_retry_exceed = true)
     return unless block_given?
     retries = 0
     begin
@@ -42,8 +42,10 @@ module Fluent::ElasticsearchIndexTemplate
         log.warn "Could not communicate to Elasticsearch, resetting connection and trying again. #{e.message}"
         retry
       end
+      message = "Could not communicate to Elasticsearch after #{retries} retries. #{e.message}"
+      log.warn message
       raise Fluent::Plugin::ElasticsearchError::RetryableOperationExhaustedFailure,
-            "Could not communicate to Elasticsearch after #{retries} retries. #{e.message}"
+            message if fail_on_retry_exceed
     end
   end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -109,6 +109,7 @@ EOC
     config_param :application_name, :string, :default => "default"
     config_param :templates, :hash, :default => nil
     config_param :max_retry_putting_template, :integer, :default => 10
+    config_param :fail_on_putting_template_retry_exceed, :bool, :default => true
     config_param :max_retry_get_es_version, :integer, :default => 15
     config_param :include_tag_key, :bool, :default => false
     config_param :tag_key, :string, :default => 'tag'
@@ -185,7 +186,7 @@ EOC
 
       if !Fluent::Engine.dry_run_mode
         if @template_name && @template_file
-          retry_operate(@max_retry_putting_template) do
+          retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
             if @customize_template
               if @rollover_index
                 raise Fluent::ConfigError, "'deflector_alias' must be provided if 'rollover_index' is set true ." if not @deflector_alias
@@ -196,7 +197,7 @@ EOC
             end
           end
         elsif @templates
-          retry_operate(@max_retry_putting_template) do
+          retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
             templates_hash_install(@templates, @template_overwrite)
           end
         end


### PR DESCRIPTION
Currently the elastic plugin with the following config
```
<match elastic.**>
  @type elasticsearch
  [...]
  template_name test_name
  template_file /test_template
  [...]
</match>
```
tries to apply the index templates in the `configure` step. If the apply step fails, the plugin starts retrying before to fail after `max_retry_putting_template` and fluentd fails to start.

You could also have another output plugins such as:
```
<match foo.**>
  @type stdout
  @id stdout_foo
</match>

<match bar.**>
  @type stdout
  @id stdout_bar
</match>
```
and probably you will want to have fluentd running with the other output plugins even without the elastic templates.

The PR introduces `fail_on_putting_template_retry_exceed` config that can ignore  `max_retry_putting_template` exceed.

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
