### PR TITLE
Add contribution guideline document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+Contributing to fluent-plugin-elasticsearch
+===
+
+We'd love your contribution. Here are the guidelines!
+
+## Got a question or problem?
+
+RESOURCES of [Official site's documentation](https://docs.fluentd.org/output/elasticsearch) and [ES plugin documentation](https://github.com/uken/fluent-plugin-elasticsearch/blob/master/README.md) may help you.
+
+If you have further questions about ES plugin, feel free to [open an Issue](https://github.com/uken/fluent-plugin-elasticsearch/issues).
+
+## Found a bug?
+
+If you find a bug of ES plugin or a mistake in the documentation, you can help us by submitting an issue to ES plugin. Even better you can submit a pull request with a fix.
+
+Note: Please follow the issue template/pull request template when sending your issue. Otherwise, your issue _might going to be closed with no response_.
+
+## Patch Guidelines
+
+Here are some things that would increase a chance that your patch is accepted:
+
+* Write tests
+* Run tests before sending pull request with `bundle exec rake test`
+* Write [a good commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,6 @@
+(check apply)
+- [ ] read [the contribution guideline](CONTRIBUTING.md)
+
 #### Problem
 
 ...

--- a/README.md
+++ b/README.md
@@ -1502,6 +1502,8 @@ There are usually a few feature requests, tagged [Easy](https://github.com/uken/
 
 Pull Requests are welcomed.
 
+Becore send a pull request or report an issue, please read [the contribution guideline](CONTRIBUTING.md).
+
 [![Pull Request Graph](https://graphs.waffle.io/uken/fluent-plugin-elasticsearch/throughput.svg)](https://waffle.io/uken/fluent-plugin-elasticsearch/metrics)
 
 ## Running tests


### PR DESCRIPTION
Added contribution guideline document.
When users report their issues, we investigate root cause of issues by user provided information.
So, user provided information should be fulfill issue templates.
Otherwise, it doesn't reproducible their issue with incomplete information.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
