### PR TITLE
Use http.scheme settings for persisent scheme setup

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -519,7 +519,8 @@ EOC
                                                                               },
                                                                               http: {
                                                                                 user: @user,
-                                                                                password: @password
+                                                                                password: @password,
+                                                                                scheme: @scheme
                                                                               },
                                                                               sniffer_class: @sniffer_class,
                                                                               serializer_class: @serializer_class,

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -64,7 +64,8 @@ module Fluent::Plugin
                                                                               },
                                                                               http: {
                                                                                 user: @user,
-                                                                                password: @password
+                                                                                password: @password,
+                                                                                scheme: @scheme
                                                                               },
                                                                               compression: compression,
                                                                             }), &adapter_conf)


### PR DESCRIPTION
This patch fixes the scheme glitch failure issue which is reported by
several users who use https scheme.

Basically, elasticsearch-ruby handles *hosts* information as
short-living things and trying to reconstruct them with sniffered
information.

So, we should pass scheme information into elasticsearch-transport
through `http.scheme`. This should be passed into `options` parameter in
`#__build_connections`.

Fixes #476.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
