### PR TITLE
Fix DST-breaking unit test

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1796,7 +1796,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     stub_elastic
     ts = "2001-02-03 13:14:01.673+02:00"
     time = Time.parse(ts)
-    current_zone_offset = Time.now.to_datetime.offset
+    current_zone_offset = Time.new(2001, 02, 03).to_datetime.offset
     float_time = time.to_f
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => float_time))


### PR DESCRIPTION
This is a fix for https://github.com/uken/fluent-plugin-elasticsearch/issues/622

Currently the /test/plugin/test_out_elasticsearch.rb testcase
test_uses_custom_time_key_with_float_record_and_format breaks
depending on whether or not the timezone generated by Time.now
is the same as the timezone that would be used on 2001-02-03.

This is a simple fix that bases the current_zone_offset off of
2001-02-03 instead of Time.now.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
