### PR TITLE
Restructuring ILM related features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1606,9 +1606,10 @@ When using `deflectoe_alias` parameter, Elasticsearch plugin will create ILM tar
 And also, ILM feature users should specify their Elasticsearch template for ILM enabled indices.
 Because ILM settings are injected into their Elasticsearch templates.
 
+#### Example ILM settings
+
 ```aconf
 index_name fluentd-${tag}
-# Should specify rollover_index as true
 application_name ${tag}
 index_date_pattern "now/d"
 enable_ilm true
@@ -1617,10 +1618,43 @@ ilm_policy_id fluentd-policy
 # ilm_policy {} # Use default policy
 template_name your-fluentd-template
 template_file /path/to/fluentd-template.json
-customize_template {"<<index_prefix>>": "fluentd"}
+# customize_template {"<<index_prefix>>": "fluentd"}
 ```
 
 Note: This plugin only creates rollover-enabled indices, which are aliases pointing to them and index templates, and creates an ILM policy if enabled.
+
+#### Create ILM indices in each day
+
+If you want to create new index in each day, you should use `logstash_format` style configuration:
+
+```aconf
+logstash_prefix fluentd
+application_name default
+index_date_pattern "now/d"
+enable_ilm true
+# Policy configurations
+ilm_policy_id fluentd-policy
+# ilm_policy {} # Use default policy
+template_name your-fluentd-template
+template_file /path/to/fluentd-template.json
+```
+
+#### Fixed ILM indices
+
+Also, users can use fixed ILM indices configuration.
+If `index_date_pattern` is set as `""`(empty string), Elasticsearch plugin won't attach date pattern in ILM indices:
+
+```aconf
+index_name fluentd
+application_name default
+index_date_pattern ""
+enable_ilm true
+# Policy configurations
+ilm_policy_id fluentd-policy
+# ilm_policy {} # Use default policy
+template_name your-fluentd-template
+template_file /path/to/fluentd-template.json
+```
 
 ### How to specify index codec
 

--- a/README.md
+++ b/README.md
@@ -435,15 +435,14 @@ Specify this to override the index date pattern for creating a rollover index. T
 for example: <logstash-default-{now/d}-000001>. Overriding this changes the rollover time period. Setting
 "now/w{xxxx.ww}" would create weekly rollover indexes instead of daily.
 
-This setting only takes effect when combined with the [rollover_index](#rollover_index) setting.
+This setting only takes effect when combined with the [enable_ilm](#enable_ilm) setting.
 
-And rollover\_index is also used in Lifecycle Index Management(ILM) feature.
 ```
 index_date_pattern "now/w{xxxx.ww}" # defaults to "now/d"
 ```
 
 If empty string(`""`) is specified in `index_date_pattern`, index date pattern is not used.
-Elasticsearch plugin just creates <`index_prefix`-`application_name`-000001> rollover index instead of <`index_prefix`-`application_name`-`{index_date_pattern}`-000001>.
+Elasticsearch plugin just creates <`target_index`-`application_name`-000001> rollover index instead of <`target_index`-`application_name`-`{index_date_pattern}`-000001>.
 
 If [customize_template](#customize_template) is set, then this parameter will be in effect otherwise ignored.
 
@@ -458,12 +457,9 @@ If [rollover_index](#rollover_index) is set, then this parameter will be in effe
 
 ### index_prefix
 
-Specify the index prefix for the rollover index to be created.
-```
-index_prefix mylogs # defaults to "logstash"
-```
-
-If [rollover_index](#rollover_index) is set, then this parameter will be in effect otherwise ignored.
+This parameter is marked as obsoleted.
+Consider to use [index_name](#index_name) for specify ILM target index when not using with logstash_format.
+When specifying `logstash_format` as true, consider to use [logstash_prefix](#logstash_prefix) to specify ILM target index prefix.
 
 ### application_name
 
@@ -472,7 +468,7 @@ Specify the application name for the rollover index to be created.
 application_name default # defaults to "default"
 ```
 
-If [rollover_index](#rollover_index) is set, then this parameter will be in effect otherwise ignored.
+If [enable_ilm](#enable_ilm is set, then this parameter will be in effect otherwise ignored.
 
 ### template_overwrite
 
@@ -1593,13 +1589,19 @@ Index lifecycle management is template based index management feature.
 
 Main ILM feature parameters are:
 
-* `rollover_index`
-* `deflector_alias`
+* `index_name` (when logstash_format as false)
+* `logstash_prefix` (when logstash_format as true)
 * `enable_ilm`
 * `ilm_policy_id`
 * `ilm_policy`
 
 They are not all mandatory parameters but they are used for ILM feature in effect.
+
+ILM target index alias is created with `index_name` or an index which is calculated from `logstash_prefix`.
+
+From Elasticsearch plugin v4.0.0, ILM target index will be calculated from `index_name` (normal mode) or `logstash_prefix` (using with `logstash_format`as true).
+
+When using `deflectoe_alias` parameter, Elasticsearch plugin will create ILM target indices alias with `deflector_alias` instead of `index_name` or an index which is calculated from `logstash_prefix`. This behavior should be kept due to backward ILM feature compatibility.
 
 And also, ILM feature users should specify their Elasticsearch template for ILM enabled indices.
 Because ILM settings are injected into their Elasticsearch templates.
@@ -1607,9 +1609,6 @@ Because ILM settings are injected into their Elasticsearch templates.
 ```aconf
 index_name fluentd-${tag}
 # Should specify rollover_index as true
-rollover_index true
-deflector_alias fluentd-${tag} # Should specify as same index_name
-index_prefix fluentd
 application_name ${tag}
 index_date_pattern "now/d"
 enable_ilm true

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -74,7 +74,7 @@ module Fluent::ElasticsearchIndexTemplate
                                                                 get_template(template_file)) :
                      get_template(template_file), host)
 
-      log.info("Template '#{inject_template_name}' overwritten with #{template_file}.")
+      log.debug("Template '#{inject_template_name}' overwritten with #{template_file}.")
       return
     end
     if !template_exists?(inject_template_name, host)

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -128,7 +128,8 @@ module Fluent::ElasticsearchIndexTemplate
   end
 
   def create_rollover_alias(index_prefix, rollover_index, deflector_alias_name, app_name, index_date_pattern, index_separator, enable_ilm, ilm_policy_id, ilm_policy, host)
-    if rollover_index
+     # ILM request to create alias.
+    if rollover_index || enable_ilm
       if !client.indices.exists_alias(:name => deflector_alias_name)
         if index_date_pattern.empty?
           index_name_temp='<'+index_prefix.downcase+index_separator+app_name.downcase+'-000001>'

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -153,7 +153,7 @@ module Fluent::ElasticsearchIndexTemplate
         log.debug("The alias '#{deflector_alias_name}' is already present")
       end
     else
-      log.debug("No index and alias creation action performed because rollover_index is set to '#{rollover_index}'")
+      log.debug("No index and alias creation action performed because rollover_index or enable_ilm is set to: '#{rollover_index}', '#{enable_ilm}'")
     end
   end
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -842,6 +842,7 @@ EOC
 
     def placeholder_substitution_needed_for_template?
       placeholder?(:host, @host.to_s) ||
+        placeholder?(:index_name, @index_name.to_s) ||
         placeholder?(:logstash_prefix, @logstash_prefix.to_s) ||
         placeholder?(:deflector_alias, @deflector_alias.to_s) ||
         placeholder?(:application_name, @application_name.to_s)

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -214,11 +214,7 @@ EOC
       @alias_indexes = []
       if !dry_run?
         if @template_name && @template_file
-          if @rollover_index
-            raise Fluent::ConfigError, "'deflector_alias' or 'logstash_format' as true must be provided if 'rollover_index' is set true ." if not @deflector_alias and not @logstash_format
-          end
           if @enable_ilm
-            raise Fluent::ConfigError, "'rollover_index' and 'deflector_alias' or 'logstash_format' as true must be provided if 'enable_ilm' is set true." if !@rollover_index && !(@deflector_alias || @logstash_format)
             raise Fluent::ConfigError, "deflector_alias is prohibited to use with 'logstash_format at same time." if @logstash_format and @deflector_alias
           end
           if @logstash_format || placeholder_substitution_needed_for_template?
@@ -226,7 +222,7 @@ EOC
               alias_method :template_installation, :template_installation_actual
             end
           else
-            template_installation_actual(@deflector_alias, @application_name, @index_name)
+            template_installation_actual(@deflector_alias ? @deflector_alias : @index_name, @application_name, @index_name)
           end
           verify_ilm_working if @enable_ilm
         elsif @templates

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -584,10 +584,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
 
     driver(config)
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
+
     assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
   end
 
@@ -664,12 +661,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
       driver(config)
 
-      elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
-      driver.run(default_tag: 'test') do
-        driver.feed(sample_record)
-      end
-
-      assert_requested(elastic_request)
+      assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_deflector", times: 1)
     end
 
     def test_template_create_with_rollover_index_and_default_ilm_with_empty_index_date_pattern
@@ -735,12 +727,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
       driver(config)
 
-      elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
-      driver.run(default_tag: 'test') do
-        driver.feed(sample_record)
-      end
-
-      assert_requested(elastic_request)
+      assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_deflector", times: 1)
     end
 
     def test_template_create_with_rollover_index_and_custom_ilm
@@ -808,12 +795,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
       driver(config)
 
-      elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
-      driver.run(default_tag: 'test') do
-        driver.feed(sample_record)
-      end
-
-      assert_requested(elastic_request)
+      assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_deflector", times: 1)
     end
 
     def test_template_create_with_rollover_index_and_default_ilm_and_placeholders
@@ -923,11 +905,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     driver(config)
 
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
-
     assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_alias_template", times: 1)
   end
 
@@ -1017,11 +994,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     driver(config)
 
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
-
     assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_alias_template", times: 1)
   end
 
@@ -1102,12 +1074,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
       driver(config)
 
-      elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
-      driver.run(default_tag: 'test') do
-        driver.feed(sample_record)
-      end
-
-      assert_requested(elastic_request)
+      assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_deflector", times: 1)
     end
 
     def test_custom_template_with_rollover_index_create_and_default_ilm_and_placeholders
@@ -1258,12 +1225,7 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
       driver(config)
 
-      elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
-      driver.run(default_tag: 'test') do
-        driver.feed(sample_record)
-      end
-
-      assert_requested(elastic_request)
+      assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_deflector", times: 1)
     end
   end
 
@@ -1297,11 +1259,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
 
     driver(config)
-
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
 
     assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
   end
@@ -1337,11 +1294,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
 
     driver(config)
-
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
 
     assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_alias_template", times: 1)
   end
@@ -1394,11 +1346,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
     driver(config)
 
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
-
     assert_requested(:put, "https://logs.google.com:777/es//_template/myapp_alias_template", times: 1)
   end
 
@@ -1423,13 +1370,9 @@ class ElasticsearchOutput < Test::Unit::TestCase
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 404, :body => "", :headers => {})
 
-    driver(config)
 
-    stub_elastic("https://logs.google.com:777/es//_bulk")
     assert_raise(RuntimeError) {
-      driver.run(default_tag: 'test') do
-        driver.feed(sample_record)
-      end
+      driver(config)
     }
   end
 
@@ -1497,11 +1440,8 @@ class ElasticsearchOutput < Test::Unit::TestCase
       raise Faraday::ConnectionFailed, "Test message"
     end
 
-    driver(config)
-
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
+    assert_raise(Fluent::Plugin::ElasticsearchError::RetryableOperationExhaustedFailure) do
+      driver(config)
     end
 
     assert_equal(4, connection_resets)
@@ -1533,11 +1473,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
 
     driver(config)
-
-    stub_elastic("https://logs.google.com:778/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
 
     assert_equal(4, connection_resets)
   end
@@ -1673,11 +1608,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
 
     driver(config)
-
-    stub_elastic("https://logs.google.com:777/es//_bulk")
-    driver.run(default_tag: 'test') do
-      driver.feed(sample_record)
-    end
 
     assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
 


### PR DESCRIPTION
Related to #685, #690, #693, #697, and #700 .
Fixes #690 
Fixes #693
Fixes #697
Fixes #700

When not using placeholders inside Elasticsearch template related parameter, we shouldn't call template installation methods in `#send_bulk` which also means not to call it inside `#write`.

(check all that apply)
- [x] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
