### PR TITLE
Fix arguments order of `assert_equal`

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -392,7 +392,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
         create_driver(config)
       end
 
-      assert_equal(connection_resets, 4)
+      assert_equal(4, connection_resets)
     end
   end
 
@@ -706,7 +706,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver(config)
     end
 
-    assert_equal(connection_resets, 4)
+    assert_equal(4, connection_resets)
   end
 
   def test_template_retry_install_does_not_fail
@@ -735,7 +735,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     driver(config)
 
-    assert_equal(connection_resets, 4)
+    assert_equal(4, connection_resets)
   end
 
   def test_templates_create
@@ -1712,7 +1712,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
+    assert_equal(ts.iso8601(9), index_cmds[1]['@timestamp'])
   end
 
   def test_adds_timestamp_when_include_timestamp
@@ -1724,7 +1724,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts.iso8601(9))
+    assert_equal(ts.iso8601(9), index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_timestamp_when_included_in_record
@@ -1735,7 +1735,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('@timestamp' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_timestamp_when_included_in_record_without_logstash
@@ -1746,7 +1746,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('@timestamp' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key
@@ -1758,7 +1758,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key_with_float_record
@@ -1772,7 +1772,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => float_time))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], time.to_datetime.iso8601(3))
+    assert_equal(time.to_datetime.iso8601(3), index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key_with_format
@@ -1785,7 +1785,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], DateTime.parse(ts).iso8601(9))
+    assert_equal(DateTime.parse(ts).iso8601(9), index_cmds[1]['@timestamp'])
     assert_equal("logstash-2001.02.03", index_cmds[0]['index']['_index'])
   end
 
@@ -1802,7 +1802,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => float_time))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], DateTime.parse(ts).new_offset(current_zone_offset).iso8601(9))
+    assert_equal(DateTime.parse(ts).new_offset(current_zone_offset).iso8601(9), index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key_with_format_without_logstash
@@ -1816,7 +1816,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], DateTime.parse(ts).iso8601(9))
+    assert_equal(DateTime.parse(ts).iso8601(9), index_cmds[1]['@timestamp'])
     assert_equal("test", index_cmds[0]['index']['_index'])
   end
 
@@ -1842,7 +1842,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
     assert_equal("logstash-2001.02.03", index_cmds[0]['index']['_index'])
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key_format_without_logstash
@@ -1856,7 +1856,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
     assert_equal("test", index_cmds[0]['index']['_index'])
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   data(:default => nil,
@@ -1879,7 +1879,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     assert_equal(index, index_cmds[0]['index']['_index'])
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
 
@@ -1893,7 +1893,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
     assert_equal("logstash-2001.11.29", index_cmds[0]['index']['_index'])
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_nanosecond_precision_by_default
@@ -1904,7 +1904,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(9))
+    assert_equal(Time.at(time).iso8601(9), index_cmds[1]['@timestamp'])
   end
 
   def test_uses_subsecond_precision_when_configured
@@ -1916,7 +1916,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(3))
+    assert_equal(Time.at(time).iso8601(3), index_cmds[1]['@timestamp'])
   end
 
   def test_doesnt_add_tag_key_by_default
@@ -1934,7 +1934,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record)
     end
     assert(index_cmds[1].has_key?('tag'))
-    assert_equal(index_cmds[1]['tag'], 'mytag')
+    assert_equal('mytag', index_cmds[1]['tag'])
   end
 
   def test_adds_id_key_when_configured
@@ -1943,7 +1943,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal(index_cmds[0]['index']['_id'], '42')
+    assert_equal('42', index_cmds[0]['index']['_id'])
   end
 
   class NestedIdKeyTest < self
@@ -1953,7 +1953,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_id'], '42')
+      assert_equal('42', index_cmds[0]['index']['_id'])
     end
 
     def test_adds_nested_id_key_with_dollar_dot
@@ -1962,7 +1962,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_id'], '42')
+      assert_equal('42', index_cmds[0]['index']['_id'])
     end
 
     def test_adds_nested_id_key_with_bracket
@@ -1971,7 +1971,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_id'], '42')
+      assert_equal('42', index_cmds[0]['index']['_id'])
     end
   end
 
@@ -1998,7 +1998,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    assert_equal('parent', index_cmds[0]['index']['_parent'])
   end
 
   class NestedParentKeyTest < self
@@ -2008,7 +2008,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+      assert_equal('parent', index_cmds[0]['index']['_parent'])
     end
 
     def test_adds_nested_parent_key_with_dollar_dot
@@ -2017,7 +2017,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+      assert_equal('parent', index_cmds[0]['index']['_parent'])
     end
 
     def test_adds_nested_parent_key_with_bracket
@@ -2026,7 +2026,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+      assert_equal('parent', index_cmds[0]['index']['_parent'])
     end
   end
 
@@ -2054,7 +2054,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
 
     def test_es7
@@ -2063,7 +2063,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
-      assert_equal(index_cmds[0]['index']['routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['routing'])
     end
   end
 
@@ -2074,7 +2074,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
 
     def test_adds_nested_routing_key_with_dollar_dot
@@ -2083,7 +2083,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
 
     def test_adds_nested_routing_key_with_bracket
@@ -2092,7 +2092,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
   end
 
@@ -2175,7 +2175,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
         driver.feed(sample_record)
       end
     }
-    assert_equal(connection_resets, 1)
+    assert_equal(1, connection_resets)
   end
 
   def test_reconnect_on_error_enabled
@@ -2201,7 +2201,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     }
     # FIXME: Consider keywords arguments in #run and how to test this later.
     # Because v0.14 test driver does not have 1 to 1 correspondence between #run and #flush in tests.
-    assert_equal(connection_resets, 1)
+    assert_equal(1, connection_resets)
   end
 
   def test_reconnect_on_error_disabled
@@ -2225,7 +2225,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
         driver.feed(sample_record)
       end
     }
-    assert_equal(connection_resets, 1)
+    assert_equal(1, connection_resets)
   end
 
   def test_bulk_error_retags_when_configured
@@ -2609,8 +2609,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record)
     end
 
-    assert_equal(index_cmds.length, 2)
-    assert_equal(index_cmds.first['index']['_index'], nil)
+    assert_equal(2, index_cmds.length)
+    assert_equal(nil, index_cmds.first['index']['_index'])
   end
 
   def test_use_simple_sniffer

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -508,7 +508,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(9))
+    assert_equal(Time.at(time).iso8601(9), index_cmds[1]['@timestamp'])
   end
 
   def test_uses_subsecond_precision_when_configured
@@ -520,7 +520,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(time, sample_record)
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], Time.at(time).iso8601(3))
+    assert_equal(Time.at(time).iso8601(3), index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_timestamp_when_included_in_record
@@ -531,7 +531,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record.merge!('@timestamp' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_timestamp_when_included_in_record_logstash
@@ -542,7 +542,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record.merge!('@timestamp' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key_logstash
@@ -554,7 +554,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key_timestamp
@@ -566,7 +566,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
   end
 
   def test_uses_custom_time_key_timestamp_custom_index
@@ -579,7 +579,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record.merge!('vtm' => ts))
     end
     assert(index_cmds[1].has_key? '@timestamp')
-    assert_equal(index_cmds[1]['@timestamp'], ts)
+    assert_equal(ts, index_cmds[1]['@timestamp'])
     assert_equal('test', index_cmds.first['index']['_index'])
   end
 
@@ -622,7 +622,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record)
     end
     assert(index_cmds[1].has_key?('tag'))
-    assert_equal(index_cmds[1]['tag'], 'mytag')
+    assert_equal('mytag', index_cmds[1]['tag'])
   end
 
   def test_adds_id_key_when_configured
@@ -631,7 +631,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal(index_cmds[0]['index']['_id'], '42')
+    assert_equal('42', index_cmds[0]['index']['_id'])
   end
 
   class NestedIdKeyTest < self
@@ -641,7 +641,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_id'], '42')
+      assert_equal('42', index_cmds[0]['index']['_id'])
     end
 
     def test_adds_nested_id_key_with_dollar_dot
@@ -650,7 +650,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_id'], '42')
+      assert_equal('42', index_cmds[0]['index']['_id'])
     end
 
     def test_adds_nested_id_key_with_bracket
@@ -659,7 +659,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_id'], '42')
+      assert_equal('42', index_cmds[0]['index']['_id'])
     end
   end
 
@@ -686,7 +686,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
-    assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+    assert_equal('parent', index_cmds[0]['index']['_parent'])
   end
 
   class NestedParentKeyTest < self
@@ -696,7 +696,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+      assert_equal('parent', index_cmds[0]['index']['_parent'])
     end
 
     def test_adds_nested_parent_key_with_dollar_dot
@@ -705,7 +705,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+      assert_equal('parent', index_cmds[0]['index']['_parent'])
     end
 
     def test_adds_nested_parent_key_with_bracket
@@ -714,7 +714,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_parent'], 'parent')
+      assert_equal('parent', index_cmds[0]['index']['_parent'])
     end
   end
 
@@ -742,7 +742,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
 
     def test_es7
@@ -751,7 +751,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
-      assert_equal(index_cmds[0]['index']['routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['routing'])
     end
   end
 
@@ -762,7 +762,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
 
     def test_adds_nested_routing_key_with_dollar_dot
@@ -771,7 +771,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
 
     def test_adds_nested_routing_key_with_bracket
@@ -780,7 +780,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
-      assert_equal(index_cmds[0]['index']['_routing'], 'routing')
+      assert_equal('routing', index_cmds[0]['index']['_routing'])
     end
   end
 
@@ -874,7 +874,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
         driver.feed(sample_record)
       end
     }
-    assert_equal(connection_resets, 1)
+    assert_equal(1, connection_resets)
   end
 
   def test_reconnect_on_error_enabled
@@ -900,7 +900,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }
     # FIXME: Consider keywords arguments in #run and how to test this later.
     # Because v0.14 test driver does not have 1 to 1 correspondence between #run and #flush in tests.
-    assert_equal(connection_resets, 1)
+    assert_equal(1, connection_resets)
   end
 
   def test_reconnect_on_error_disabled
@@ -924,7 +924,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
         driver.feed(sample_record)
       end
     }
-    assert_equal(connection_resets, 1)
+    assert_equal(1, connection_resets)
   end
 
   def test_update_should_not_write_if_theres_no_id
@@ -995,7 +995,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       driver.feed(sample_record)
     end
 
-    assert_equal(index_cmds.length, 2)
-    assert_equal(index_cmds.first['index']['_index'], nil)
+    assert_equal(2, index_cmds.length)
+    assert_equal(nil, index_cmds.first['index']['_index'])
   end
 end


### PR DESCRIPTION
Fix arguments order of `assert_equal`.
First argument is expected result.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
