### PR TITLE
Added http_backend_excon_nonblock config in out_elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Current maintainers: @cosmo0920
   + [content_type](#content_type)
   + [include_index_in_url](#include_index_in_url)
   + [http_backend](#http_backend)
+  + [http_backend_excon_nonblock](#http_backend_excon_nonblock)
   + [prefer_oj_serializer](#prefer_oj_serializer)
   + [compression_level](#compression_level)
   + [Client/host certificate options](#clienthost-certificate-options)
@@ -814,6 +815,21 @@ Default value is `excon` which is default http_backend of elasticsearch plugin.
 
 ```
 http_backend typhoeus
+```
+
+### http_backend_excon_nonblock
+
+With `http_backend_excon_nonblock false`, elasticsearch plugin use excon with nonblock=false.
+If you use elasticsearch plugin with jRuby for https, you may need to consider to set `false` to avoid follwoing problems.
+- https://github.com/geemus/excon/issues/106
+- https://github.com/jruby/jruby-ossl/issues/19
+
+But for all other case, it strongly reccomend to set `true` to avoid process hangin problem reported in https://github.com/uken/fluent-plugin-elasticsearch/issues/732
+
+Default value is `true`.
+
+```
+http_backend_excon_nonblock false
 ```
 
 ### compression_level

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -143,6 +143,7 @@ see: https://github.com/elastic/elasticsearch-ruby/pull/514
 EOC
     config_param :include_index_in_url, :bool, :default => false
     config_param :http_backend, :enum, list: [:excon, :typhoeus], :default => :excon
+    config_param :http_backend_excon_nonblock, :bool, :default => true
     config_param :validate_client_version, :bool, :default => false
     config_param :prefer_oj_serializer, :bool, :default => false
     config_param :unrecoverable_error_types, :array, :default => ["out_of_memory_error", "es_rejected_execution_exception"]
@@ -409,7 +410,7 @@ EOC
     def backend_options
       case @http_backend
       when :excon
-        { client_key: @client_key, client_cert: @client_cert, client_key_pass: @client_key_pass }
+        { client_key: @client_key, client_cert: @client_cert, client_key_pass: @client_key_pass, nonblock: @http_backend_excon_nonblock }
       when :typhoeus
         require 'typhoeus'
         { sslkey: @client_key, sslcert: @client_cert, keypasswd: @client_key_pass }

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -328,6 +328,13 @@ EOC
         end
       end
 
+      if @ssl_version && @scheme == :https
+        if !@http_backend_excon_nonblock
+          log.warn "TLS handshake will be stucked with block connection.
+                    Consider to set `http_backend_excon_nonblock` as true"
+        end
+      end
+
       # Consider missing the prefix of "$." in nested key specifiers.
       @id_key = convert_compat_id_key(@id_key) if @id_key
       @parent_key = convert_compat_id_key(@parent_key) if @parent_key

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -333,6 +333,20 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     }
   end
 
+  sub_test_case 'Check TLS handshake stuck warning log' do
+    test 'warning TLS log' do
+      config = %{
+        scheme https
+        http_backend_excon_nonblock false
+        ssl_version TLSv1_2
+        @log_level info
+      }
+      driver(config)
+      logs = driver.logs
+      assert_logs_include(logs, /TLS handshake will be stucked with block connection.\n                    Consider to set `http_backend_excon_nonblock` as true\n/)
+    end
+  end
+
   sub_test_case 'ILM default config' do
     setup do
       begin

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -251,6 +251,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_equal 20 * 1024 * 1024, Fluent::Plugin::ElasticsearchOutput::TARGET_BULK_BYTES
     assert_false instance.compression
     assert_equal :no_compression, instance.compression_level
+    assert_true instance.http_backend_excon_nonblock
   end
 
   test 'configure compression' do


### PR DESCRIPTION
**Description of http_backend_excon_nonblock:**
 - If http_backend_excon_nonblock is true, Farday create Excon instance
 with nonblocking option which perform http request in nonblocking
 fassion
 - If http_backend_excon_nonblock is false, Fardday create Excon
 instance with blocking option which perform http request in blocking
 fassion

**Special Note about http_backend_excon_nonblock:**
If user use jRuby, you need to consider to configure http_backend_excon_nonblock=false.
Since you may experince some issue.
- https://github.com/geemus/excon/issues/106
- https://github.com/jruby/jruby-ossl/issues/19

But if user is not using jRuby, you'd better to configure
http_backend_excon_nonblock=true to prvent fluent-plugine-elasticsearch
from stucking

**Background:**
The older version of v1.0.0(latest as of 23 March 2020)
in Fardday(https://github.com/lostisland/farada),
When we use excon(https://github.com/excon/excon) as a adapter for
https, Faraday force to configure Excon to disable nonblock due to
following jRuby specific problem
- https://github.com/geemus/excon/issues/106
- https://github.com/jruby/jruby-ossl/issues/19

That's why currently when fluent-plugin-elasticsearch plugin connect to
Elastic Search, If it use http, Farday generate Excon instance with
nonblocking=true(default of Excon), but in the case of https, Farady
generate Excon instance with nonblocking=falase

This actually cause the problem making Farday HTTP Client stuck when SSL
Server(Elastic Search in current context) stuck during SSL Handshake
since Excon SSLSocket can not respecting to timeout, and rely on timeout
of SSL::SSLSocket in Ruby Standard Library which have exaclty process-hang
problem.

That's why sometimes flusth_thread of fluent-plugin-elasticsearch got
stuck when Elastic Search had something problem during SSL Session
handling.

Root cause of this problem is actually implementation of SSL::SSLSocket
in Ruby Standard Library(https://redmine.ruby-lang.org/issues/15729),
so better to fix Ruby side but it will take a time, and require ruby
version up, so better to provide the way to perform workaround.

(check all that apply)
- [ ] tests added
- [X] tests passing
- [X] README updated (if needed)
- [X] README Table of Contents updated (if needed)
- [X] History.md and `version` in gemspec are untouched
- [X] backward compatible
- [X] feature works in `elasticsearch_dynamic` (not required but recommended)
