### PR TITLE
Fix ILM rollover alias creation when a placeholder is used in index_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2006,4 +2006,7 @@ Install dev dependencies:
 $ gem install bundler
 $ bundle install
 $ bundle exec rake test
+# To just run the test you are working on:
+$ bundle exec rake test TEST=test/plugin/test_out_elasticsearch.rb TESTOPTS='--verbose --name=test_custom_template_with_rollover_index_create_and_custom_ilm'
+
 ```

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -259,7 +259,7 @@ EOC
             template_installation_actual(@deflector_alias ? @deflector_alias : @index_name, @template_name, @customize_template, @application_name, @index_name, @ilm_policy_id)
           end
           verify_ilm_working if @enable_ilm
-        end 
+        end
         if @templates
           retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
             templates_hash_install(@templates, @template_overwrite)
@@ -982,10 +982,12 @@ EOC
 
     def template_installation_actual(deflector_alias, template_name, customize_template, application_name, target_index, ilm_policy_id, host=nil)
       if template_name && @template_file
-        if !@logstash_format && @alias_indexes.include?(deflector_alias)
-          log.debug("Index alias #{deflector_alias} already exists (cached)")
-        elsif !@logstash_format && @template_names.include?(template_name)
-          log.debug("Template name #{template_name} already exists (cached)")
+        if !@logstash_format && (deflector_alias.nil? || (@alias_indexes.include? deflector_alias)) && (@template_names.include? template_name)
+          if deflector_alias
+            log.debug("Index alias #{deflector_alias} and template #{template_name} already exist (cached)")
+          else
+            log.debug("Template #{template_name} already exists (cached)")
+          end
         else
           retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
             if customize_template


### PR DESCRIPTION
This logic incorrectly assumes that if a template with the given `template_name` was previously
installed then it can safely do an early exit, even if the rollover alias was not created.

This corrects the logic so that it only does an early exit if both the rollover alias was created
AND the template was installed.

- [x] tests added - I updated existing tests to cover this scenario, that seemed to make sense
- [x] tests passing - tests for the modified code pass, but unrelated tests failed for me.  Maybe they will work in CI
- [x] backward compatible - I can't really think of a use case that this would break
- [?] feature works in `elasticsearch_dynamic` (not required but recommended) - I think it probably does, but I'm not totally sure.


