### PR TITLE
Display retry counts and interval

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -38,8 +38,10 @@ module Fluent::ElasticsearchIndexTemplate
       @_es_info = nil
       if retries < max_retries
         retries += 1
-        sleep 2**retries
+        wait_seconds = 2**retries
+        sleep wait_seconds
         log.warn "Could not communicate to Elasticsearch, resetting connection and trying again. #{e.message}"
+        log.warn "Remaining retry: #{max_retries - retries}. Retry to communicate after #{wait_seconds} second(s)."
         retry
       end
       message = "Could not communicate to Elasticsearch after #{retries} retries. #{e.message}"


### PR DESCRIPTION
Current `retry_operate` implementation is not debugging friendly because waiting interval and remaining retrying counts are not recorded in Fluentd log.

I found this inconvenient issue when debugging #596. 

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
