### PR TITLE
Allow _index in chunk_keys

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -170,7 +170,7 @@ EOC
       compat_parameters_convert(conf, :buffer)
 
       super
-      raise Fluent::ConfigError, "'tag' in chunk_keys is required." if not @chunk_key_tag
+      raise Fluent::ConfigError, "'tag' or '_index' in chunk_keys is required." if not @buffer_config.chunk_keys.include? "tag" and not @buffer_config.chunk_keys.include? "_index"
 
       @time_parser = create_time_parser
       @backend_options = backend_options

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -341,23 +341,65 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
   end
 
-  test 'lack of tag in chunk_keys' do
-    assert_raise_message(/'tag' in chunk_keys is required./) do
-      driver(Fluent::Config::Element.new(
-               'ROOT', '', {
-                 '@type' => 'elasticsearch',
-                 'host' => 'log.google.com',
-                 'port' => 777,
-                 'scheme' => 'https',
-                 'path' => '/es/',
-                 'user' => 'john',
-                 'password' => 'doe',
-               }, [
-                 Fluent::Config::Element.new('buffer', 'mykey', {
-                                               'chunk_keys' => 'mykey'
-                                             }, [])
-               ]
-             ))
+  sub_test_case 'chunk_keys requirement' do
+    test 'tag in chunk_keys' do
+      assert_nothing_raised do
+        driver(Fluent::Config::Element.new(
+                 'ROOT', '', {
+                   '@type' => 'elasticsearch',
+                   'host' => 'log.google.com',
+                   'port' => 777,
+                   'scheme' => 'https',
+                   'path' => '/es/',
+                   'user' => 'john',
+                   'password' => 'doe',
+                 }, [
+                   Fluent::Config::Element.new('buffer', 'tag', {
+                                                 'chunk_keys' => 'tag'
+                                               }, [])
+                 ]
+               ))
+      end
+    end
+
+    test '_index in chunk_keys' do
+      assert_nothing_raised do
+        driver(Fluent::Config::Element.new(
+                 'ROOT', '', {
+                   '@type' => 'elasticsearch',
+                   'host' => 'log.google.com',
+                   'port' => 777,
+                   'scheme' => 'https',
+                   'path' => '/es/',
+                   'user' => 'john',
+                   'password' => 'doe',
+                 }, [
+                   Fluent::Config::Element.new('buffer', '_index', {
+                                                 'chunk_keys' => '_index'
+                                               }, [])
+                 ]
+               ))
+      end
+    end
+
+    test 'lack of tag and _index in chunk_keys' do
+      assert_raise_message(/'tag' or '_index' in chunk_keys is required./) do
+        driver(Fluent::Config::Element.new(
+                 'ROOT', '', {
+                   '@type' => 'elasticsearch',
+                   'host' => 'log.google.com',
+                   'port' => 777,
+                   'scheme' => 'https',
+                   'path' => '/es/',
+                   'user' => 'john',
+                   'password' => 'doe',
+                 }, [
+                   Fluent::Config::Element.new('buffer', 'mykey', {
+                                                 'chunk_keys' => 'mykey'
+                                               }, [])
+                 ]
+               ))
+      end
     end
   end
 


### PR DESCRIPTION
To support defining index in record field. This is using placeholders so it requires to use `_index` field in buffer and ensure it exists in all records. This is similar feature like `target_index_key` but more robust. It's only configuration but it requires to change config check.

Example usage:

```
<filter systemd.**>
  @type record_transformer
  enable_ruby true
  auto_typecast true
  <record>
    _index ${record['_index'].class == String ? record['_index'] : "systemd"}
    types _index:string
  </record>
</filter>
<filter **>
  @type record_transformer
  enable_ruby true
  auto_typecast true
  <record>
    _index ${record['index'].class == String ? record['_index'] : tag}
    types _index:string
  </record>
</filter>

<match **>
  <store>
    @type elasticsearch
    @id out_es
    @log_level info
    id_key _hash
    remove_keys _hash,_index
    log_es_400_reason true
    include_tag_key true
    include_timestamp true
    time_key time
    flatten_hashes true
    flatten_hashes_separator .
    index_name ${_index}
    # Rollover index configuration
    rollover_index true
    deflector_alias ${_index}
    index_prefix ""
    application_name ${_index}
    index_separator ""
    index_date_pattern "now/d"
    enable_ilm true
    # Policy is already created by init container so fluentd will skip it's creation
    ilm_policy {}
    ilm_policy_id fluentd-policy
    # Template name is not used if ilm is in effect but it's mandatory parameter
    template_name fluentd
    template_file /fluentd/etc/fluentd-template.json
    customize_template {"<<index_prefix>>": ""}

    ssl_version TLSv1_2
    reload_connections false
    reconnect_on_error true
    reload_on_failure true
    type_name fluentd
    request_timeout 120s

    <buffer tag,_index,time>
      @type memory
      chunk_keys _index
      timekey 60
      total_limit_size 128M
      chunk_limit_size 16M
      overflow_action block
      chunk_full_threshold 0.9
      compress gzip       # text,gzip
      flush_mode interval # default,interval,immediate,lazy
      flush_interval 10s
      flush_at_shutdown true
      flush_thread_count 4
    </buffer>

    host "elasticsearch"
    port "9200"
    scheme "http"
    ssl_verify true
  </store>
</match>
```

DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
