### PR TITLE
Add possibility to configure multiple ILM policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Current maintainers: @cosmo0920
   + [enable_ilm](#enable_ilm)
   + [ilm_policy_id](#ilm_policy_id)
   + [ilm_policy](#ilm_policy)
+  + [ilm_policies](#ilm_policies)
   + [ilm_policy_overwrite](#ilm_policy_overwrite)
   + [truncate_caches_interval](#truncate_caches_interval)
 * [Configuration - Elasticsearch Input](#configuration---elasticsearch-input)
@@ -1208,6 +1209,14 @@ Default value is `logstash-policy`.
 ## ilm_policy
 
 Specify ILM policy contents as Hash.
+
+Default value is `{}`.
+
+**NOTE:** This parameter requests to install elasticsearch-xpack gem.
+
+## ilm_policies
+
+A hash in the format `{"ilm_policy_id1":{ <ILM policy 1 hash> }, "ilm_policy_id2": { <ILM policy 2 hash> }}`.
 
 Default value is `{}`.
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1317,6 +1317,78 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
     end
 
+    def test_template_create_with_rollover_index_and_ilm_policies_and_placeholders
+      cwd = File.dirname(__FILE__)
+      template_file = File.join(cwd, 'test_template.json')
+
+      config = %{
+        host            logs.google.com
+        port            777
+        scheme          https
+        path            /es/
+        user            john
+        password        doe
+        template_name   logstash
+        template_file   #{template_file}
+        index_date_pattern now/w{xxxx.ww}
+        ilm_policy_id   fluentd-policy
+        enable_ilm      true
+        index_name      logstash
+        ilm_policies    {"fluentd-policy":{"policy":{"phases":{"hot":{"actions":{"rollover":{"max_size":"70gb", "max_age":"30d"}}}}}}}
+      }
+
+      # connection start
+      stub_request(:head, "https://logs.google.com:777/es//").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => "", :headers => {})
+      # check if template exists
+      stub_request(:get, "https://logs.google.com:777/es//_template/logstash").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 404, :body => "", :headers => {})
+      # creation
+      stub_request(:put, "https://logs.google.com:777/es//_template/logstash").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => "", :headers => {})
+      # check if alias exists
+      stub_request(:head, "https://logs.google.com:777/es//_alias/logstash").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 404, :body => "", :headers => {})
+      stub_request(:get, "https://logs.google.com:777/es//_template/logstash").
+        with(basic_auth: ['john', 'doe']).
+        to_return(status: 404, body: "", headers: {})
+      stub_request(:put, "https://logs.google.com:777/es//_template/logstash").
+        with(basic_auth: ['john', 'doe'],
+             body: "{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"fluentd-policy\",\"index.lifecycle.rollover_alias\":\"myalogs\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}},\"index_patterns\":\"mylogs-*\",\"order\":51}").
+        to_return(status: 200, body: "", headers: {})
+      # put the alias for the index
+      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => "", :headers => {})
+      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/logstash").
+        with(body: "{\"aliases\":{\"logstash\":{\"is_write_index\":true}}}").
+        to_return(status: 200, body: "", headers: {})
+      stub_request(:get, "https://logs.google.com:777/es//_xpack").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+      stub_request(:get, "https://logs.google.com:777/es//_ilm/policy/fluentd-policy").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 404, :body => "", :headers => {})
+      stub_request(:put, "https://logs.google.com:777/es//_ilm/policy/fluentd-policy").
+        with(basic_auth: ['john', 'doe'],
+             :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"70gb\",\"max_age\":\"30d\"}}}}}}").
+        to_return(:status => 200, :body => "", :headers => {})
+
+      driver(config)
+
+      elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
+      driver.run(default_tag: 'test') do
+        driver.feed(sample_record)
+      end
+      assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
+
+      assert_requested(elastic_request)
+    end
+
     def test_template_create_with_rollover_index_and_default_ilm_and_placeholders
       cwd = File.dirname(__FILE__)
       template_file = File.join(cwd, 'test_template.json')

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1389,6 +1389,152 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       assert_requested(elastic_request)
     end
 
+    class TemplateCreateWithRolloverIndexAndILMPoliciesWithPlaceholdersTest < self
+      def test_tag_placeholder
+        cwd = File.dirname(__FILE__)
+        template_file = File.join(cwd, 'test_template.json')
+
+        config = %{
+          host            logs.google.com
+          port            777
+          scheme          https
+          path            /es/
+          user            john
+          password        doe
+          template_name   logstash
+          template_file   #{template_file}
+          index_date_pattern now/w{xxxx.ww}
+          ilm_policy_id   ${tag}
+          enable_ilm      true
+          index_name      logstash
+          ilm_policies    {"fluentd-policy":{"policy":{"phases":{"hot":{"actions":{"rollover":{"max_size":"70gb", "max_age":"30d"}}}}}}}
+        }
+
+        # connection start
+        stub_request(:head, "https://logs.google.com:777/es//").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => "", :headers => {})
+        # check if template exists
+        stub_request(:get, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 404, :body => "", :headers => {})
+        # creation
+        stub_request(:put, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => "", :headers => {})
+        # check if alias exists
+        stub_request(:head, "https://logs.google.com:777/es//_alias/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:get, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(status: 404, body: "", headers: {})
+        stub_request(:put, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe'],
+               body: "{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"fluentd-policy\",\"index.lifecycle.rollover_alias\":\"myalogs\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}},\"index_patterns\":\"mylogs-*\",\"order\":51}").
+          to_return(status: 200, body: "", headers: {})
+        # put the alias for the index
+        stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => "", :headers => {})
+        stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/logstash").
+          with(body: "{\"aliases\":{\"logstash\":{\"is_write_index\":true}}}").
+          to_return(status: 200, body: "", headers: {})
+        stub_request(:get, "https://logs.google.com:777/es//_xpack").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+        stub_request(:get, "https://logs.google.com:777/es//_ilm/policy/fluentd-policy").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:put, "https://logs.google.com:777/es//_ilm/policy/fluentd-policy").
+          with(basic_auth: ['john', 'doe'],
+               body: "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"70gb\",\"max_age\":\"30d\"}}}}}}").
+          to_return(:status => 200, :body => "", :headers => {})
+
+        driver(config)
+
+        elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
+        driver.run(default_tag: 'fluentd-policy') do
+          driver.feed(sample_record)
+        end
+        assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
+
+        assert_requested(elastic_request)
+      end
+
+      def test_tag_placeholder_with_multiple_policies
+        cwd = File.dirname(__FILE__)
+        template_file = File.join(cwd, 'test_template.json')
+
+        config = %{
+          host            logs.google.com
+          port            777
+          scheme          https
+          path            /es/
+          user            john
+          password        doe
+          template_name   logstash
+          template_file   #{template_file}
+          index_date_pattern now/w{xxxx.ww}
+          ilm_policy_id   ${tag}
+          enable_ilm      true
+          index_name      logstash
+          ilm_policies    {"fluentd-policy":{"policy":{"phases":{"hot":{"actions":{"rollover":{"max_size":"70gb", "max_age":"30d"}}}}}}, "fluentd-policy2":{"policy":{"phases":{"hot":{"actions":{"rollover":{"max_size":"80gb", "max_age":"20d"}}}}}}}
+        }
+
+        # connection start
+        stub_request(:head, "https://logs.google.com:777/es//").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => "", :headers => {})
+        # check if template exists
+        stub_request(:get, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 404, :body => "", :headers => {})
+        # creation
+        stub_request(:put, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => "", :headers => {})
+        # check if alias exists
+        stub_request(:head, "https://logs.google.com:777/es//_alias/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:get, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe']).
+          to_return(status: 404, body: "", headers: {})
+        stub_request(:put, "https://logs.google.com:777/es//_template/logstash").
+          with(basic_auth: ['john', 'doe'],
+               body: "{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"fluentd-policy\",\"index.lifecycle.rollover_alias\":\"myalogs\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}},\"index_patterns\":\"mylogs-*\",\"order\":51}").
+          to_return(status: 200, body: "", headers: {})
+        # put the alias for the index
+        stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => "", :headers => {})
+        stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/logstash").
+          with(body: "{\"aliases\":{\"logstash\":{\"is_write_index\":true}}}").
+          to_return(status: 200, body: "", headers: {})
+        stub_request(:get, "https://logs.google.com:777/es//_xpack").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+        stub_request(:get, "https://logs.google.com:777/es//_ilm/policy/fluentd-policy2").
+          with(basic_auth: ['john', 'doe']).
+          to_return(:status => 404, :body => "", :headers => {})
+        stub_request(:put, "https://logs.google.com:777/es//_ilm/policy/fluentd-policy2").
+          with(basic_auth: ['john', 'doe'],
+               body: "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"80gb\",\"max_age\":\"20d\"}}}}}}").
+          to_return(:status => 200, :body => "", :headers => {})
+
+        driver(config)
+
+        elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
+        driver.run(default_tag: 'fluentd-policy2') do
+          driver.feed(sample_record)
+        end
+        assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
+
+        assert_requested(elastic_request)
+      end
+    end
+
     def test_template_create_with_rollover_index_and_default_ilm_and_placeholders
       cwd = File.dirname(__FILE__)
       template_file = File.join(cwd, 'test_template.json')


### PR DESCRIPTION
This PR adds to possibility to configure multiple ILM policies. There is now a new configuration parameter `ilm_policies` which is a hash that contains the ILM policies with their policy id as key. The configuration parameter `ilm_policy_id` can now contain placeholders as well.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
