### PR TITLE
Add description for `port` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Current maintainers: @cosmo0920
   + [Index templates](#index-templates)
 * [Configuration](#configuration)
   + [host](#host)
+  + [port](#port)
   + [emit_error_for_missing_id](#emit_error_for_missing_id)
   + [hosts](#hosts)
   + [user, password, path, scheme, ssl_verify](#user-password-path-scheme-ssl_verify)
@@ -146,6 +147,14 @@ host user-custom-host.domain # default localhost
 You can specify Elasticsearch host by this parameter.
 
 **Note:** Since v3.3.2, `host` parameter supports builtin placeholders. If you want to send events dynamically into different hosts at runtime with `elasticsearch_dynamic` output plugin, please consider to switch to use plain `elasticsearch` output plugin. In more detail for builtin placeholders, please refer to [Placeholders](#placeholders) section.
+
+### port
+
+```
+port 9201 # defaults to 9200
+```
+
+You can specify Elasticsearch port by this parameter.
 
 ### emit_error_for_missing_id
 


### PR DESCRIPTION
Add description for `port` option.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
