### PR TITLE
Remove needless section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Current maintainers: @cosmo0920
   + [Cannot see detailed failure log](#cannot-see-detailed-failure-log)
   + [Cannot connect TLS enabled reverse Proxy](#cannot-connect-tls-enabled-reverse-proxy)
   + [Declined logs are resubmitted forever, why?](#declined-logs-are-resubmitted-forever-why)
-  + [Suggested to increase flush_thread_count, why?](#suggested-to-increase-flush_thread_count-why)
   + [Suggested to install typhoeus gem, why?](#suggested-to-install-typhoeus-gem-why)
   + [Stopped to send events on k8s, why?](#stopped-to-send-events-on-k8s-why)
   + [Random 400 - Rejected by Elasticsearch is occured, why?](#random-400---rejected-by-elasticsearch-is-occured-why)
@@ -1443,30 +1442,6 @@ The following configuration uses label:
     @type stdout
   </match>
 </label>
-```
-
-### Suggested to increase flush_thread_count, why?
-
-fluent-plugin-elasticsearch default behavior has a possibility to cause events traffic jam.
-When users use `flush_thread_count` = 1, ES plugin retries to send events if connection errors are disappeared.
-
-To prevent the following warning and sending events blocking, you must specify `flush_thread_count` >= 2:
-
-```log
-2018-12-24 14:32:06 +0900 [warn]: #0 To prevent events traffic jam, you should specify 2 or more 'flush_thread_count'.
-```
-
-```aconf
-<match out.elasticsearch.**>
-  @type elasticsearch
-  host localhost
-  port 9200
-  # ...
-  <buffer tag>
-    @type memory # or file
-    flush_thread_count 4
-  </buffer>
-</match>
 ```
 
 ### Suggested to install typhoeus gem, why?


### PR DESCRIPTION
Because increasing `flush_thread_count` suggestion had been removed in v4.0.0.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
