### PR TITLE
Support TLSv1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,18 @@ ssl_version TLSv1_2 # or [SSLv23, TLSv1, TLSv1_1]
 
 :warning: If SSL/TLS enabled, it might have to be required to set ssl\_version.
 
+In Elasticsearch plugin v4.0.2 with Ruby 2.5 or later combination, Elasticsearch plugin also support `ssl_max_version` and `ssl_min_version`.
+
+```
+ssl_max_version TLSv1_3
+ssl_min_version TLSv1_2
+```
+
+Elasticsearch plugin will use TLSv1.2 as minimum ssl version and TLSv1.3 as maximum ssl version on transportation with TLS. Note that when they are used in Elastissearch plugin configuration, *`ssl_version` is not used* to set up TLS version.
+
+If they are *not* specified in the Elasticsearch plugin configuration, the value of `ssl_version` will be *used in `ssl_max_version` and `ssl_min_version`*.
+
+
 ### Proxy Support
 
 Starting with version 0.8.0, this gem uses excon, which supports proxy with environment variables - https://github.com/excon/excon#proxy-support
@@ -1231,6 +1243,13 @@ If you want to use TLS v1.2, please use `ssl_version` parameter like as:
 ssl_version TLSv1_2
 ```
 
+or, in v4.0.2 or later with Ruby 2.5 or later combination, the following congiuration is also valid:
+
+```
+ssl_max_version TLSv1_2
+ssl_min_version TLSv1_2
+```
+
 ### Cannot connect TLS enabled reverse Proxy
 
 A common cause of failure is that you are trying to connect to an Elasticsearch instance behind nginx reverse proxy which uses an incompatible ssl protocol version.
@@ -1320,6 +1339,13 @@ If you want to use TLS v1.2, please use `ssl_version` parameter like as:
 
 ```
 ssl_version TLSv1_2
+```
+
+or, in v4.0.2 or later with Ruby 2.5 or later combination, the following congiuration is also valid:
+
+```
+ssl_max_version TLSv1_2
+ssl_min_version TLSv1_2
 ```
 
 ### Declined logs are resubmitted forever, why?

--- a/lib/fluent/plugin/elasticsearch_tls.rb
+++ b/lib/fluent/plugin/elasticsearch_tls.rb
@@ -1,0 +1,70 @@
+require 'openssl'
+require 'fluent/configurable'
+require 'fluent/config/error'
+
+module Fluent::Plugin
+  module ElasticsearchTLS
+    SUPPORTED_TLS_VERSIONS = if defined?(OpenSSL::SSL::TLS1_3_VERSION)
+                               [:TLSv1, :TLSv1_1, :TLSv1_2, :TLSv1_3].freeze
+                             else
+                               [:SSLv23, :TLSv1, :TLSv1_1, :TLSv1_2].freeze
+                             end
+
+    DEFAULT_VERSION = :TLSv1
+    METHODS_MAP = begin
+                    # When openssl supports OpenSSL::SSL::TLSXXX constants representations, we use them.
+                    map = {
+                      TLSv1: OpenSSL::SSL::TLS1_VERSION,
+                      TLSv1_1: OpenSSL::SSL::TLS1_1_VERSION,
+                      TLSv1_2: OpenSSL::SSL::TLS1_2_VERSION
+                    }
+                    map[:TLSv1_3] = OpenSSL::SSL::TLS1_3_VERSION if defined?(OpenSSL::SSL::TLS1_3_VERSION)
+                    USE_TLS_MINMAX_VERSION = true
+                    map.freeze
+                  rescue NameError
+                    map = {
+                      SSLv23: :SSLv23,
+                      TLSv1: :TLSv1,
+                      TLSv1_1: :TLSv1_1,
+                      TLSv1_2: :TLSv1_2,
+                    }
+                    USE_TLS_MINMAX_VERSION = false
+                  end
+    private_constant :METHODS_MAP
+
+    module ElasticsearchTLSParams
+      include Fluent::Configurable
+
+      config_param :ssl_version, :enum, list: Fluent::Plugin::ElasticsearchTLS::SUPPORTED_TLS_VERSIONS, default: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION
+      config_param :ssl_min_version, :enum, list: Fluent::Plugin::ElasticsearchTLS::SUPPORTED_TLS_VERSIONS, default: nil
+      config_param :ssl_max_version, :enum, list: Fluent::Plugin::ElasticsearchTLS::SUPPORTED_TLS_VERSIONS, default: nil
+    end
+
+    def self.included(mod)
+      mod.include ElasticsearchTLSParams
+    end
+
+    def set_tls_minmax_version_config(ssl_version, ssl_max_version, ssl_min_version)
+      if USE_TLS_MINMAX_VERSION
+        case
+        when ssl_min_version.nil? && ssl_max_version.nil?
+          ssl_min_version = METHODS_MAP[ssl_version]
+          ssl_max_version = METHODS_MAP[ssl_version]
+        when ssl_min_version && ssl_max_version.nil?
+          raise Fluent::ConfigError, "When you set 'ssl_min_version', must set 'ssl_max_version' together."
+        when ssl_min_version.nil? && ssl_max_version
+          raise Fluent::ConfigError, "When you set 'ssl_max_version', must set 'ssl_min_version' together."
+        else
+          ssl_min_version = METHODS_MAP[ssl_min_version]
+          ssl_max_version = METHODS_MAP[ssl_max_version]
+        end
+
+        {max_version: ssl_max_version, min_version: ssl_min_version}
+      else
+        log.warn "'ssl_min_version' does not have any effect in this environment. Use 'ssl_version' instead." unless ssl_min_version.nil?
+        log.warn "'ssl_max_version' does not have any effect in this environment. Use 'ssl_version' instead." unless ssl_max_version.nil?
+        {version: ssl_version}
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -50,6 +50,7 @@ module Fluent::Plugin
                          {}
                        end
         headers = { 'Content-Type' => @content_type.to_s, }.merge(gzip_headers)
+        ssl_options = { verify: @ssl_verify, ca_file: @ca_file}.merge(@ssl_version_options)
         transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
                                                                               reload_connections: @reload_connections,
@@ -59,7 +60,7 @@ module Fluent::Plugin
                                                                               transport_options: {
                                                                                 headers: headers,
                                                                                 request: { timeout: @request_timeout },
-                                                                                ssl: { verify: @ssl_verify, ca_file: @ca_file, version: @ssl_version }
+                                                                                ssl: ssl_options,
                                                                               },
                                                                               http: {
                                                                                 user: @user,

--- a/test/plugin/test_elasticsearch_tls.rb
+++ b/test/plugin/test_elasticsearch_tls.rb
@@ -35,6 +35,12 @@ class TestElasticsearchTLS < Test::Unit::TestCase
                               rescue NameError
                                 false
                               end
+    @enabled_tlsv1_3 = begin
+                         map = {TLSv1_3: OpenSSL::SSL::TLS1_3_VERSION}
+                         true
+                       rescue NameError
+                         false
+                       end
   end
 
   def driver(conf='')
@@ -116,7 +122,7 @@ class TestElasticsearchTLS < Test::Unit::TestCase
     end
 
     test 'TLSv1.3' do
-      omit "openssl gem does not support TLSv1.3" unless @use_tls_minmax_version
+      omit "openssl gem does not support TLSv1.3" unless @enabled_tlsv1_3
       config = %{
         ssl_max_version TLSv1_3
         ssl_min_version TLSv1_2

--- a/test/plugin/test_elasticsearch_tls.rb
+++ b/test/plugin/test_elasticsearch_tls.rb
@@ -1,0 +1,133 @@
+require_relative '../helper'
+require 'fluent/test/driver/output'
+require 'fluent/plugin/output'
+require 'fluent/plugin/elasticsearch_tls'
+
+class TestElasticsearchTLS < Test::Unit::TestCase
+
+  class TestTLSModuleOutput < Fluent::Plugin::Output
+    include Fluent::Plugin::ElasticsearchTLS
+
+    def initialize
+      super
+      @emit_streams = []
+    end
+
+    def write(chunk)
+      es = Fluent::ArrayEventStream.new
+      chunk.each do |time, record|
+        es.add(time, record)
+      end
+      @emit_streams << [tag, es]
+    end
+  end
+
+  setup do
+    Fluent::Test.setup
+    @use_tls_minmax_version = begin
+                                map = {
+                                  TLSv1: OpenSSL::SSL::TLS1_VERSION,
+                                  TLSv1_1: OpenSSL::SSL::TLS1_1_VERSION,
+                                  TLSv1_2: OpenSSL::SSL::TLS1_2_VERSION
+                                }
+                                map[:TLSv1_3] = OpenSSL::SSL::TLS1_3_VERSION if defined?(OpenSSL::SSL::TLS1_3_VERSION)
+                                true
+                              rescue NameError
+                                false
+                              end
+  end
+
+  def driver(conf='')
+    Fluent::Test::Driver::Output.new(TestTLSModuleOutput).configure(conf)
+  end
+
+  test 'configure' do
+    assert_equal Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION, driver.instance.ssl_version
+    assert_nil driver.instance.ssl_max_version
+    assert_nil driver.instance.ssl_min_version
+  end
+
+  test 'check USE_TLS_MINMAX_VERSION value' do
+    assert_equal @use_tls_minmax_version, Fluent::Plugin::ElasticsearchTLS::USE_TLS_MINMAX_VERSION
+  end
+
+  sub_test_case 'set_tls_minmax_version_config' do
+    test 'default' do
+      d = driver('')
+      ssl_version_options = d.instance.set_tls_minmax_version_config(d.instance.ssl_version, nil, nil)
+      if @use_tls_minmax_version
+        assert_equal({max_version: OpenSSL::SSL::TLS1_VERSION,
+                      min_version: OpenSSL::SSL::TLS1_VERSION}, ssl_version_options)
+      else
+        assert_equal({version: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION}, ssl_version_options)
+      end
+    end
+
+    test 'errorous cases' do
+      if @use_tls_minmax_version
+        assert_raise(Fluent::ConfigError) do
+          d = driver(%{ssl_max_version TLSv1_2})
+          d.instance.set_tls_minmax_version_config(d.instance.ssl_version,
+                                                   d.instance.ssl_max_version,
+                                                   d.instance.ssl_min_version)
+        end
+        assert_raise(Fluent::ConfigError) do
+          d = driver(%{ssl_min_version TLSv1_2})
+          d.instance.set_tls_minmax_version_config(d.instance.ssl_version,
+                                                   d.instance.ssl_max_version,
+                                                   d.instance.ssl_min_version)
+        end
+      else
+        d1 = driver(%{
+          ssl_max_version TLSv1_2
+          @log_level info
+        })
+        d1.instance.set_tls_minmax_version_config(d1.instance.ssl_version,
+                                                  d1.instance.ssl_max_version,
+                                                  d1.instance.ssl_min_version)
+
+        d1.logs.any? {|a| a.include?("'ssl_max_version' does not have any effect in this environment.") }
+        d2 = driver(%{
+          ssl_min_version TLSv1_2
+          @log_level info
+        })
+        d2.instance.set_tls_minmax_version_config(d2.instance.ssl_version,
+                                                  d2.instance.ssl_max_version,
+                                                  d2.instance.ssl_min_version)
+        d2.logs.any? {|a| a.include?("'ssl_min_version' does not have any effect in this environment.") }
+      end
+    end
+
+    test 'min_version & max_version' do
+      config = %{
+        ssl_max_version TLSv1_2
+        ssl_min_version TLSv1_1
+      }
+      d = driver(config)
+      ssl_version_options = d.instance.set_tls_minmax_version_config(d.instance.ssl_version,
+                                                                     d.instance.ssl_max_version,
+                                                                     d.instance.ssl_min_version)
+      if @use_tls_minmax_version
+        assert_equal({max_version: OpenSSL::SSL::TLS1_2_VERSION,
+                      min_version: OpenSSL::SSL::TLS1_1_VERSION}, ssl_version_options)
+      else
+        assert_equal({version: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION}, ssl_version_options)
+      end
+    end
+
+    test 'TLSv1.3' do
+      omit "openssl gem does not support TLSv1.3" unless @use_tls_minmax_version
+      config = %{
+        ssl_max_version TLSv1_3
+        ssl_min_version TLSv1_2
+      }
+      d = driver(config)
+      ssl_version_options = d.instance.set_tls_minmax_version_config(d.instance.ssl_version,
+                                                                     d.instance.ssl_max_version,
+                                                                     d.instance.ssl_min_version)
+      assert_equal({max_version: OpenSSL::SSL::TLS1_3_VERSION,
+                    min_version: OpenSSL::SSL::TLS1_2_VERSION}, ssl_version_options)
+
+    end
+  end
+end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -218,7 +218,16 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_equal '/es/', instance.path
     assert_equal 'john', instance.user
     assert_equal 'doe', instance.password
-    assert_equal :TLSv1, instance.ssl_version
+    assert_equal Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION, instance.ssl_version
+    assert_nil instance.ssl_max_version
+    assert_nil instance.ssl_min_version
+    if Fluent::Plugin::ElasticsearchTLS::USE_TLS_MINMAX_VERSION
+      assert_equal({max_version: OpenSSL::SSL::TLS1_VERSION, min_version: OpenSSL::SSL::TLS1_VERSION},
+                   instance.ssl_version_options)
+    else
+      assert_equal({version: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION},
+                   instance.ssl_version_options)
+    end
     assert_nil instance.client_key
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -97,7 +97,16 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_equal 'john', instance.user
     assert_equal 'doe', instance.password
     assert_equal '/es/', instance.path
-    assert_equal :TLSv1, instance.ssl_version
+    assert_equal Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION, instance.ssl_version
+    assert_nil instance.ssl_max_version
+    assert_nil instance.ssl_min_version
+    if Fluent::Plugin::ElasticsearchTLS::USE_TLS_MINMAX_VERSION
+      assert_equal({max_version: OpenSSL::SSL::TLS1_VERSION, min_version: OpenSSL::SSL::TLS1_VERSION},
+                   instance.ssl_version_options)
+    else
+      assert_equal({version: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION},
+                   instance.ssl_version_options)
+    end
     assert_nil instance.client_key
     assert_nil instance.client_cert
     assert_nil instance.client_key_pass


### PR DESCRIPTION
Support TLSv1.3 on Ruby 2.5 or later.
Fixes #709.

(check all that apply)
- [x] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
