### PR TITLE
Tweak travis.yml for suppressing validator warnings and add CI for Linux Arm64 architecture and macOS 10.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,28 @@
 language: ruby
 
-matrix:
+jobs:
   include:
     - rvm: 2.4.6
       gemfile: Gemfile
+      os: linux
     - rvm: 2.5.5
       gemfile: Gemfile
+      os: linux
     - rvm: 2.6.3
       gemfile: gemfiles/Gemfile.ilm
+      os: linux
     - rvm: 2.6.3
       gemfile: gemfiles/Gemfile.elasticsearch.v6
+      os: linux
     - rvm: 2.6.3
       gemfile: Gemfile
+      os: linux
+    - rvm: 2.6.3
+      gemfile: Gemfile
+      os: osx
     - rvm: 2.7.0
       gemfile: Gemfile
+      os: linux
 
 gemfile:
  - Gemfile
@@ -22,4 +31,3 @@ before_install:
   - gem update --system=2.7.8
 
 script: bundle exec rake test
-sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,35 @@ jobs:
     - rvm: 2.4.6
       gemfile: Gemfile
       os: linux
+      arch: amd64
     - rvm: 2.5.5
       gemfile: Gemfile
       os: linux
+      arch: amd64
     - rvm: 2.6.3
       gemfile: gemfiles/Gemfile.ilm
       os: linux
+      arch: amd64
     - rvm: 2.6.3
       gemfile: gemfiles/Gemfile.elasticsearch.v6
       os: linux
+      arch: amd64
     - rvm: 2.6.3
       gemfile: Gemfile
       os: linux
+      arch: amd64
+    - rvm: 2.6.3
+      gemfile: Gemfile
+      os: linux
+      arch: arm64
     - rvm: 2.6.3
       gemfile: Gemfile
       os: osx
+      osx_image: xcode11.3
     - rvm: 2.7.0
       gemfile: Gemfile
       os: linux
+      arch: amd64
 
 gemfile:
  - Gemfile


### PR DESCRIPTION
Tweak travis.yml to tidy up job for suppressing validator warnings and add CI for Linux Arm64 architecture and macOS 10.14.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
