### PR TITLE
Use Hash#dig instead of Hash#[] on retrieving version information from Elasticsearch info API

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -461,7 +461,10 @@ EOC
 
     def detect_es_major_version
       @_es_info ||= client.info
-      @_es_info["version"]["number"].to_i
+      unless version = @_es_info.dig("version", "number")
+        version = @default_elasticsearch_version
+      end
+      version.to_i
     end
 
     def client_library_version

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -707,7 +707,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       Fluent::Plugin::ElasticsearchOutput.module_eval(<<-CODE)
         def detect_es_major_version
           @_es_info ||= client.info
-          @_es_info["version"]["number"].to_i
+          unless version = @_es_info.dig("version", "number")
+            version = @default_elasticsearch_version
+          end
+          version.to_i
         end
       CODE
       Fluent::Plugin::ElasticsearchOutput.module_eval(<<-CODE)
@@ -753,7 +756,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       Fluent::Plugin::ElasticsearchOutput.module_eval(<<-CODE)
         def detect_es_major_version
           @_es_info ||= client.info
-          @_es_info["version"]["number"].to_i
+          unless version = @_es_info.dig("version", "number")
+            version = @default_elasticsearch_version
+          end
+          version.to_i
         end
       CODE
       Fluent::Plugin::ElasticsearchOutput.module_eval(<<-CODE)


### PR DESCRIPTION
Hash#dig(key, ...) can handle nested key without exception.

Hash#[].[] should be dangerous calling when assumed structure is not suitable for received json.
Hash#dig(key, ...) won't raise error when provided key does not exist.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
