### PR TITLE
Enable ElasticsearchSimpleSniffer for candidate sniffer classes

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -18,6 +18,7 @@ require_relative 'elasticsearch_constants'
 require_relative 'elasticsearch_error'
 require_relative 'elasticsearch_error_handler'
 require_relative 'elasticsearch_index_template'
+require_relative 'elasticsearch_simple_sniffer'
 begin
   require_relative 'oj_serializer'
 rescue LoadError


### PR DESCRIPTION
ElasticsearchSimpleSniffer is a option for sniffer_class_name
configuration. It is implemented and tested well, but it can not
be used in real service due to missing of require. So just enable
this option as adding require for elasticsearch_simple_sniffer file

It is subsequent PR after https://github.com/uken/fluent-plugin-elasticsearch/pull/461. At the https://github.com/uken/fluent-plugin-elasticsearch/pull/461, ElasticsearchSimpleSniffer class is implemented and tested, but it is not applied in out_elasticsearch.rb for real usage.

If there is no require for elasticsearch_simple_sniffer.rb in out_elasticsearch.rb and configure to use Fluent::Plugin::ElasticsearchSimpleSniffer as README, there will be error like below.

`[error]: config error file="/etc/td-agent/td-agent.conf" error_class=Fluent::ConfigError error="Could not load sniffer class Fluent::Plugin::ElasticsearchSimpleSniffer: uninitialized constant Fluent::Plugin::ElasticsearchSimpleSniffer\nDid you mean?  Fluent::ElasticsearchIndexTemplate"`

So I request to enable ElasticsearchSimpleSniffer option for real usage. Thanks.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
