### PR TITLE
retry upsert on recoverable error.

### DIFF
--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -60,6 +60,8 @@ class Fluent::Plugin::ElasticsearchErrorHandler
         write_operation = @plugin.write_operation
       elsif INDEX_OP == @plugin.write_operation && item.is_a?(Hash) && item.has_key?(CREATE_OP)
         write_operation = CREATE_OP
+      elsif UPSERT_OP == @plugin.write_operation && item.is_a?(Hash) && item.has_key?(UPDATE_OP)
+        write_operation = UPDATE_OP
       elsif item.nil?
         stats[:errors_nil_resp] += 1
         next


### PR DESCRIPTION
### Problem
When write_operation is set to 'upsert', plugin does not retry to send on recoverable error such as conflict.
I think this is unexpected behavior because I could not find related issues.

The main cause is that ElasticsearchErrorHandler can not retrive operation in response correctly.
This is because ES's response does not contain 'upsert', but 'update' as operation.

* target code snipet
https://github.com/uken/fluent-plugin-elasticsearch/blob/eb5ba52ddd6825d1e60bad6d08c6d5ef1e2904f1/lib/fluent/plugin/elasticsearch_error_handler.rb#L59-L71

* A part of ES response when upsert bulk is requested
`
{"took":20,"errors":true,"items":[{"update":{"_index":"hoge","_type":"_doc","_id":"hoge","status":409,"error":{"type":"version_conflict_engine_exception","reason":"[_doc][hoge]: version conflict, document already exists (current version [1])", .....
`

### How to solve
As index, tweak write_operation.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
