### PR TITLE
Validate `max_retry_get_es_version`

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -179,6 +179,7 @@ EOC
       end
 
       raise Fluent::ConfigError, "'max_retry_putting_template' must be greater than or equal to zero." if @max_retry_putting_template < 0
+      raise Fluent::ConfigError, "'max_retry_get_es_version' must be greater than or equal to zero." if @max_retry_get_es_version < 0
 
       # Raise error when using host placeholders and template features at same time.
       valid_host_placeholder = placeholder?(:host_placeholder, @host)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -260,6 +260,15 @@ class ElasticsearchOutput < Test::Unit::TestCase
     }
   end
 
+  test 'invalid specification of times of retrying get es version' do
+    config = %{
+      max_retry_get_es_version -3
+    }
+    assert_raise(Fluent::ConfigError) {
+      driver(config)
+    }
+  end
+
   test 'Detected Elasticsearch 7' do
     config = %{
       type_name changed


### PR DESCRIPTION
Validate `max_retry_get_es_version`.
Same validation as `max_retry_putting_template`.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
