### PR TITLE
Handle api key header

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Current maintainers: @cosmo0920
   + [verify_es version at startup](#verify_es_version_at_startup)
   + [default_elasticsearch_version](#default_elasticsearch_version)
   + [custom_headers](#custom_headers)
+  + [api_key](#api_key)
   + [Not seeing a config you need?](#not-seeing-a-config-you-need)
   + [Dynamic configuration](#dynamic-configuration)
   + [Placeholders](#placeholders)
@@ -1104,6 +1105,14 @@ This parameter adds additional headers to request. The default value is `{}`.
 
 ```
 custom_headers {"token":"secret"}
+```
+
+### api_key
+
+This parameter adds authentication header. The default value is `nil`.
+
+```
+api_key "ElasticsearchAPIKEY"
 ```
 
 ### Not seeing a config you need?

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -252,6 +252,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_false instance.compression
     assert_equal :no_compression, instance.compression_level
     assert_true instance.http_backend_excon_nonblock
+    assert_equal({}, instance.api_key_header)
   end
 
   test 'configure compression' do
@@ -2904,6 +2905,18 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
                         with(headers: {'custom' => 'header1','and_others' => 'header2' })
     driver.configure(%[custom_headers {"custom":"header1", "and_others":"header2"}])
+    driver.run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+    assert_requested(elastic_request)
+  end
+
+  def test_api_key_header
+    stub_request(:head, "http://localhost:9200/").
+      to_return(:status => 200, :body => "", :headers => {})
+    elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
+                        with(headers: {'Authorization'=>'ApiKey dGVzdGF1dGhoZWFkZXI='})
+    driver.configure(%[api_key testauthheader])
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end


### PR DESCRIPTION
Closes #806.

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
