### PR TITLE
Fix `@meta_config_map` creation timing

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -205,13 +205,6 @@ EOC
         end
       end
 
-      # Consider missing the prefix of "$." in nested key specifiers.
-      @id_key = convert_compat_id_key(@id_key) if @id_key
-      @parent_key = convert_compat_id_key(@parent_key) if @parent_key
-      @routing_key = convert_compat_id_key(@routing_key) if @routing_key
-
-      @meta_config_map = create_meta_config_map
-
       @serializer_class = nil
       begin
         require 'oj'
@@ -285,7 +278,13 @@ EOC
         log.warn "To prevent events traffic jam, you should specify 2 or more 'flush_thread_count'."
       end
 
+      # Consider missing the prefix of "$." in nested key specifiers.
+      @id_key = convert_compat_id_key(@id_key) if @id_key
+      @parent_key = convert_compat_id_key(@parent_key) if @parent_key
+      @routing_key = convert_compat_id_key(@routing_key) if @routing_key
+
       @routing_key_name = configure_routing_key_name
+      @meta_config_map = create_meta_config_map
       @current_config = nil
 
       @ignore_exception_classes = @ignore_exceptions.map do |exception|

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -2049,7 +2049,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   class AddsRoutingKeyWhenConfiguredTest < self
     def test_es6
-      driver('', 6).configure("routing_key routing_id\n")
+      driver("routing_key routing_id\n", 6)
       stub_elastic
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
@@ -2058,7 +2058,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
 
     def test_es7
-      driver('', 7).configure("routing_key routing_id\n")
+      driver("routing_key routing_id\n", 7)
       stub_elastic
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -475,7 +475,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     # creation
     stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template").
       to_return(:status => 200, :body => "", :headers => {})
-    
+
     driver(config)
 
     assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template", times: 1)
@@ -520,7 +520,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     # put the alias for the index
     stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/_alias/myapp_deflector").
       to_return(:status => 200, :body => "", :headers => {})
-    
+
     driver(config)
 
     assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template", times: 1)
@@ -584,7 +584,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     # creation
     stub_request(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template").
       to_return(:status => 200, :body => "", :headers => {})
-    
+
     driver(config)
 
     assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template", times: 1)
@@ -629,7 +629,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     # put the alias for the index
     stub_request(:put, "https://john:doe@logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E/_alias/myapp_deflector").
       to_return(:status => 200, :body => "", :headers => {})
-  
+
     driver(config)
 
     assert_requested(:put, "https://john:doe@logs.google.com:777/es//_template/myapp_alias_template", times: 1)

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -737,7 +737,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   class AddsRoutingKeyWhenConfiguredTest < self
     def test_es6
-      driver('', 6).configure("routing_key routing_id\n")
+      driver("routing_key routing_id\n", 6)
       stub_elastic
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
@@ -746,7 +746,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     end
 
     def test_es7
-      driver('', 7).configure("routing_key routing_id\n")
+      driver("routing_key routing_id\n", 7)
       stub_elastic
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)


### PR DESCRIPTION
When I use `routing_key` in conf, `@routing_key_name` is `nil` at https://github.com/uken/fluent-plugin-elasticsearch/blob/master/lib/fluent/plugin/out_elasticsearch.rb#L362
Fixed test 2c9c17b reproduces `nil`.

`configure_routing_key_name` should be called before `create_meta_config_map`.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
