### PR TITLE
Suppress type in meta with suppress_type_name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Current maintainers: @cosmo0920
   + [time_key_exclude_timestamp](#time_key_exclude_timestamp)
   + [include_timestamp](#include_timestamp)
   + [utc_index](#utc_index)
+  + [suppress_type_name](#suppress_type_name)
   + [target_index_key](#target_index_key)
   + [target_type_key](#target_type_key)
   + [template_name](#template_name)
@@ -352,6 +353,20 @@ utc_index true
 ```
 
 By default, the records inserted into index `logstash-YYMMDD` with UTC (Coordinated Universal Time). This option allows to use local time if you describe utc_index to false.
+
+### suppress_type_name
+
+In Elasticsearch 7.x, Elasticsearch cluster complains the following types removal warnings:
+
+```json
+{"type": "deprecation", "timestamp": "2020-07-03T08:02:20,830Z", "level": "WARN", "component": "o.e.d.a.b.BulkRequestParser", "cluster.name": "docker-cluster", "node.name": "70dd5c6b94c3", "message": "[types removal] Specifying types in bulk requests is deprecated.", "cluster.uuid": "NoJJmtzfTtSzSMv0peG8Wg", "node.id": "VQ-PteHmTVam2Pnbg7xWHw"  }
+```
+
+This can be suppressed with:
+
+```
+suppress_type_name true
+```
 
 ### target_index_key
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -3147,6 +3147,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   data("border"        => {"es_version" => 6, "_type" => "mytype"},
        "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
+       "to be nil"     => {"es_version" => 8, "_type" => nil},
       )
   def test_writes_to_speficied_type(data)
     driver('', data["es_version"]).configure("type_name mytype\n")
@@ -3159,9 +3160,24 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   data("border"        => {"es_version" => 6, "_type" => "mytype.test"},
        "fixed_behavior"=> {"es_version" => 7, "_type" => "_doc"},
+       "to be nil"     => {"es_version" => 8, "_type" => nil},
       )
   def test_writes_to_speficied_type_with_placeholders(data)
     driver('', data["es_version"]).configure("type_name mytype.${tag}\n")
+    stub_elastic
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+    assert_equal(data['_type'], index_cmds.first['index']['_type'])
+  end
+
+  data("border"        => {"es_version" => 6, "_type" => "mytype.test"},
+       "fixed_behavior"=> {"es_version" => 7, "_type" => nil},
+       "to be nil"     => {"es_version" => 8, "_type" => nil},
+      )
+  def test_writes_to_speficied_type_with_suppress_type_name(data)
+    driver('', data["es_version"])
+      .configure("type_name mytype.${tag}\nsuppress_type_name true")
     stub_elastic
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)


### PR DESCRIPTION
Fixes #766.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
