### PR TITLE
Unblocking buffer overflow with block action

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -863,6 +863,7 @@ EOC
           error.handle_error(response, tag, chunk, bulk_message_count, extracted_values)
         end
       rescue RetryStreamError => e
+        log.trace "router.emit_stream for retry stream doing..."
         emit_tag = @retry_tag ? @retry_tag : tag
         # check capacity of buffer space
         if @buffer.storable?
@@ -870,6 +871,7 @@ EOC
         else
           raise RetryStreamEmitFailure, "buffer is full."
         end
+        log.trace "router.emit_stream for retry stream done."
       rescue => e
         ignore = @ignore_exception_classes.any? { |clazz| e.class <= clazz }
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -866,7 +866,7 @@ EOC
         log.trace "router.emit_stream for retry stream doing..."
         emit_tag = @retry_tag ? @retry_tag : tag
         # check capacity of buffer space
-        if @buffer.storable?
+        if retry_stream_retryable?
           router.emit_stream(emit_tag, e.retry_stream)
         else
           raise RetryStreamEmitFailure, "buffer is full."
@@ -885,6 +885,10 @@ EOC
         # FIXME: identify unrecoverable errors and raise UnrecoverableRequestFailure instead
         raise RecoverableRequestFailure, "could not push logs to Elasticsearch cluster (#{connection_options_description(info.host)}): #{e.message}" unless ignore
       end
+    end
+
+    def retry_stream_retryable?
+      @buffer.storable?
     end
 
     def is_existing_connection(host)


### PR DESCRIPTION
Fixes #625 
Fixes #609
Fixes https://github.com/fluent/fluentd/issues/2580
Fixes https://github.com/fluent/fluentd/issues/2533

Fluentd stuck was occurred with the following scenario:

* flushing thread try Output::write
* fluent-plugin-elasticsearch try to write
* It fails to write since Elasticsearch is freezed
* It try Output::emit_buffered to write back the chunk
* It cannot write to the buffer since buffer is full.
* When overflow_action is :block, it can't return from the following loop because write of fluent-plugin-elasticsearch never be called until exiting from this loop:
  * https://github.com/fluent/fluentd/blob/fcef949ce40472547fde295ddd2cfe297e1eddd6/lib/fluent/plugin/output.rb#L896-L904
* It can't recover even if Elasticsearch is unfreezed since above infinite loop never exit.

RetryStream feature is for sending another Elasticsearch cluster instead of exhausted Elasticsearch destination.
But previous implementation for RetryStream caontains dangerous
operation when buffer is fulfilled another buffer.

Co-authored-by: Ashie Takuro <ashie@clear-code.com>

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
