### PR TITLE
Fix description position and add examples for `hosts` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ If you specify multiple hosts, this plugin will load balance updates to Elastics
 
 If you specify `hosts` option, `host` and `port` options are ignored.
 
+```
+host user-custom-host.domain # ignored
+port 9200                    # ignored
+hosts host1:port1,host2:port2,host3:port3
+```
+
+If you specify `hosts` option without port, `port` option is used.
+
+```
+port 9200
+hosts host1:port1,host2:port2,host3 # port3 is 9200
+```
+
 **Note:** If you will use scheme https, do not include "https://" in your hosts ie. host "https://domain", this will cause ES cluster to be unreachable and you will receive an error "Can not reach Elasticsearch cluster"
 
 **Note:** Up until v2.8.5, it was allowed to embed the username/password in the URL. However, this syntax is deprecated as of v2.8.6 because it was found to cause serious connection problems (See #394). Please migrate your settings to use the `user` and `password` field (described below) instead.

--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ You can specify multiple Elasticsearch hosts with separator ",".
 
 If you specify multiple hosts, this plugin will load balance updates to Elasticsearch. This is an [elasticsearch-ruby](https://github.com/elasticsearch/elasticsearch-ruby) feature, the default strategy is round-robin.
 
+If you specify `hosts` option, `host` and `port` options are ignored.
+
 **Note:** If you will use scheme https, do not include "https://" in your hosts ie. host "https://domain", this will cause ES cluster to be unreachable and you will receive an error "Can not reach Elasticsearch cluster"
 
 **Note:** Up until v2.8.5, it was allowed to embed the username/password in the URL. However, this syntax is deprecated as of v2.8.6 because it was found to cause serious connection problems (See #394). Please migrate your settings to use the `user` and `password` field (described below) instead.
 
 ### user, password, path, scheme, ssl_verify
-
-If you specify this option, port options are ignored.
 
 ```
 user demo

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1000,6 +1000,21 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal nil, host1[:path]
   end
 
+  def test_host_and_port_are_ignored_if_specify_hosts
+    config = %{
+      host  logs.google.com
+      port  9200
+      hosts host1:50,host2:100
+    }
+    instance = driver(config).instance
+
+    params = instance.get_connection_options[:hosts]
+    hosts = params.map { |p| p[:host] }
+    ports = params.map { |p| p[:port] }
+    assert(hosts.none? { |h| h == 'logs.google.com' })
+    assert(ports.none? { |p| p == 9200 })
+  end
+
   def test_content_type_header
     stub_request(:head, "http://localhost:9200/").
       to_return(:status => 200, :body => "", :headers => {})


### PR DESCRIPTION
* Fix description position.
  * https://github.com/uken/fluent-plugin-elasticsearch/commit/0424f2dfa46db18787dc65681612ad18244e79d4#diff-04c6e90faac2675aa89e2176d2eec7d8
  Above commit, the description moved out of right position.
* Fix description content.
* Add examples.
* Add test.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
