### PR TITLE
Make conpatible for Fluentd v1.8

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -204,7 +204,7 @@ EOC
       end
 
       @alias_indexes = []
-      if !Fluent::Engine.dry_run_mode
+      if !dry_run?
         if @template_name && @template_file
           if @rollover_index
             raise Fluent::ConfigError, "'deflector_alias' must be provided if 'rollover_index' is set true ." if not @deflector_alias
@@ -257,7 +257,7 @@ EOC
       end
 
       @last_seen_major_version =
-        if @verify_es_version_at_startup && !Fluent::Engine.dry_run_mode
+        if @verify_es_version_at_startup && !dry_run?
           retry_operate(@max_retry_get_es_version) do
             detect_es_major_version
           end
@@ -276,7 +276,7 @@ EOC
         @type_name = nil
       end
 
-      if @validate_client_version && !Fluent::Engine.dry_run_mode
+      if @validate_client_version && !dry_run?
         if @last_seen_major_version != client_library_version.to_i
           raise Fluent::ConfigError, <<-EOC
             Detected ES #{@last_seen_major_version} but you use ES client #{client_library_version}.
@@ -326,6 +326,14 @@ EOC
         class << self
           alias_method :split_request?, :split_request_size_check?
         end
+      end
+    end
+
+    def dry_run?
+      if Fluent::Engine.respond_to?(:dry_run_mode)
+        Fluent::Engine.dry_run_mode
+      elsif Fluent::Engine.respond_to?(:supervisor_mode)
+        Fluent::Engine.supervisor_mode
       end
     end
 


### PR DESCRIPTION
Fluentd v1.8 will remove `Fluent::Engine.dry_run_mode`.
So, we should adopt this change.

ref: https://github.com/fluent/fluentd/pull/2651

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
