### PR TITLE
Release 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: ruby
 
 matrix:
   include:
-    - rvm: 2.1
-      gemfile: Gemfile
-    - rvm: 2.2
-      gemfile: Gemfile
-    - rvm: 2.3
-      gemfile: Gemfile
     - rvm: 2.4.6
       gemfile: Gemfile
     - rvm: 2.5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       gemfile: gemfiles/Gemfile.ilm
     - rvm: 2.6.3
       gemfile: Gemfile
+    - rvm: 2.7.0
+      gemfile: Gemfile
 
 gemfile:
  - Gemfile

--- a/History.md
+++ b/History.md
@@ -1,6 +1,13 @@
 ## Changelog [[tags]](https://github.com/uken/fluent-plugin-elasticsearch/tags)
 
 ### [Unreleased]
+
+### 4.0.0
+- Restructuring ILM related features (#701)
+- Extract placeholders in pipeline parameter (#695)
+- fix typo in `README.md` (#698)
+- Reduce log noise when not using rollover_index (#692)
+
 ### 3.8.0
 - Add FAQ for specifying index.codec (#679)
 - Add FAQ for connect_write timeout reached error (#687)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 version: '{build}'
 install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - "%devkit%\\devkitvars.bat"
-  - IF EXIST "%devkit%\\bin\\ridk.cmd" ridk.cmd enable
+  - ridk.cmd enable
   - ruby --version
   - gem --version
   - bundle install
@@ -13,11 +12,9 @@ test_script:
 # https://www.appveyor.com/docs/installed-software/#ruby
 environment:
   matrix:
+    - ruby_version: "26-x64"
+    - ruby_version: "26"
     - ruby_version: "25-x64"
-      devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "25"
-      devkit: C:\Ruby23\DevKit
     - ruby_version: "24-x64"
-      devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "24"
-      devkit: C:\Ruby23\DevKit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,10 +21,3 @@ environment:
       devkit: C:\Ruby23-x64\DevKit
     - ruby_version: "24"
       devkit: C:\Ruby23\DevKit
-    - ruby_version: "23-x64"
-      devkit: C:\Ruby23-x64\DevKit
-    - ruby_version: "22-x64"
-      devkit: C:\Ruby23-x64\DevKit
-matrix:
-  allow_failures:
-    - ruby_version: "21"

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '>= 0'
   s.add_development_dependency 'webmock', '~> 3'
-  s.add_development_dependency 'test-unit', '~> 3.1.0'
+  s.add_development_dependency 'test-unit', '~> 3.3.0'
   s.add_development_dependency 'minitest', '~> 5.8'
   s.add_development_dependency 'flexmock', '~> 2.0'
 end

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = 'fluent-plugin-elasticsearch'
-  s.version       = '3.8.0'
+  s.version       = '4.0.0'
   s.authors       = ['diogo', 'pitr', 'Hiroshi Hatake']
   s.email         = ['pitr.vern@gmail.com', 'me@diogoterror.com', 'cosmo0920.wp@gmail.com']
   s.description   = %q{Elasticsearch output plugin for Fluent event collector}

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -307,10 +307,6 @@ EOC
         end
       end
 
-      if @buffer_config.flush_thread_count < 2
-        log.warn "To prevent events traffic jam, you should specify 2 or more 'flush_thread_count'."
-      end
-
       # Consider missing the prefix of "$." in nested key specifiers.
       @id_key = convert_compat_id_key(@id_key) if @id_key
       @parent_key = convert_compat_id_key(@parent_key) if @parent_key

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -151,7 +151,7 @@ EOC
     config_param :ignore_exceptions, :array, :default => [], value_type: :string, :desc => "Ignorable exception list"
     config_param :exception_backup, :bool, :default => true, :desc => "Chunk backup flag when ignore exception occured"
     config_param :bulk_message_request_threshold, :size, :default => TARGET_BULK_BYTES
-    config_param :compression_level, :enum, {list: [:no_compression, :best_speed, :best_compression, :default_compression], :default => :no_compression}
+    config_param :compression_level, :enum, list: [:no_compression, :best_speed, :best_compression, :default_compression], :default => :no_compression
     config_param :enable_ilm, :bool, :default => false
     config_param :ilm_policy_id, :string, :default => DEFAULT_POLICY_ID
     config_param :ilm_policy, :hash, :default => {}

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -246,7 +246,7 @@ module Fluent::Plugin
       # check for '${ ... }'
       #   yes => `eval`
       #   no  => return param
-      return param if (param =~ /\${.+}/).nil?
+      return param if (param.to_s =~ /\${.+}/).nil?
 
       # check for 'tag_parts[]'
         # separated by a delimiter (default '.')

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -545,27 +545,6 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
   end
 
-  sub_test_case 'connection exceptions' do
-    test 'default connection exception' do
-      driver(Fluent::Config::Element.new(
-               'ROOT', '', {
-                 '@type' => 'elasticsearch',
-                 'host' => 'log.google.com',
-                 'port' => 777,
-                 'scheme' => 'https',
-                 'path' => '/es/',
-                 'user' => 'john',
-                 'password' => 'doe',
-               }, [
-                 Fluent::Config::Element.new('buffer', 'tag', {
-                                             }, [])
-               ]
-             ))
-      logs = driver.logs
-      assert_logs_include(logs, /you should specify 2 or more 'flush_thread_count'/, 1)
-    end
-  end
-
   class GetElasticsearchVersionTest < self
     def create_driver(conf='', client_version="\"5.0\"")
       # For request stub to detect compatibility.

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -169,27 +169,6 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal '_doc', instance.type_name
   end
 
-  sub_test_case 'connection exceptions' do
-    test 'default connection exception' do
-      driver(Fluent::Config::Element.new(
-               'ROOT', '', {
-                 '@type' => 'elasticsearch',
-                 'host' => 'log.google.com',
-                 'port' => 777,
-                 'scheme' => 'https',
-                 'path' => '/es/',
-                 'user' => 'john',
-                 'password' => 'doe',
-               }, [
-                 Fluent::Config::Element.new('buffer', 'tag', {
-                                             }, [])
-               ]
-             ))
-      logs = driver.logs
-      assert_logs_include(logs, /you should specify 2 or more 'flush_thread_count'/, 1)
-    end
-  end
-
   def test_defaults
     config = %{
       host     logs.google.com


### PR DESCRIPTION
We will release Elasticsearch plugin v4.0.0. :tada:

### Breaking changes

- Restructuring ILM related features (#701)

### Fixes

- Extract placeholders in pipeline parameter (#695)
- fix typo in `README.md` (#698)
- Reduce log noise when not using rollover_index (#692)

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
