### PR TITLE
Load multiple templates even if template_name and template_file given

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Specify index templates in form of hash. Can contain multiple templates.
 templates { "template_name_1": "path_to_template_1_file", "template_name_2": "path_to_template_2_file"}
 ```
 
-If `template_file` and `template_name` are set, then this parameter will be ignored.
+**Note:** Before ES plugin v4.1.2, if `template_file` and `template_name` are set, then this parameter will be ignored. In 4.1.3 or later, `template_file` and `template_name` can work with `templates`.
 
 ### customize_template
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -247,7 +247,8 @@ EOC
             template_installation_actual(@deflector_alias ? @deflector_alias : @index_name, @template_name, @customize_template, @application_name, @index_name, @ilm_policy_id)
           end
           verify_ilm_working if @enable_ilm
-        elsif @templates
+        end 
+        if @templates
           retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
             templates_hash_install(@templates, @template_overwrite)
           end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -2659,7 +2659,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_requested(:put, "https://logs.google.com:777/es//_template/logstash3", times: 1)
   end
 
-  def test_templates_not_used
+  def test_templates_are_also_used
     cwd = File.dirname(__FILE__)
     template_file = File.join(cwd, 'test_template.json')
 
@@ -2703,8 +2703,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
     assert_requested(:put, "https://logs.google.com:777/es//_template/logstash", times: 1)
 
-    assert_not_requested(:put, "https://logs.google.com:777/es//_template/logstash1")
-    assert_not_requested(:put, "https://logs.google.com:777/es//_template/logstash2")
+    assert_requested(:put, "https://logs.google.com:777/es//_template/logstash1")
+    assert_requested(:put, "https://logs.google.com:777/es//_template/logstash2")
   end
 
   def test_templates_can_be_partially_created_if_error_occurs


### PR DESCRIPTION

This allows loading some auxiliary templates on startup even when using ILM.

If you are OK with this general approach I can adjust the other stuff (docs, tests?)
