### PR TITLE
filter_elasticsearch_genid: Use entire record as hash seed

### DIFF
--- a/README.ElasticsearchGenID.md
+++ b/README.ElasticsearchGenID.md
@@ -1,0 +1,116 @@
+## Index
+
+* [Usage](#usage)
+* [Configuration](#configuration)
+  + [hash_id_key](#hash_id_key)
+  + [include_tag_in_seed](#include_tag_in_seed)
+  + [include_time_in_seed](#include_time_in_seed)
+  + [use_record_as_seed](#use_record_as_seed)
+  + [use_entire_record](#use_entire_record)
+  + [record_keys](#record_keys)
+  + [separator](#separator)
+  + [hash_type](#hash_type)
+* [Advanced Usage](#advanced-usage)
+
+## Usage
+
+In your Fluentd configuration, use `@type elasticsearch_genid`. Additional configuration is optional, default values would look like this:
+
+```
+<source>
+  @type elasticsearch_genid
+  hash_id_key _hash
+  include_tag_in_seed false
+  include_time_in_seed false
+  use_record_as_seed false
+  use_entire_record false
+  record_keys []
+  separator _
+  hash_type md5
+</match>
+```
+
+## Configuration
+
+### hash_id_key
+
+```
+hash_id_key _id
+```
+
+You can specify generated hash storing key.
+
+### include_tag_in_seed
+
+```
+include_tag_in_seed true
+```
+
+You can specify to use tag for hash generation seed.
+
+### include_time_in_seed
+
+```
+include_time_in_seed true
+```
+
+You can specify to use time for hash generation seed.
+
+### use_record_as_seed
+
+```
+use_record_as_seed true
+```
+
+You can specify to use record in events for hash generation seed. This parameter should be used with [record_keys](#record_keys) parameter in practice.
+
+### record_keys
+
+```
+record_keys request_id,pipeline_id
+```
+
+You can specify keys which are record in events for hash generation seed. This parameter should be used with [use_record_as_seed](#use_record_as_seed) parameter in practice.
+
+### use_entire_record
+
+```
+use_entire_record true
+```
+
+You can specify to use entire record in events for hash generation seed.
+
+
+### separator
+
+```
+separator |
+```
+
+You can specify separator charactor to creating seed for hash generation.
+
+### hash_type
+
+```
+hash_type sha1
+```
+
+You can specify hash algorithm.
+
+## Advanced Usage
+
+Elasticsearch GenID plugin can handle record contents differing with the following parameters:
+
+```aconf
+<filter the.awesome.your.routing.tag>
+  @type elasticsearch_genid
+  use_entire_record true
+  hash_type sha1
+  hash_id_key _hash
+  separator _
+  inc_time_as_key true
+  inc_tag_as_key true
+</filter>
+```
+
+The above configuration can handle tag, time, and record differing and generate different base64 encoded hash per record.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Current maintainers: @cosmo0920
   + [ilm_policy_overwrite](#ilm_policy_overwrite)
   + [truncate_caches_interval](#truncate_caches_interval)
 * [Configuration - Elasticsearch Input](#configuration---elasticsearch-input)
+* [Configuration - Elasticsearch Filter GenID](#configuration---elasticsearch-filter-genid)
 * [Elasticsearch permissions](#elasticsearch-permissions)
 * [Troubleshooting](#troubleshooting)
   + [Cannot send events to elasticsearch](#cannot-send-events-to-elasticsearch)
@@ -1259,6 +1260,10 @@ Default value is `nil`.
 ## Configuration - Elasticsearch Input
 
 See [Elasticsearch Input plugin document](README.ElasticsearchInput.md)
+
+## Configuration - Elasticsearch Filter GenID
+
+See [Elasticsearch Filter GenID document](README.ElasticsearchGenID.md)
 
 ## Elasticsearch permissions
 

--- a/lib/fluent/plugin/filter_elasticsearch_genid.rb
+++ b/lib/fluent/plugin/filter_elasticsearch_genid.rb
@@ -24,20 +24,34 @@ module Fluent::Plugin
       if @record_keys.empty? && @use_record_as_seed
         raise Fluent::ConfigError, "When using record as hash seed, users must specify `record_keys`."
       end
+
+      if @use_record_as_seed
+        class << self
+          alias_method :filter, :filter_seed_as_record
+        end
+      else
+        class << self
+          alias_method :filter, :filter_simple
+        end
+      end
     end
 
     def filter(tag, time, record)
-      if @use_record_as_seed
-        seed = ""
-        seed += tag + separator if @include_tag_in_seed
-        seed += time.to_s + separator if @include_time_in_seed
-        seed += record_keys.map {|k| record[k]}.join(separator)
-        record[@hash_id_key] = Base64.strict_encode64(encode_hash(@hash_type, seed))
-        record
-      else
-        record[@hash_id_key] = Base64.strict_encode64(SecureRandom.uuid)
-        record
-      end
+      # for safety.
+    end
+
+    def filter_simple(tag, time, record)
+      record[@hash_id_key] = Base64.strict_encode64(SecureRandom.uuid)
+      record
+    end
+
+    def filter_seed_as_record(tag, time, record)
+      seed = ""
+      seed += tag + separator if @include_tag_in_seed
+      seed += time.to_s + separator if @include_time_in_seed
+      seed += record_keys.map {|k| record[k]}.join(separator)
+      record[@hash_id_key] = Base64.strict_encode64(encode_hash(@hash_type, seed))
+      record
     end
 
     def encode_hash(type, seed)

--- a/test/plugin/test_filter_elasticsearch_genid.rb
+++ b/test/plugin/test_filter_elasticsearch_genid.rb
@@ -130,4 +130,86 @@ class ElasticsearchGenidFilterTest < Test::Unit::TestCase
                    d.filtered.map {|e| e.last}.first[d.instance.hash_id_key])
     end
   end
+
+  class UseEntireRecordAsSeedTest < self
+    data("md5" => ["md5", "MuMU0gHOP1cWvvg/J4aEFg=="],
+         "sha1" => ["sha1", "GZ6Iup9Ywyk5spCWtPQbtZnfK0U="],
+         "sha256" => ["sha256", "O4YN0RiXCUAYeaR97UUULRLxgra/R2dvTV47viir5l4="],
+         "sha512" => ["sha512", "FtbwO1xsLUq0KcO0mj0l80rbwFH5rGE3vL+Vgh90+4R/9j+/Ni/ipwhiOoUcetDxj1r5Vf/92B54La+QTu3eMA=="],)
+    def test_record
+      hash_type, expected = data
+      d = create_driver(%[
+        use_record_as_seed true
+        use_entire_record true
+        hash_type #{hash_type}
+      ])
+      time = event_time("2017-10-15 15:00:23.34567890 UTC")
+      d.run(default_tag: 'test.fluentd') do
+        d.feed(time, sample_record.merge("custom_key" => "This is also encoded value."))
+      end
+      assert_equal(expected,
+                   d.filtered.map {|e| e.last}.first[d.instance.hash_id_key])
+    end
+
+    data("md5" => ["md5", "GJfpWe8ofiGzn97bc9Gh0Q=="],
+         "sha1" => ["sha1", "AVaK67Tz0bEJ8xNEzjOQ6r9fAu4="],
+         "sha256" => ["sha256", "WIXWAuf/Z94Uw95mudloo2bgjhSsSduQIwkKTQsNFgU="],
+         "sha512" => ["sha512", "yjMGGxy8uc7gCrPgm8W6MzJGLFk0GtUwJ6w/91laf6WNywuvG/7T6kNHLagAV8rSW8xzxmtEfyValBO5scuoKw=="],)
+    def test_record_with_tag
+      hash_type, expected = data
+      d = create_driver(%[
+        use_record_as_seed true
+        use_entire_record true
+        hash_type #{hash_type}
+        include_tag_in_seed true
+      ])
+      time = event_time("2017-10-15 15:00:23.34567890 UTC")
+      d.run(default_tag: 'test.fluentd') do
+        d.feed(time, sample_record.merge("custom_key" => "This is also encoded value."))
+      end
+      assert_equal(expected,
+                   d.filtered.map {|e| e.last}.first[d.instance.hash_id_key])
+    end
+
+    data("md5" => ["md5", "5nQSaJ4F1p9rDFign13Lfg=="],
+         "sha1" => ["sha1", "hyo9+0ZFBpizKl2NShs3C8yQcGw="],
+         "sha256" => ["sha256", "romVsZSIksbqYsOSnUzolZQw76ankcy0DgvDZ3CayTo="],
+         "sha512" => ["sha512", "RPU7K2Pt0iVyvV7p5usqcUIIOmfTajD1aa7pkR9qZ89UARH/lpm6ESY9iwuYJj92lxOUuF5OxlEwvV7uXJ07iA=="],)
+    def test_record_with_time
+      hash_type, expected = data
+      d = create_driver(%[
+        use_record_as_seed true
+        use_entire_record true
+        hash_type #{hash_type}
+        include_time_in_seed true
+      ])
+      time = event_time("2017-10-15 15:00:23.34567890 UTC")
+      d.run(default_tag: 'test.fluentd') do
+        d.feed(time, sample_record.merge("custom_key" => "This is also encoded value."))
+      end
+      assert_equal(expected,
+                   d.filtered.map {|e| e.last}.first[d.instance.hash_id_key])
+    end
+
+    data("md5" => ["md5", "zGQF35KlMUibJAcgkgQDtw=="],
+         "sha1" => ["sha1", "1x9RZO1xEuWps090qq4DUIsU9x8="],
+         "sha256" => ["sha256", "eulMz0eF56lBEf31aIs0OG2TGCH/aoPfZbRqfEOkAwk="],
+         "sha512" => ["sha512", "mIiYATtpdUFEFCIZg1FdKssIs7oWY0gJjhSSbet0ddUmqB+CiQAcAMTmrXO6AVSH0vsMvao/8vtC8AsIPfF1fA=="],)
+    def test_record_with_tag_and_time
+      hash_type, expected = data
+      d = create_driver(%[
+        use_record_as_seed true
+        use_entire_record true
+        hash_type #{hash_type}
+        include_tag_in_seed true
+        include_time_in_seed true
+      ])
+      time = event_time("2017-10-15 15:00:23.34567890 UTC")
+      d.run(default_tag: 'test.fluentd') do
+        d.feed(time, sample_record.merge("custom_key" => "This is also encoded value."))
+      end
+      assert_equal(expected,
+                   d.filtered.map {|e| e.last}.first[d.instance.hash_id_key])
+    end
+  end
 end


### PR DESCRIPTION
This PR was requested in https://github.com/uken/fluent-plugin-elasticsearch/issues/767#issuecomment-653575548.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
