### PR TITLE
Use newer tls protocol versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ If they are *not* specified in the Elasticsearch plugin configuration, `ssl_max_
 
 In Elasticsearch plugin v4.0.8 or later with Ruby 2.5 or later environment, `ssl_max_version` should be `TLSv1_3` and `ssl_min_version` should be `TLSv1_2`.
 
-From Elasticsearch plugin v4.0.4 to v4.0.7 with RUby 2.5 or later environment, the value of `ssl_version` will be *used in `ssl_max_version` and `ssl_min_version`*.
+From Elasticsearch plugin v4.0.4 to v4.0.7 with Ruby 2.5 or later environment, the value of `ssl_version` will be *used in `ssl_max_version` and `ssl_min_version`*.
 
 
 ### Proxy Support

--- a/README.md
+++ b/README.md
@@ -881,7 +881,11 @@ ssl_min_version TLSv1_2
 
 Elasticsearch plugin will use TLSv1.2 as minimum ssl version and TLSv1.3 as maximum ssl version on transportation with TLS. Note that when they are used in Elastissearch plugin configuration, *`ssl_version` is not used* to set up TLS version.
 
-If they are *not* specified in the Elasticsearch plugin configuration, the value of `ssl_version` will be *used in `ssl_max_version` and `ssl_min_version`*.
+If they are *not* specified in the Elasticsearch plugin configuration, `ssl_max_version` and `ssl_min_version` is set up with:
+
+In Elasticsearch plugin v4.0.8 or later with Ruby 2.5 or later environment, `ssl_max_version` should be `TLSv1_3` and `ssl_min_version` should be `TLSv1_2`.
+
+From Elasticsearch plugin v4.0.4 to v4.0.7 with RUby 2.5 or later environment, the value of `ssl_version` will be *used in `ssl_max_version` and `ssl_min_version`*.
 
 
 ### Proxy Support

--- a/lib/fluent/plugin/elasticsearch_tls.rb
+++ b/lib/fluent/plugin/elasticsearch_tls.rb
@@ -10,7 +10,7 @@ module Fluent::Plugin
                                [:SSLv23, :TLSv1, :TLSv1_1, :TLSv1_2].freeze
                              end
 
-    DEFAULT_VERSION = :TLSv1
+    DEFAULT_VERSION = :TLSv1_2
     METHODS_MAP = begin
                     # When openssl supports OpenSSL::SSL::TLSXXX constants representations, we use them.
                     map = {
@@ -48,8 +48,8 @@ module Fluent::Plugin
       if USE_TLS_MINMAX_VERSION
         case
         when ssl_min_version.nil? && ssl_max_version.nil?
-          ssl_min_version = METHODS_MAP[ssl_version]
-          ssl_max_version = METHODS_MAP[ssl_version]
+          ssl_min_version = METHODS_MAP[:TLSv1_2]
+          ssl_max_version = METHODS_MAP[:TLSv1_3]
         when ssl_min_version && ssl_max_version.nil?
           raise Fluent::ConfigError, "When you set 'ssl_min_version', must set 'ssl_max_version' together."
         when ssl_min_version.nil? && ssl_max_version

--- a/test/plugin/test_elasticsearch_tls.rb
+++ b/test/plugin/test_elasticsearch_tls.rb
@@ -62,8 +62,8 @@ class TestElasticsearchTLS < Test::Unit::TestCase
       d = driver('')
       ssl_version_options = d.instance.set_tls_minmax_version_config(d.instance.ssl_version, nil, nil)
       if @use_tls_minmax_version
-        assert_equal({max_version: OpenSSL::SSL::TLS1_VERSION,
-                      min_version: OpenSSL::SSL::TLS1_VERSION}, ssl_version_options)
+        assert_equal({max_version: OpenSSL::SSL::TLS1_3_VERSION,
+                      min_version: OpenSSL::SSL::TLS1_2_VERSION}, ssl_version_options)
       else
         assert_equal({version: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION}, ssl_version_options)
       end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -230,7 +230,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_nil instance.ssl_max_version
     assert_nil instance.ssl_min_version
     if Fluent::Plugin::ElasticsearchTLS::USE_TLS_MINMAX_VERSION
-      assert_equal({max_version: OpenSSL::SSL::TLS1_VERSION, min_version: OpenSSL::SSL::TLS1_VERSION},
+      assert_equal({max_version: OpenSSL::SSL::TLS1_3_VERSION, min_version: OpenSSL::SSL::TLS1_2_VERSION},
                    instance.ssl_version_options)
     else
       assert_equal({version: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION},

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -101,7 +101,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     assert_nil instance.ssl_max_version
     assert_nil instance.ssl_min_version
     if Fluent::Plugin::ElasticsearchTLS::USE_TLS_MINMAX_VERSION
-      assert_equal({max_version: OpenSSL::SSL::TLS1_VERSION, min_version: OpenSSL::SSL::TLS1_VERSION},
+      assert_equal({max_version: OpenSSL::SSL::TLS1_3_VERSION, min_version: OpenSSL::SSL::TLS1_2_VERSION},
                    instance.ssl_version_options)
     else
       assert_equal({version: Fluent::Plugin::ElasticsearchTLS::DEFAULT_VERSION},


### PR DESCRIPTION
Fixes #736 
We should consider Elasticsearch 6.x and 7.x lines.
So, we should use newer TLS procotol version such as TLS v1.2 and TLS v1.3 by default.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
