### PR TITLE
Provide clearing caches timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Current maintainers: @cosmo0920
   + [ilm_policy_id](#ilm_policy_id)
   + [ilm_policy](#ilm_policy)
   + [ilm_policy_overwrite](#ilm_policy_overwrite)
+  + [truncate_caches_interval](#truncate_caches_interval)
 * [Configuration - Elasticsearch Input](#configuration---elasticsearch-input)
 * [Troubleshooting](#troubleshooting)
   + [Cannot send events to elasticsearch](#cannot-send-events-to-elasticsearch)
@@ -1182,6 +1183,14 @@ Specify whether overwriting ilm policy or not.
 Default value is `false`.
 
 **NOTE:** This parameter requests to install elasticsearch-xpack gem.
+
+## truncate_caches_interval
+
+Specify truncating caches interval.
+
+If it is set, timer for clearing `alias_indexes` and `template_names` caches will be launched and executed.
+
+Default value is `nil`.
 
 ## Configuration - Elasticsearch Input
 

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -141,15 +141,16 @@ module Fluent::ElasticsearchIndexTemplate
         client.indices.put_alias(:index => index_name_temp, :name => deflector_alias_name,
                                  :body => body)
         log.info("The alias '#{deflector_alias_name}' is created for the index '#{index_name_temp}'")
-        if enable_ilm
-          if ilm_policy.empty?
-            setup_ilm(enable_ilm, ilm_policy_id)
-          else
-            setup_ilm(enable_ilm, ilm_policy_id, ilm_policy, ilm_policy_overwrite)
-          end
-        end
       else
         log.debug("The alias '#{deflector_alias_name}' is already present")
+      end
+      # Create ILM policy if rollover indices exist.
+      if enable_ilm
+        if ilm_policy.empty?
+          setup_ilm(enable_ilm, ilm_policy_id)
+        else
+          setup_ilm(enable_ilm, ilm_policy_id, ilm_policy, ilm_policy_overwrite)
+        end
       end
     else
       log.debug("No index and alias creation action performed because rollover_index or enable_ilm is set to: '#{rollover_index}', '#{enable_ilm}'")

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -810,6 +810,70 @@ class ElasticsearchOutput < Test::Unit::TestCase
     assert_requested(elastic_request)
   end
 
+  def test_template_create_with_rollover_index_and_template_related_placeholders_with_truncating_caches
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_template.json')
+    config = %{
+      host               logs.google.com
+      port               777
+      scheme             https
+      path               /es/
+      user               john
+      password           doe
+      template_name      logstash-${tag}
+      template_file      #{template_file}
+      rollover_index     true
+      index_date_pattern ""
+      index_name         fluentd-${tag}
+      deflector_alias    myapp_deflector-${tag}
+      truncate_caches_interval 2s
+    }
+
+    # connection start
+    stub_request(:head, "https://logs.google.com:777/es//").
+      with(basic_auth: ['john', 'doe']).
+    to_return(:status => 200, :body => "", :headers => {})
+    # check if template exists
+    stub_request(:get, "https://logs.google.com:777/es//_template/logstash-test.template").
+      with(basic_auth: ['john', 'doe']).
+      to_return(:status => 404, :body => "", :headers => {})
+    # create template
+    stub_request(:put, "https://logs.google.com:777/es//_template/logstash-test.template").
+      with(basic_auth: ['john', 'doe']).
+      to_return(:status => 200, :body => "", :headers => {})
+    # check if alias exists
+    stub_request(:head, "https://logs.google.com:777/es//_alias/myapp_deflector-test.template").
+      with(basic_auth: ['john', 'doe']).
+      to_return(:status => 404, :body => "", :headers => {})
+    # put the alias for the index
+    stub_request(:put, "https://logs.google.com:777/es//%3Cfluentd-test.template-default-000001%3E").
+      with(basic_auth: ['john', 'doe']).
+      to_return(status: 200, body: "", headers: {})
+    stub_request(:put, "https://logs.google.com:777/es//%3Cfluentd-test.template-default-000001%3E/_alias/myapp_deflector-test.template").
+      with(basic_auth: ['john', 'doe'],
+           body: "{\"aliases\":{\"myapp_deflector-test.template\":{\"is_write_index\":true}}}").
+      to_return(:status => 200, :body => "", :headers => {})
+
+    driver(config)
+
+    elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
+    driver.run(default_tag: 'test.template', shutdown: false) do
+      driver.feed(sample_record)
+    end
+    assert_equal('fluentd-test.template', index_cmds.first['index']['_index'])
+
+    assert_equal ["myapp_deflector-test.template"], driver.instance.alias_indexes
+    assert_equal ["logstash-test.template"], driver.instance.template_names
+
+    assert_requested(elastic_request)
+
+    sleep 0.1 until driver.instance.alias_indexes.empty?
+    sleep 0.1 until driver.instance.template_names.empty?
+
+    assert_equal [], driver.instance.alias_indexes
+    assert_equal [], driver.instance.template_names
+  end
+
   class TemplateIndexLifecycleManagementTest < self
     def setup
       begin


### PR DESCRIPTION
Provide timer which clears alias_indexes and template_names caches.
Related to #715, #716.

(check all that apply)
- [x] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
