### PR TITLE
Fix access to Elasticsearch::Transport::VERSION with explicit top level class path

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -330,7 +330,7 @@ EOC
         end
       end
 
-      version_arr = Elasticsearch::Transport::VERSION.split('.')
+      version_arr = ::Elasticsearch::Transport::VERSION.split('.')
 
       if (version_arr[0].to_i < 7) || (version_arr[0].to_i == 7 && version_arr[1].to_i < 2)
         if compression


### PR DESCRIPTION
Fluentd is failing to start with this `Gemfile` configuration under Ruby 2.5.1:

```
source 'https://rubygems.org'

gem 'fluent-plugin-aws-elasticsearch-service', '~> 2.2.0'
gem 'fluent-plugin-grok-parser', '~> 2.1.3'
gem 'fluentd', '~> 1.7.4'
gem 'fluent-plugin-splunk-hec', '~> 1.1.2'
```

The error during startup is:

```
bundler: failed to load command: fluentd (/opt/ruby-2.5.1/bin/fluentd)
NameError: uninitialized constant Fluent::Plugin::ElasticsearchOutput::Elasticsearch::Transport::VERSION
Did you mean?  Fluent::VERSION
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluent-plugin-elasticsearch-3.6.1/lib/fluent/plugin/out_elasticsearch.rb:333:in `configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/plugin.rb:164:in `configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/agent.rb:130:in `add_match'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/agent.rb:72:in `block in configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/agent.rb:64:in `each'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/agent.rb:64:in `configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/root_agent.rb:150:in `configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/engine.rb:131:in `configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/engine.rb:96:in `run_configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:812:in `run_configure'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:589:in `dry_run'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:607:in `supervise'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/supervisor.rb:512:in `run_supervisor'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/lib/fluent/command/fluentd.rb:324:in `<top (required)>'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/bin/fluentd:8:in `require'
  /opt/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/fluentd-1.7.4/bin/fluentd:8:in `<top (required)>'
  /opt/ruby-2.5.1/bin/fluentd:23:in `load'
  /opt/ruby-2.5.1/bin/fluentd:23:in `<top (required)>'
```

It looks like the error is happening because we're using a relative class path instead of an absolute class path to check the elasticsearch-transport version.

I was unable to reproduce this behavior in test, unfortunately. `test_configure` in `test_out_elasticsearch.rb` passes when using either variant below: 


```
version_arr = Elasticsearch::Transport::VERSION.split('.')
```

OR

```
version_arr = ::Elasticsearch::Transport::VERSION.split('.')
```

This PR addresses using the latter case, as it does not break the code, but does fix the error in our system with our Gemfile configuration. 

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
