### PR TITLE
fix typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ And rollover\_index is also used in Lifecycle Index Management(ILM) feature.
 index_date_pattern "now/w{xxxx.ww}" # defaults to "now/d"
 ```
 
-If empty string(`""`) is specified in `index_date_patter`, index date pattern is not used.
+If empty string(`""`) is specified in `index_date_pattern`, index date pattern is not used.
 Elasticsearch plugin just creates <`index_prefix`-`application_name`-000001> rollover index instead of <`index_prefix`-`application_name`-`{index_date_pattern}`-000001>.
 
 If [customize_template](#customize_template) is set, then this parameter will be in effect otherwise ignored.


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
