### PR TITLE
Support compression feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Current maintainers: @cosmo0920
   + [include_index_in_url](#include_index_in_url)
   + [http_backend](#http_backend)
   + [prefer_oj_serializer](#prefer_oj_serializer)
+  + [compression_level](#compression_level)
   + [Client/host certificate options](#clienthost-certificate-options)
   + [Proxy Support](#proxy-support)
   + [Buffer options](#buffer-options)
@@ -791,6 +792,13 @@ Default value is `excon` which is default http_backend of elasticsearch plugin.
 ```
 http_backend typhoeus
 ```
+
+### compression_level
+You can add gzip compression of output data. In this case `default_compression`, `best_compression` or `best speed` option should be chosen. 
+By default there is no compression, default value for this option is `no_compression`
+```
+compression_level best_compression
+``` 
 
 ### prefer_oj_serializer
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -470,7 +470,11 @@ EOC
           local_reload_connections = @reload_after
         end
 
-        gzip_headers = if compression then {'Content-Encoding' => 'gzip'} else {} end
+        gzip_headers = if compression
+                         {'Content-Encoding' => 'gzip'}
+                       else
+                         {}
+                       end
         headers = { 'Content-Type' => @content_type.to_s }.merge(@custom_headers).merge(gzip_headers)
 
         transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
@@ -836,7 +840,11 @@ EOC
 
         log.on_trace { log.trace "bulk request: #{data}" }
 
-        prepared_data = if compression then gzip(data) else data end
+        prepared_data = if compression
+                          gzip(data)
+                        else
+                          data
+                        end
 
         response = client(info.host).bulk body: prepared_data, index: info.index
         log.on_trace { log.trace "bulk response: #{response}" }

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -18,6 +18,7 @@ require 'fluent/event'
 require 'fluent/error'
 require 'fluent/time'
 require 'fluent/log-ext'
+require 'zlib'
 require_relative 'elasticsearch_constants'
 require_relative 'elasticsearch_error'
 require_relative 'elasticsearch_error_handler'
@@ -148,6 +149,7 @@ EOC
     config_param :ignore_exceptions, :array, :default => [], value_type: :string, :desc => "Ignorable exception list"
     config_param :exception_backup, :bool, :default => true, :desc => "Chunk backup flag when ignore exception occured"
     config_param :bulk_message_request_threshold, :size, :default => TARGET_BULK_BYTES
+    config_param :compression_level, :enum, {list: [:no_compression, :best_speed, :best_compression, :default_compression], :default => :no_compression}
     config_param :enable_ilm, :bool, :default => false
     config_param :ilm_policy_id, :string, :default => DEFAULT_POLICY_ID
     config_param :ilm_policy, :hash, :default => {}
@@ -327,6 +329,18 @@ EOC
           alias_method :split_request?, :split_request_size_check?
         end
       end
+
+      version_arr = Elasticsearch::Transport::VERSION.split('.')
+
+      if (version_arr[0].to_i < 7) || (version_arr[0].to_i == 7 && version_arr[1].to_i < 2)
+        if compression
+          raise Fluent::ConfigError, <<-EOC
+            Cannot use compression with elasticsearch-transport plugin version < 7.2.0
+            Your elasticsearch-transport plugin version version is #{Elasticsearch::Transport::VERSION}.
+            Please consider to upgrade ES client.
+          EOC
+        end
+      end
     end
 
     def placeholder?(name, param)
@@ -335,6 +349,23 @@ EOC
         true
       rescue Fluent::ConfigError
         false
+      end
+    end
+
+    def compression
+      !(@compression_level == :no_compression)
+    end
+
+    def compression_strategy
+      case @compression_level
+      when :default_compression
+        Zlib::DEFAULT_COMPRESSION
+      when :best_compression
+        Zlib::BEST_COMPRESSION
+      when :best_speed
+        Zlib::BEST_SPEED
+      else
+        Zlib::NO_COMPRESSION
       end
     end
 
@@ -438,7 +469,10 @@ EOC
         if local_reload_connections && @reload_after > DEFAULT_RELOAD_AFTER
           local_reload_connections = @reload_after
         end
-        headers = { 'Content-Type' => @content_type.to_s }.merge(@custom_headers)
+
+        gzip_headers = if compression then {'Content-Encoding' => 'gzip'} else {} end
+        headers = { 'Content-Type' => @content_type.to_s }.merge(@custom_headers).merge(gzip_headers)
+
         transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
                                                                               reload_connections: local_reload_connections,
@@ -456,6 +490,7 @@ EOC
                                                                               },
                                                                               sniffer_class: @sniffer_class,
                                                                               serializer_class: @serializer_class,
+                                                                              compression: compression,
                                                                             }), &adapter_conf)
         Elasticsearch::Client.new transport: transport
       end
@@ -768,6 +803,15 @@ EOC
       [parent_object, path[-1]]
     end
 
+    # gzip compress data
+    def gzip(string)
+      wio = StringIO.new("w")
+      w_gz = Zlib::GzipWriter.new(wio, strategy = compression_strategy)
+      w_gz.write(string)
+      w_gz.close
+      wio.string
+    end
+
     # send_bulk given a specific bulk request, the original tag,
     # chunk, and bulk_message_count
     def send_bulk(data, tag, chunk, bulk_message_count, extracted_values, info)
@@ -791,7 +835,10 @@ EOC
       begin
 
         log.on_trace { log.trace "bulk request: #{data}" }
-        response = client(info.host).bulk body: data, index: info.index
+
+        prepared_data = if compression then gzip(data) else data end
+
+        response = client(info.host).bulk body: prepared_data, index: info.index
         log.on_trace { log.trace "bulk response: #{response}" }
 
         if response['errors']

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -44,6 +44,8 @@ module Fluent::Plugin
       @_es ||= begin
         @current_config = connection_options[:hosts].clone
         adapter_conf = lambda {|f| f.adapter @http_backend, @backend_options }
+        gzip_headers = if compression then {'Content-Encoding' => 'gzip'} else {} end
+        headers = { 'Content-Type' => @content_type.to_s, }.merge(gzip_headers)
         transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
                                                                               reload_connections: @reload_connections,
@@ -51,14 +53,15 @@ module Fluent::Plugin
                                                                               resurrect_after: @resurrect_after,
                                                                               logger: @transport_logger,
                                                                               transport_options: {
-                                                                                headers: { 'Content-Type' => @content_type.to_s },
+                                                                                headers: headers,
                                                                                 request: { timeout: @request_timeout },
                                                                                 ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
                                                                               },
                                                                               http: {
                                                                                 user: @user,
                                                                                 password: @password
-                                                                              }
+                                                                              },
+                                                                              compression: compression,
                                                                             }), &adapter_conf)
         Elasticsearch::Client.new transport: transport
       end
@@ -210,7 +213,8 @@ module Fluent::Plugin
 
     def send_bulk(data, host, index)
       begin
-        response = client(host).bulk body: data, index: index
+        prepared_data = if compression then gzip(data) else data end
+        response = client(host).bulk body: prepared_data, index: index
         if response['errors']
           log.error "Could not push log to Elasticsearch: #{response}"
         end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -44,7 +44,11 @@ module Fluent::Plugin
       @_es ||= begin
         @current_config = connection_options[:hosts].clone
         adapter_conf = lambda {|f| f.adapter @http_backend, @backend_options }
-        gzip_headers = if compression then {'Content-Encoding' => 'gzip'} else {} end
+        gzip_headers = if compression
+                         {'Content-Encoding' => 'gzip'}
+                       else
+                         {}
+                       end
         headers = { 'Content-Type' => @content_type.to_s, }.merge(gzip_headers)
         transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
@@ -213,7 +217,11 @@ module Fluent::Plugin
 
     def send_bulk(data, host, index)
       begin
-        prepared_data = if compression then gzip(data) else data end
+        prepared_data = if compression
+                          gzip(data)
+                        else
+                          data
+                        end
         response = client(host).bulk body: prepared_data, index: index
         if response['errors']
           log.error "Could not push log to Elasticsearch: #{response}"

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1831,7 +1831,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
     compressed_body = gzip(bodystr, Zlib::DEFAULT_COMPRESSION)
 
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-        to_return(:status => 200, :headers => {"Content-Type": "Application/json"}, :body => compressed_body)
+        to_return(:status => 200, :headers => {'Content-Type' => 'Application/json'}, :body => compressed_body)
 
     driver(config)
     driver.run(default_tag: 'test') do

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1812,7 +1812,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   def test_writes_to_default_index_with_compression
     config = %[
-      compression_level best_compression
+      compression_level default_compression
     ]
 
     bodystr = %({

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -232,6 +232,44 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal Fluent::Plugin::ElasticsearchOutput::DEFAULT_ELASTICSEARCH_VERSION, instance.default_elasticsearch_version
     assert_false instance.log_es_400_reason
     assert_equal 20 * 1024 * 1024, Fluent::Plugin::ElasticsearchOutput::TARGET_BULK_BYTES
+    assert_false instance.compression
+    assert_equal :no_compression, instance.compression_level
+  end
+
+  test 'configure compression' do
+    config = %{
+      compression_level best_compression
+    }
+    instance = driver(config).instance
+
+    assert_equal true, instance.compression
+  end
+
+  test 'check compression strategy' do
+    config = %{
+      compression_level best_speed
+    }
+    instance = driver(config).instance
+
+    assert_equal Zlib::BEST_SPEED, instance.compression_strategy
+  end
+
+  test 'check content-encoding header with compression' do
+    config = %{
+      compression_level best_compression
+    }
+    instance = driver(config).instance
+
+    assert_equal "gzip", instance.client.transport.options[:transport_options][:headers]["Content-Encoding"]
+  end
+
+  test 'check compression option is passed to transport' do
+    config = %{
+      compression_level best_compression
+    }
+    instance = driver(config).instance
+
+    assert_equal true, instance.client.transport.options[:compression]
   end
 
   test 'configure Content-Type' do
@@ -1760,6 +1798,47 @@ class ElasticsearchOutput < Test::Unit::TestCase
       driver.feed(sample_record)
     end
     assert_equal(index_name, index_cmds.first['index']['_index'])
+  end
+
+  # gzip compress data
+  def gzip(string, strategy)
+    wio = StringIO.new("w")
+    w_gz = Zlib::GzipWriter.new(wio, strategy = strategy)
+    w_gz.write(string)
+    w_gz.close
+    wio.string
+  end
+
+
+  def test_writes_to_default_index_with_compression
+    config = %[
+      compression_level best_compression
+    ]
+
+    bodystr = %({
+          "took" : 500,
+          "errors" : false,
+          "items" : [
+            {
+              "create": {
+                "_index" : "fluentd",
+                "_type"  : "fluentd"
+              }
+            }
+           ]
+        })
+
+    compressed_body = gzip(bodystr, Zlib::DEFAULT_COMPRESSION)
+
+    elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+        to_return(:status => 200, :headers => {"Content-Type": "Application/json"}, :body => compressed_body)
+
+    driver(config)
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+
+    assert_requested(elastic_request)
   end
 
   data('Elasticsearch 6' => [6, Fluent::Plugin::ElasticsearchOutput::DEFAULT_TYPE_NAME],

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -373,7 +373,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     compressed_body = gzip(bodystr, Zlib::DEFAULT_COMPRESSION)
 
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
-        to_return(:status => 200, :headers => {"Content-Type": "Application/json"}, :body => compressed_body)
+        to_return(:status => 200, :headers => {'Content-Type' => 'Application/json'}, :body => compressed_body)
 
     driver(config)
     driver.run(default_tag: 'test') do


### PR DESCRIPTION
Compression feature is added. You can set compression_level option choosing one of the values: 'default_compression', 'best_compression', 'best_speed'. There is also 'no_compression' value when compression isn't needed which is used by default.

- [x] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
