### PR TITLE
Use upper-case to compare before and after conversion

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1193,7 +1193,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     stub_elastic
     driver.run(default_tag: 'test') do
-      driver.feed(time.to_i, sample_record.merge('@target_index' => 'local-override'))
+      driver.feed(time.to_i, sample_record.merge('@target_index' => 'LOCAL-OVERRIDE'))
     end
     # Allthough @target_index has upper-case characters,
     # it should be set as lower-case when sent to elasticsearch.


### PR DESCRIPTION
Use upper-case as `target_index` in test to compare before and after conversion.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
