### PR TITLE
index_template: Handle error object entirely on index creation failure

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -61,7 +61,7 @@ module Fluent::ElasticsearchIndexTemplate
     if e.message =~ /"already exists"/ || e.message =~ /resource_already_exists_exception/
       log.debug("Index #{index_name} already exists")
     else
-      log.error("Error while index creation - #{index_name}: #{e.inspect}")
+      log.error("Error while index creation - #{index_name}", error: e)
     end
   end
 


### PR DESCRIPTION
ref: https://github.com/fluent/fluentd/blob/master/lib/fluent/log.rb#L369
ref: https://github.com/fluent/fluentd/blob/adca0296bfcbb8696afa949a55e82807dd69c155/lib/fluent/log.rb#L511

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

Related to https://github.com/uken/fluent-plugin-elasticsearch/issues/803.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
