### PR TITLE
Handle exception if index already exists

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -58,7 +58,7 @@ module Fluent::ElasticsearchIndexTemplate
   def indexcreation(index_name, host = nil)
     client(host).indices.create(:index => index_name)
   rescue Elasticsearch::Transport::Transport::Error => e
-    if e.message =~ /"already exists"/
+    if e.message =~ /"already exists"/ || e.message =~ /resource_already_exists_exception/
       log.debug("Index #{index_name} already exists")
     else
       log.error("Error while index creation - #{index_name}: #{e.inspect}")


### PR DESCRIPTION
Found this issue when trying elasticsearch 7.6.0, error message probably changed so it didn't match our test. Resulting in unnecessary failure loop.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
