### PR TITLE
Set order in newly created templates

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -119,6 +119,7 @@ module Fluent::ElasticsearchIndexTemplate
     log.debug("Overwriting index patterns when Index Lifecycle Management is enabled.")
     template.delete('template') if template.include?('template')
     template['index_patterns'] = "#{deflector_alias_name}-*"
+    template['order'] = template['order'] ? template['order'] + deflector_alias_name.split('-').length : 50 + deflector_alias_name.split('-').length
     if template['settings'] && (template['settings']['index.lifecycle.name'] || template['settings']['index.lifecycle.rollover_alias'])
       log.debug("Overwriting index lifecycle name and rollover alias when Index Lifecycle Management is enabled.")
     end


### PR DESCRIPTION
This fix solves issue when deflector alias name contains dashes.
For example:

- having deflector_alias fluentd.kube.app.grafana will create index
  template for pattern fluentd.kube.app.grafana-*

- another deflector_alias fluentd.kube.app.grafana-another-one will
  create index template for pattern fluentd.kube.app.grafana-another-one-*
  which conflicts with previous pattern

Above case will cause that newly created indexes will have
undeterministic rollover index alias.

To fix such situations, templates with more dashes in index pattern needs to be applied last.

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
