### PR TITLE
Include chunk_id in records

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Current maintainers: @cosmo0920
   + [ilm_policy_overwrite](#ilm_policy_overwrite)
   + [truncate_caches_interval](#truncate_caches_interval)
   + [use_legacy_template](#use_legacy_template)
+  + [metadata section](#metadata-section)
+    + [include_chunk_id](#include_chunk_id)
+    + [chunk_id_key](#chunk_id_key)
 * [Configuration - Elasticsearch Input](#configuration---elasticsearch-input)
 * [Configuration - Elasticsearch Filter GenID](#configuration---elasticsearch-filter-genid)
 * [Elasticsearch permissions](#elasticsearch-permissions)
@@ -1315,6 +1318,51 @@ For Elasticsearch 7.7 or older, users should specify this parameter as `false`.
 Composable template documentation is [Put Index Template API | Elasticsearch Reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html) and legacy template documentation is [Index Templates | Elasticsearch Reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html).
 
 Please confirm that whether the using Elasticsearch cluster(s) support the composable template feature or not when turn on the brand new feature with this parameter.
+
+## <metadata\> section
+
+Users can specify whether including `chunk_id` information into records or not:
+
+```aconf
+<match your.awesome.routing.tag>
+  @type elasticsearch
+  # Other configurations.
+  <metadata>
+    include_chunk_id true
+    # chunk_id_key chunk_id # Default value is "chunk_id".
+  </metadata>
+</match>
+```
+
+### include_chunk_id
+
+Whether including `chunk_id` for not. Default value is `false`.
+
+```aconf
+<match your.awesome.routing.tag>
+  @type elasticsearch
+  # Other configurations.
+  <metadata>
+    include_chunk_id true
+  </metadata>
+</match>
+```
+
+
+### chunk_id_key
+
+Specify `chunk_id_key` to store `chunk_id` information into records. Default value is `chunk_id`.
+
+```aconf
+<match your.awesome.routing.tag>
+  @type elasticsearch
+  # Other configurations.
+  <metadata>
+  include_chunk_id
+    chunk_id_key chunk_hex
+  </metadata>
+</match>
+```
 
 ## Configuration - Elasticsearch Input
 

--- a/README.md
+++ b/README.md
@@ -1358,7 +1358,7 @@ Specify `chunk_id_key` to store `chunk_id` information into records. Default val
   @type elasticsearch
   # Other configurations.
   <metadata>
-  include_chunk_id
+    include_chunk_id
     chunk_id_key chunk_hex
   </metadata>
 </match>

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -778,7 +778,7 @@ EOC
     end
 
     def inject_chunk_id_to_record_if_needed(record, chunk_id)
-      if @metainfo && @metainfo.include_chunk_id
+      if @metainfo&.include_chunk_id
         record[@metainfo.chunk_id_key] = chunk_id
         record
       else

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -777,6 +777,15 @@ EOC
       true
     end
 
+    def inject_chunk_id_to_record_if_needed(record, chunk_id)
+      if @metainfo && @metainfo.include_chunk_id
+        record[@metainfo.chunk_id_key] = chunk_id
+        record
+      else
+        record
+      end
+    end
+
     def write(chunk)
       bulk_message_count = Hash.new { |h,k| h[k] = 0 }
       bulk_message = Hash.new { |h,k| h[k] = '' }
@@ -795,9 +804,7 @@ EOC
       chunk.msgpack_each do |time, record|
         next unless record.is_a? Hash
 
-        if @metainfo && @metainfo.include_chunk_id
-          record[@metainfo.chunk_id_key] = chunk_id
-        end
+        record = inject_chunk_id_to_record_if_needed(record, chunk_id)
 
         begin
           meta, header, record = process_message(tag, meta, header, time, record, extracted_values)


### PR DESCRIPTION
I implemented chunk_id injecting mechanism.

Closes https://github.com/uken/fluent-plugin-elasticsearch/issues/814

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
