### PR TITLE
Only set Content-Encoding:gzip when body is gzip compressed

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -525,12 +525,7 @@ EOC
           local_reload_connections = @reload_after
         end
 
-        gzip_headers = if compression
-                         {'Content-Encoding' => 'gzip'}
-                       else
-                         {}
-                       end
-        headers = { 'Content-Type' => @content_type.to_s }.merge(@custom_headers).merge(gzip_headers)
+        headers = { 'Content-Type' => @content_type.to_s }.merge(@custom_headers)
         ssl_options = { verify: @ssl_verify, ca_file: @ca_file}.merge(@ssl_version_options)
 
         transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
@@ -947,7 +942,13 @@ EOC
                           data
                         end
 
-        response = client(info.host).bulk body: prepared_data, index: info.index
+        headers = if compression
+                    {'Content-Encoding' => 'gzip'}
+                  else
+                    {}
+                  end
+
+        response = client(info.host).bulk body: prepared_data, headers: headers, index: info.index
         log.on_trace { log.trace "bulk response: #{response}" }
 
         if response['errors']


### PR DESCRIPTION
When sending a bulk index request with a gzip compressed body ( e.g. `compression_level` is not `no_compression`), then we need to set the request header `Content-Encoding: gzip` in the HTTP request.

Currently this is done globally on `client`, however that way will cause dynamic mapping template creation and possibly other requests to fail, as those requests do not have a gzip compressed request body.

This is PR is one way to resolve the problem: Only set `Content-Encoding: gzip` on the requests that have a compressed body.

This depends on https://github.com/elastic/elasticsearch-ruby/pull/820