### PR TITLE
Placeholders for template name and customize template

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     s.metadata["changelog_uri"] = "https://github.com/uken/fluent-plugin-elasticsearch/blob/master/History.md"
   end
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.0".freeze)
+  s.required_ruby_version = Gem::Requirement.new(">= 2.3".freeze)
 
   s.add_runtime_dependency 'fluentd', '>= 0.14.22'
   s.add_runtime_dependency 'excon', '>= 0'

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -137,8 +137,7 @@ module Fluent::ElasticsearchIndexTemplate
           index_name_temp='<'+index_prefix.downcase+index_separator+app_name.downcase+'-{'+index_date_pattern+'}-000001>'
         end
         indexcreation(index_name_temp, host)
-        body = {}
-        body = rollover_alias_payload(deflector_alias_name) if enable_ilm
+        body = rollover_alias_payload(deflector_alias_name)
         client.indices.put_alias(:index => index_name_temp, :name => deflector_alias_name,
                                  :body => body)
         log.info("The alias '#{deflector_alias_name}' is created for the index '#{index_name_temp}'")

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -852,7 +852,7 @@ EOC
       need_substitution = placeholder?(:host, @host.to_s) ||
         placeholder?(:index_name, @index_name.to_s) ||
         placeholder?(:template_name, @template_name.to_s) ||
-        @customize_template.values.any? { |value| placeholder?(:customize_template, value.to_s) } ||
+        @customize_template&.values&.any? { |value| placeholder?(:customize_template, value.to_s) } ||
         placeholder?(:logstash_prefix, @logstash_prefix.to_s) ||
         placeholder?(:deflector_alias, @deflector_alias.to_s) ||
         placeholder?(:application_name, @application_name.to_s)

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -224,7 +224,7 @@ EOC
               alias_method :template_installation, :template_installation_actual
             end
           else
-            template_installation_actual(@deflector_alias ? @deflector_alias : @index_name, @template_name, @application_name, @index_name)
+            template_installation_actual(@deflector_alias ? @deflector_alias : @index_name, @template_name, @customize_template, @application_name, @index_name)
           end
           verify_ilm_working if @enable_ilm
         elsif @templates
@@ -654,6 +654,11 @@ EOC
       else
         template_name = nil
       end
+      if @customize_template
+        customize_template = @customize_template.each_with_object({}) { |(key, value), hash| hash[key] = extract_placeholders(value, chunk) }
+      else
+        customize_template = nil
+      end
       if @deflector_alias
         deflector_alias = extract_placeholders(@deflector_alias, chunk)
       else
@@ -669,7 +674,7 @@ EOC
       else
         pipeline = nil
       end
-      return logstash_prefix, index_name, type_name, template_name, deflector_alias, application_name, pipeline
+      return logstash_prefix, index_name, type_name, template_name, customize_template, deflector_alias, application_name, pipeline
     end
 
     def multi_workers_ready?
@@ -743,7 +748,7 @@ EOC
     end
 
     def process_message(tag, meta, header, time, record, extracted_values)
-      logstash_prefix, index_name, type_name, _template_name, _deflector_alias, _application_name, pipeline = extracted_values
+      logstash_prefix, index_name, type_name, _template_name, _customize_template, _deflector_alias, _application_name, pipeline = extracted_values
 
       if @flatten_hashes
         record = flatten_record(record)
@@ -847,16 +852,17 @@ EOC
       placeholder?(:host, @host.to_s) ||
         placeholder?(:index_name, @index_name.to_s) ||
         placeholder?(:template_name, @template_name.to_s) ||
+        @customize_template.values.any? { |value| placeholder?(:customize_template, value.to_s) } ||
         placeholder?(:logstash_prefix, @logstash_prefix.to_s) ||
         placeholder?(:deflector_alias, @deflector_alias.to_s) ||
         placeholder?(:application_name, @application_name.to_s)
     end
 
-    def template_installation(deflector_alias, template_name, application_name, target_index, host)
+    def template_installation(deflector_alias, template_name, customize_template, application_name, target_index, host)
       # for safety.
     end
 
-    def template_installation_actual(deflector_alias, template_name, application_name, target_index, host=nil)
+    def template_installation_actual(deflector_alias, template_name, customize_template, application_name, target_index, host=nil)
       if template_name && @template_file
         if @alias_indexes.include? deflector_alias
           log.debug("Index alias #{deflector_alias} already exists (cached)")
@@ -864,8 +870,8 @@ EOC
           log.debug("Template name #{template_name} already exists (cached)")
         else
           retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
-            if @customize_template
-              template_custom_install(template_name, @template_file, @template_overwrite, @customize_template, @enable_ilm, deflector_alias, @ilm_policy_id, host)
+            if customize_template
+              template_custom_install(template_name, @template_file, @template_overwrite, customize_template, @enable_ilm, deflector_alias, @ilm_policy_id, host)
             else
               template_install(template_name, @template_file, @template_overwrite, @enable_ilm, deflector_alias, @ilm_policy_id, host)
             end
@@ -880,11 +886,11 @@ EOC
     # send_bulk given a specific bulk request, the original tag,
     # chunk, and bulk_message_count
     def send_bulk(data, tag, chunk, bulk_message_count, extracted_values, info)
-      logstash_prefix, index_name, _type_name, template_name, deflector_alias, application_name, _pipeline = extracted_values
+      logstash_prefix, index_name, _type_name, template_name, customize_template, deflector_alias, application_name, _pipeline = extracted_values
       if deflector_alias
-        template_installation(deflector_alias, template_name, application_name, index_name, info.host)
+        template_installation(deflector_alias, template_name, customize_template, application_name, index_name, info.host)
       else
-        template_installation(info.ilm_index, template_name, application_name, @logstash_format ? logstash_prefix : index_name, info.host)
+        template_installation(info.ilm_index, template_name, customize_template, application_name, @logstash_format ? logstash_prefix : index_name, info.host)
       end
 
       begin

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -52,6 +52,7 @@ module Fluent::Plugin
     RequestInfo = Struct.new(:host, :index, :ilm_index)
 
     attr_reader :alias_indexes
+    attr_reader :template_names
 
     helpers :event_emitter, :compat_parameters, :record_accessor
 
@@ -212,6 +213,7 @@ EOC
       end
 
       @alias_indexes = []
+      @template_names = []
       if !dry_run?
         if @template_name && @template_file
           if @enable_ilm
@@ -222,7 +224,7 @@ EOC
               alias_method :template_installation, :template_installation_actual
             end
           else
-            template_installation_actual(@deflector_alias ? @deflector_alias : @index_name, @application_name, @index_name)
+            template_installation_actual(@deflector_alias ? @deflector_alias : @index_name, @template_name, @application_name, @index_name)
           end
           verify_ilm_working if @enable_ilm
         elsif @templates
@@ -647,6 +649,11 @@ EOC
       else
         type_name = nil
       end
+      if @template_name
+        template_name = extract_placeholders(@template_name, chunk)
+      else
+        template_name = nil
+      end
       if @deflector_alias
         deflector_alias = extract_placeholders(@deflector_alias, chunk)
       else
@@ -662,7 +669,7 @@ EOC
       else
         pipeline = nil
       end
-      return logstash_prefix, index_name, type_name, deflector_alias, application_name, pipeline
+      return logstash_prefix, index_name, type_name, template_name, deflector_alias, application_name, pipeline
     end
 
     def multi_workers_ready?
@@ -736,7 +743,7 @@ EOC
     end
 
     def process_message(tag, meta, header, time, record, extracted_values)
-      logstash_prefix, index_name, type_name, _deflector_alias, _application_name, pipeline = extracted_values
+      logstash_prefix, index_name, type_name, _template_name, _deflector_alias, _application_name, pipeline = extracted_values
 
       if @flatten_hashes
         record = flatten_record(record)
@@ -839,29 +846,33 @@ EOC
     def placeholder_substitution_needed_for_template?
       placeholder?(:host, @host.to_s) ||
         placeholder?(:index_name, @index_name.to_s) ||
+        placeholder?(:template_name, @template_name.to_s) ||
         placeholder?(:logstash_prefix, @logstash_prefix.to_s) ||
         placeholder?(:deflector_alias, @deflector_alias.to_s) ||
         placeholder?(:application_name, @application_name.to_s)
     end
 
-    def template_installation(deflector_alias, application_name, target_index, host)
+    def template_installation(deflector_alias, template_name, application_name, target_index, host)
       # for safety.
     end
 
-    def template_installation_actual(deflector_alias, application_name, target_index, host=nil)
-      if @template_name && @template_file
+    def template_installation_actual(deflector_alias, template_name, application_name, target_index, host=nil)
+      if template_name && @template_file
         if @alias_indexes.include? deflector_alias
           log.debug("Index alias #{deflector_alias} already exists (cached)")
+        elsif @template_names.include? template_name
+          log.debug("Template name #{template_name} already exists (cached)")
         else
           retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
             if @customize_template
-              template_custom_install(@template_name, @template_file, @template_overwrite, @customize_template, @enable_ilm, deflector_alias, @ilm_policy_id, host)
+              template_custom_install(template_name, @template_file, @template_overwrite, @customize_template, @enable_ilm, deflector_alias, @ilm_policy_id, host)
             else
-              template_install(@template_name, @template_file, @template_overwrite, @enable_ilm, deflector_alias, @ilm_policy_id, host)
+              template_install(template_name, @template_file, @template_overwrite, @enable_ilm, deflector_alias, @ilm_policy_id, host)
             end
             create_rollover_alias(target_index, @rollover_index, deflector_alias, application_name, @index_date_pattern, @index_separator, @enable_ilm, @ilm_policy_id, @ilm_policy, host)
           end
           @alias_indexes << deflector_alias unless deflector_alias.nil?
+          @template_names << template_name unless template_name.nil?
         end
       end
     end
@@ -869,11 +880,11 @@ EOC
     # send_bulk given a specific bulk request, the original tag,
     # chunk, and bulk_message_count
     def send_bulk(data, tag, chunk, bulk_message_count, extracted_values, info)
-      logstash_prefix, index_name, _type_name, deflector_alias, application_name, _pipeline = extracted_values
+      logstash_prefix, index_name, _type_name, template_name, deflector_alias, application_name, _pipeline = extracted_values
       if deflector_alias
-        template_installation(deflector_alias, application_name, index_name, info.host)
+        template_installation(deflector_alias, template_name, application_name, index_name, info.host)
       else
-        template_installation(info.ilm_index, application_name, @logstash_format ? logstash_prefix : index_name, info.host)
+        template_installation(info.ilm_index, template_name, application_name, @logstash_format ? logstash_prefix : index_name, info.host)
       end
 
       begin

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -360,13 +360,17 @@ EOC
     end
 
     def placeholder?(name, param)
-      begin
-        placeholder_validate!(name, param)
-        true
-      rescue Fluent::ConfigError => e
-        log.debug("'#{name} #{param}' is tested built-in placeholder(s) but there is no valid placeholder(s). error: #{e}")
-        false
+      placeholder_validities = []
+      placeholder_validators(name, param).each do |v|
+        begin
+          v.validate!
+          placeholder_validities << true
+        rescue Fluent::ConfigError => e
+          log.debug("'#{name} #{param}' is tested built-in placeholder(s) but there is no valid placeholder(s). error: #{e}")
+          placeholder_validities << false
+        end
       end
+      placeholder_validities.include?(true)
     end
 
     def compression
@@ -857,7 +861,7 @@ EOC
         placeholder?(:deflector_alias, @deflector_alias.to_s) ||
         placeholder?(:application_name, @application_name.to_s)
       log.debug("Need substitution: #{need_substitution}")
-      true
+      need_substitution
     end
 
     def template_installation(deflector_alias, template_name, customize_template, application_name, target_index, host)

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -849,13 +849,15 @@ EOC
     end
 
     def placeholder_substitution_needed_for_template?
-      placeholder?(:host, @host.to_s) ||
+      need_substitution = placeholder?(:host, @host.to_s) ||
         placeholder?(:index_name, @index_name.to_s) ||
         placeholder?(:template_name, @template_name.to_s) ||
         @customize_template.values.any? { |value| placeholder?(:customize_template, value.to_s) } ||
         placeholder?(:logstash_prefix, @logstash_prefix.to_s) ||
         placeholder?(:deflector_alias, @deflector_alias.to_s) ||
         placeholder?(:application_name, @application_name.to_s)
+      log.debug("Need substitution: #{need_substitution}")
+      true
     end
 
     def template_installation(deflector_alias, template_name, customize_template, application_name, target_index, host)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -409,6 +409,9 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
   sub_test_case "placeholder substitution needed?" do
     data("host placeholder" => ["host", "host-${tag}.google.com"],
+         "index_name_placeholder" => ["index_name", "logstash-${tag}"],
+         "template_name_placeholder" => ["template_name", "logstash-${tag}"],
+         "customize_template" => ["customize_template", '{"<<TAG>>":"${tag}"}'],
          "logstash_prefix_placeholder" => ["logstash_prefix", "fluentd-${tag}"],
          "deflector_alias_placeholder" => ["deflector_alias", "fluentd-${tag}"],
          "application_name_placeholder" => ["application_name", "fluentd-${tag}"],
@@ -429,6 +432,9 @@ class ElasticsearchOutput < Test::Unit::TestCase
 
 
     data("host placeholder" => ["host", "host-%Y%m%d.google.com"],
+         "index_name_placeholder" => ["index_name", "logstash-%Y%m%d"],
+         "template_name_placeholder" => ["template_name", "logstash-%Y%m%d"],
+         "customize_template" => ["customize_template", '{"<<TAG>>":"fluentd-%Y%m%d"}'],
          "logstash_prefix_placeholder" => ["logstash_prefix", "fluentd-%Y%m%d"],
          "deflector_alias_placeholder" => ["deflector_alias", "fluentd-%Y%m%d"],
          "application_name_placeholder" => ["application_name", "fluentd-%Y%m%d"],
@@ -450,6 +456,9 @@ class ElasticsearchOutput < Test::Unit::TestCase
     end
 
     data("host placeholder" => ["host", "host-${mykey}.google.com"],
+         "index_name_placeholder" => ["index_name", "logstash-${mykey}"],
+         "template_name_placeholder" => ["template_name", "logstash-${mykey}"],
+         "customize_template" => ["customize_template", '{"<<TAG>>":"${mykey}"}'],
          "logstash_prefix_placeholder" => ["logstash_prefix", "fluentd-${mykey}"],
          "deflector_alias_placeholder" => ["deflector_alias", "fluentd-${mykey}"],
          "application_name_placeholder" => ["application_name", "fluentd-${mykey}"],
@@ -463,6 +472,31 @@ class ElasticsearchOutput < Test::Unit::TestCase
         }, [
           Fluent::Config::Element.new('buffer', 'mykey', {
                                         'chunk_keys' => 'mykey',
+                                        'timekey' => '1d',
+                                      }, [])
+        ])
+      driver(config)
+
+      assert_true driver.instance.placeholder_substitution_needed_for_template?
+    end
+
+    data("host placeholder" => ["host", "host-${tag}.google.com"],
+         "index_name_placeholder" => ["index_name", "logstash-${es_index}-%Y%m%d"],
+         "template_name_placeholder" => ["template_name", "logstash-${tag}-%Y%m%d"],
+         "customize_template" => ["customize_template", '{"<<TAG>>":"${es_index}"}'],
+         "logstash_prefix_placeholder" => ["logstash_prefix", "fluentd-${es_index}-%Y%m%d"],
+         "deflector_alias_placeholder" => ["deflector_alias", "fluentd-%Y%m%d"],
+         "application_name_placeholder" => ["application_name", "fluentd-${tag}-${es_index}-%Y%m%d"],
+        )
+    test 'mixed placeholder' do |data|
+      param, value = data
+      config = Fluent::Config::Element.new(
+        'ROOT', '', {
+          '@type' => 'elasticsearch',
+          param => value
+        }, [
+          Fluent::Config::Element.new('buffer', 'tag,time,es_index', {
+                                        'chunk_keys' => 'es_index',
                                         'timekey' => '1d',
                                       }, [])
         ])


### PR DESCRIPTION
Implements #703 

I first implemented this on top of 6ca9fd9d1a79ab325c87b30f67c1228dbec8ecf9 which worked well. Now rebased on top of master, it does not work because [placeholder_substitution_needed_for_template](https://github.com/uken/fluent-plugin-elasticsearch/blob/master/lib/fluent/plugin/out_elasticsearch.rb#L839) does not seem to work. It does not seem to work in the latest release (4.0.0) either (all vanilla, without my changes). So just for testing to get this PR to work i made `placeholder_substitution_needed_for_template` always return `true` in  33562a495254bff569cfce858988aa7e6e16498d.

I have added some tests but can't seem to get the test suite running correctly so they may be wrong.

Also, I really don't know ruby so I apologize for any ugly implementations.

(check all that apply)
- [x] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

For reference, I successfully use the following configuration to get it to work in the way described in the issue:
```
        @type      elasticsearch
        @id        out_es
        @log_level debug

        id_key      _hash
        remove_keys _hash

        host               opendistro-es-discovery.log.svc
        port               9200
        scheme             https
        ssl_version        TLSv1_2
        # ca_file            /etc/ssl/certs/es/tls.crt
        ssl_verify         false
        user               "#{ENV['ES_USERNAME_OPENDISTRO']}"
        password           "#{ENV['ES_PASSWORD_OPENDISTRO']}"
        reload_connections false
        reconnect_on_error true
        reload_on_failure  true
        request_timeout    30s
        log_es_400_reason  true

        index_name               fluentd-${es_index}
        time_key                 time
        include_timestamp        true
        include_tag_key          true
        flatten_hashes           true
        flatten_hashes_separator _

        # Rollover index config
        rollover_index     true
        application_name   ${es_index}
        index_date_pattern ""
        deflector_alias    fluentd-${es_index}

        # Index template
        template_name      fluentd-${es_index}
        template_file      /fluentd/etc/es_index_template.json
        customize_template {"<<TAG>>":"${es_index}"}
        template_overwrite true

        <buffer tag,es_index>
          @type file
          path /fluentd/log/es-out

          flush_thread_count 4
          flush_interval     5s
          flush_at_shutdown  true

          chunk_limit_size   2M
          total_limit_size   256M

          retry_max_interval 30
          retry_forever      true
        </buffer>
```
with the following template file (`/fluentd/etc/es_index_template.json`):
```json
{
  "index_patterns" : ["fluentd-<<TAG>>-*"],
  "settings" : {
    "number_of_shards": 3,
    "number_of_replicas": 2,
    "opendistro.index_state_management.policy_id": "fluentd-default-policy",
    "opendistro.index_state_management.rollover_alias": "fluentd-<<TAG>>"
  }
}
```