### PR TITLE
Retry upsert on recoverable error. (porting to v0.12) #667

### DIFF
--- a/lib/fluent/log-ext.rb
+++ b/lib/fluent/log-ext.rb
@@ -1,0 +1,38 @@
+require 'fluent/log'
+# For elasticsearch-ruby v7.0.0 or later
+# logger for Elasticsearch::Loggable required the following methods:
+#
+# * debug?
+# * info?
+# * warn?
+# * error?
+# * fatal?
+
+module Fluent
+  class Log
+    # Elasticsearch::Loggable does not request trace? method.
+    # def trace?
+    #   @level <= LEVEL_TRACE
+    # end
+
+    def debug?
+      @level <= LEVEL_DEBUG
+    end
+
+    def info?
+      @level <= LEVEL_INFO
+    end
+
+    def warn?
+      @level <= LEVEL_WARN
+    end
+
+    def error?
+      @level <= LEVEL_ERROR
+    end
+
+    def fatal?
+      @level <= LEVEL_FATAL
+    end
+  end
+end

--- a/lib/fluent/plugin/elasticsearch_error_handler.rb
+++ b/lib/fluent/plugin/elasticsearch_error_handler.rb
@@ -40,6 +40,8 @@ class Fluent::ElasticsearchErrorHandler
         write_operation = @plugin.write_operation
       elsif INDEX_OP == @plugin.write_operation && item.has_key?(CREATE_OP)
         write_operation = CREATE_OP
+      elsif UPSERT_OP == @plugin.write_operation && item.has_key?(UPDATE_OP)
+        write_operation = UPDATE_OP
       else
         # When we don't have an expected ops field, something changed in the API
         # expected return values (ES 2.x)

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -11,6 +11,7 @@ end
 
 require 'fluent/output'
 require 'fluent/event'
+require 'fluent/log-ext'
 require_relative 'elasticsearch_constants'
 require_relative 'elasticsearch_error_handler'
 require_relative 'elasticsearch_index_template'

--- a/test/test_log-ext.rb
+++ b/test/test_log-ext.rb
@@ -1,0 +1,35 @@
+require 'helper'
+require 'fluent/log-ext'
+
+class TestFluentLogExtHandler < Test::Unit::TestCase
+  def setup
+    @log_device = Fluent::Test::DummyLogDevice.new
+    dl_opts = {:log_level => ServerEngine::DaemonLogger::INFO}
+    logger = ServerEngine::DaemonLogger.new(@log_device, dl_opts)
+    @log = Fluent::Log.new(logger)
+  end
+
+  def test_trace?
+    assert_false @log.respond_to?(:trace?)
+  end
+
+  def test_debug?
+    assert_true @log.respond_to?(:debug?)
+  end
+
+  def test_info?
+    assert_true @log.respond_to?(:info?)
+  end
+
+  def test_warn?
+    assert_true @log.respond_to?(:warn?)
+  end
+
+  def test_error?
+    assert_true @log.respond_to?(:error?)
+  end
+
+  def test_fatal?
+    assert_true @log.respond_to?(:fatal?)
+  end
+end

--- a/test/test_log-ext.rb
+++ b/test/test_log-ext.rb
@@ -3,10 +3,8 @@ require 'fluent/log-ext'
 
 class TestFluentLogExtHandler < Test::Unit::TestCase
   def setup
-    @log_device = Fluent::Test::DummyLogDevice.new
-    dl_opts = {:log_level => ServerEngine::DaemonLogger::INFO}
-    logger = ServerEngine::DaemonLogger.new(@log_device, dl_opts)
-    @log = Fluent::Log.new(logger)
+    @log = Fluent::Test::TestLogger.new
+    @log.level = "info"
   end
 
   def test_trace?


### PR DESCRIPTION
This patch is #667 and #583 porting to v0.12.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
