### PR TITLE
Supporess `ruby -c` warnings

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -27,7 +27,7 @@ class Fluent::Plugin::ElasticsearchErrorHandler
     if @plugin.log_es_400_reason
       block.call
     else
-      @plugin.log.on_debug &block
+      @plugin.log.on_debug(&block)
     end
   end
 

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -57,7 +57,7 @@ module Fluent::ElasticsearchIndexTemplate
 
   def indexcreation(index_name)
     client.indices.create(:index => index_name)
-    rescue Elasticsearch::Transport::Transport::Error => e
+  rescue Elasticsearch::Transport::Transport::Error => e
       log.error("Error while index creation - #{index_name}: #{e.inspect}")
   end
 


### PR DESCRIPTION
Just for suppressing `ruby -c` warnings tweaks.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
