### PR TITLE
Fix error message for `max_retry_putting_template`

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -178,7 +178,7 @@ EOC
         @remove_keys_on_update = @remove_keys_on_update.split ','
       end
 
-      raise Fluent::ConfigError, "'max_retry_putting_template' must be positive number." if @max_retry_putting_template < 0
+      raise Fluent::ConfigError, "'max_retry_putting_template' must be greater than or equal to zero." if @max_retry_putting_template < 0
 
       # Raise error when using host placeholders and template features at same time.
       valid_host_placeholder = placeholder?(:host_placeholder, @host)


### PR DESCRIPTION
Fixed error message for `max_retry_putting_template`.
Zero is not positive number.

```ruby
0.positive? # => false
0.negative? # => false
```

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
