### PR TITLE
Reduce log noise when not using rollover_index

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -152,7 +152,7 @@ module Fluent::ElasticsearchIndexTemplate
         log.debug("The alias '#{deflector_alias_name}' is already present")
       end
     else
-      log.info("No index and alias creation action performed because rollover_index is set to '#{rollover_index}'")
+      log.debug("No index and alias creation action performed because rollover_index is set to '#{rollover_index}'")
     end
   end
 


### PR DESCRIPTION
Humbly suggest that this message should be at "debug" level instead of info.

The message is highlighting that we did not do something, because the configuration is not set to do that.  For rollover_index case, I think this matches expectations, so we should not need not emphasize so much.

The function is called often, here: https://github.com/uken/fluent-plugin-elasticsearch/blob/7282f515e4be2d18709ac6b516de67acc784ff3d/lib/fluent/plugin/out_elasticsearch.rb#L842