### PR TITLE
Handle nil items response

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -56,10 +56,13 @@ class Fluent::Plugin::ElasticsearchErrorHandler
         next
       end
       item = items.shift
-      if item.has_key?(@plugin.write_operation)
+      if item.is_a?(Hash) && item.has_key?(@plugin.write_operation)
         write_operation = @plugin.write_operation
-      elsif INDEX_OP == @plugin.write_operation && item.has_key?(CREATE_OP)
+      elsif INDEX_OP == @plugin.write_operation && item.is_a?(Hash) && item.has_key?(CREATE_OP)
         write_operation = CREATE_OP
+      elsif item.nil?
+        stats[:errors_nil_resp] += 1
+        next
       else
         # When we don't have an expected ops field, something changed in the API
         # expected return values (ES 2.x)

--- a/test/plugin/test_elasticsearch_error_handler.rb
+++ b/test/plugin/test_elasticsearch_error_handler.rb
@@ -145,6 +145,20 @@ class TestElasticsearchErrorHandler < Test::Unit::TestCase
     end
   end
 
+  def test_nil_items_responses
+    records = [{time: 123, record: {"foo" => "bar", '_id' => 'abc'}}]
+    response = parse_response(%({
+      "took" : 0,
+      "errors" : true,
+      "items" : [{}]
+     }))
+    chunk = MockChunk.new(records)
+    dummy_extracted_values = []
+    @handler.handle_error(response, 'atag', chunk, records.length, dummy_extracted_values)
+    assert_equal(0, @plugin.error_events.size)
+    assert_nil(@plugin.error_events[0])
+  end
+
   def test_dlq_400_responses
     records = [{time: 123, record: {"foo" => "bar", '_id' => 'abc'}}]
     response = parse_response(%({


### PR DESCRIPTION
Related to #595.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
