### PR TITLE
Fix ILM rollover index template pattern to apply index_separator

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -143,7 +143,7 @@ module Fluent::ElasticsearchIndexTemplate
         log.debug("Overwriting index lifecycle name and rollover alias when Index Lifecycle Management is enabled.")
       end
       template['settings'].update({ 'index.lifecycle.name' => ilm_policy_id, 'index.lifecycle.rollover_alias' => deflector_alias})
-      template['order'] = template['order'] ? template['order'] + target_index.split('-').length : 50 + target_index.split('-').length
+      template['order'] = template['order'] ? template['order'] + target_index.count(index_separator) + 1 : 51 + target_index.count(index_separator)
     else
       # Prepare template.settings Hash
       if !template['template'].key?('settings')
@@ -153,7 +153,7 @@ module Fluent::ElasticsearchIndexTemplate
         log.debug("Overwriting index lifecycle name and rollover alias when Index Lifecycle Management is enabled.")
       end
       template['template']['settings'].update({ 'index.lifecycle.name' => ilm_policy_id, 'index.lifecycle.rollover_alias' => deflector_alias})
-      template['priority'] = template['priority'] ? template['priority'] + target_index.split('-').length : 100 + target_index.split('-').length
+      template['priority'] = template['priority'] ? template['priority'] + target_index.count(index_separator) + 1 : 101 + target_index.count(index_separator)
     end
     template
   end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -989,9 +989,9 @@ EOC
         else
           retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
             if customize_template
-              template_custom_install(template_name, @template_file, @template_overwrite, customize_template, @enable_ilm, deflector_alias, ilm_policy_id, host, target_index)
+              template_custom_install(template_name, @template_file, @template_overwrite, customize_template, @enable_ilm, deflector_alias, ilm_policy_id, host, target_index, @index_separator)
             else
-              template_install(template_name, @template_file, @template_overwrite, @enable_ilm, deflector_alias, ilm_policy_id, host, target_index)
+              template_install(template_name, @template_file, @template_overwrite, @enable_ilm, deflector_alias, ilm_policy_id, host, target_index, @index_separator)
             end
             ilm_policy = @ilm_policies[ilm_policy_id] || {}
             create_rollover_alias(target_index, @rollover_index, deflector_alias, application_name, @index_date_pattern, @index_separator, @enable_ilm, ilm_policy_id, ilm_policy, @ilm_policy_overwrite, host)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1846,7 +1846,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         template_name   logstash
         template_file   #{template_file}
         index_date_pattern now/w{xxxx.ww}
-        index_name logstash-${tag}
+        index_name logstash.${tag}
         enable_ilm      true
         index_separator "."
         use_legacy_template #{use_legacy_template_flag}
@@ -1865,30 +1865,30 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe']).
         to_return(:status => 200, :body => "", :headers => {})
       # check if alias exists
-      stub_request(:head, "https://logs.google.com:777/es//_alias/logstash-tag1").
+      stub_request(:head, "https://logs.google.com:777/es//_alias/logstash.tag1").
         with(basic_auth: ['john', 'doe']).
         to_return(:status => 404, :body => "", :headers => {})
-      stub_request(:get, "https://logs.google.com:777/es//#{endpoint}/logstash-tag1").
+      stub_request(:get, "https://logs.google.com:777/es//#{endpoint}/logstash.tag1").
         with(basic_auth: ['john', 'doe']).
         to_return(status: 404, body: "", headers: {})
       if use_legacy_template_flag
-        stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash-tag1").
+        stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash.tag1").
           with(basic_auth: ['john', 'doe'],
-               body: "{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"logstash-policy\",\"index.lifecycle.rollover_alias\":\"logstash-tag1\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}},\"index_patterns\":\"logstash-tag1.*\",\"order\":52}").
+               body: "{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"logstash-policy\",\"index.lifecycle.rollover_alias\":\"logstash.tag1\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}},\"index_patterns\":\"logstash.tag1.*\",\"order\":52}").
           to_return(status: 200, body: "", headers: {})
       else
-        stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash-tag1").
+        stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash.tag1").
           with(basic_auth: ['john', 'doe'],
-               body: "{\"index_patterns\":\"logstash-tag1.*\",\"template\":{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"logstash-policy\",\"index.lifecycle.rollover_alias\":\"logstash-tag1\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}}},\"priority\":102}").
+               body: "{\"index_patterns\":\"logstash.tag1.*\",\"template\":{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"logstash-policy\",\"index.lifecycle.rollover_alias\":\"logstash.tag1\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}}},\"priority\":102}").
           to_return(status: 200, body: "", headers: {})
       end
       # put the alias for the index
-      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-tag1.default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E").
+      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash.tag1.default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E").
         with(basic_auth: ['john', 'doe']).
         to_return(:status => 200, :body => "", :headers => {})
-      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-tag1.default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/logstash-tag1").
+      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash.tag1.default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/logstash.tag1").
         with(basic_auth: ['john', 'doe'],
-             :body => "{\"aliases\":{\"logstash-tag1\":{\"is_write_index\":true}}}").
+             :body => "{\"aliases\":{\"logstash.tag1\":{\"is_write_index\":true}}}").
         to_return(:status => 200, :body => "", :headers => {})
       stub_request(:get, "https://logs.google.com:777/es//_xpack").
         with(basic_auth: ['john', 'doe']).
@@ -1907,9 +1907,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       driver.run(default_tag: 'test') do
         driver.feed('tag1', event_time, sample_record)
       end
-      assert_equal('logstash-tag1', index_cmds.first['index']['_index'])
+      assert_equal('logstash.tag1', index_cmds.first['index']['_index'])
 
-      assert_equal ["logstash-tag1"], driver.instance.alias_indexes
+      assert_equal ["logstash.tag1"], driver.instance.alias_indexes
 
       assert_requested(elastic_request)
     end

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -1824,6 +1824,96 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       assert_requested(elastic_request)
     end
 
+
+    data("legacy_template" => [true, "_template"],
+         "new_template"    => [false, "_index_template"])
+    def test_template_create_with_rollover_index_and_default_ilm_and_placeholders_and_index_separator(data)
+      use_legacy_template_flag, endpoint = data
+      cwd = File.dirname(__FILE__)
+      template_file = if use_legacy_template_flag
+                        File.join(cwd, 'test_template.json')
+                      else
+                        File.join(cwd, 'test_index_template.json')
+                      end
+
+      config = %{
+        host            logs.google.com
+        port            777
+        scheme          https
+        path            /es/
+        user            john
+        password        doe
+        template_name   logstash
+        template_file   #{template_file}
+        index_date_pattern now/w{xxxx.ww}
+        index_name logstash-${tag}
+        enable_ilm      true
+        index_separator "."
+        use_legacy_template #{use_legacy_template_flag}
+      }
+
+      # connection start
+      stub_request(:head, "https://logs.google.com:777/es//").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => "", :headers => {})
+      # check if template exists
+      stub_request(:get, "https://logs.google.com:777/es//#{endpoint}/logstash").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 404, :body => "", :headers => {})
+      # creation
+      stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => "", :headers => {})
+      # check if alias exists
+      stub_request(:head, "https://logs.google.com:777/es//_alias/logstash-tag1").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 404, :body => "", :headers => {})
+      stub_request(:get, "https://logs.google.com:777/es//#{endpoint}/logstash-tag1").
+        with(basic_auth: ['john', 'doe']).
+        to_return(status: 404, body: "", headers: {})
+      if use_legacy_template_flag
+        stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash-tag1").
+          with(basic_auth: ['john', 'doe'],
+               body: "{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"logstash-policy\",\"index.lifecycle.rollover_alias\":\"logstash-tag1\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}},\"index_patterns\":\"logstash-tag1.*\",\"order\":52}").
+          to_return(status: 200, body: "", headers: {})
+      else
+        stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash-tag1").
+          with(basic_auth: ['john', 'doe'],
+               body: "{\"index_patterns\":\"logstash-tag1.*\",\"template\":{\"settings\":{\"number_of_shards\":1,\"index.lifecycle.name\":\"logstash-policy\",\"index.lifecycle.rollover_alias\":\"logstash-tag1\"},\"mappings\":{\"type1\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"string\",\"index\":\"not_analyzed\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z YYYY\"}}}}},\"priority\":102}").
+          to_return(status: 200, body: "", headers: {})
+      end
+      # put the alias for the index
+      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-tag1.default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => "", :headers => {})
+      stub_request(:put, "https://logs.google.com:777/es//%3Clogstash-tag1.default-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/logstash-tag1").
+        with(basic_auth: ['john', 'doe'],
+             :body => "{\"aliases\":{\"logstash-tag1\":{\"is_write_index\":true}}}").
+        to_return(:status => 200, :body => "", :headers => {})
+      stub_request(:get, "https://logs.google.com:777/es//_xpack").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+      stub_request(:get, "https://logs.google.com:777/es//_ilm/policy/logstash-policy").
+        with(basic_auth: ['john', 'doe']).
+        to_return(:status => 404, :body => "", :headers => {})
+      stub_request(:put, "https://logs.google.com:777/es//_ilm/policy/logstash-policy").
+        with(basic_auth: ['john', 'doe'],
+             :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
+        to_return(:status => 200, :body => "", :headers => {})
+
+      driver(config)
+
+      elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
+      driver.run(default_tag: 'test') do
+        driver.feed('tag1', event_time, sample_record)
+      end
+      assert_equal('logstash-tag1', index_cmds.first['index']['_index'])
+
+      assert_equal ["logstash-tag1"], driver.instance.alias_indexes
+
+      assert_requested(elastic_request)
+    end
+
     data("legacy_template" => [true, "_template"],
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_custom_and_time_placeholders(data)


### PR DESCRIPTION
The indexes that are created when using ILM follow one of these patterns based on whether
index_date_pattern is set blank or not:

- `<index_name><index_separator><application_name>-0000001`
- `<index_name><index_separator><application_name>-<index_date_pattern>-0000001`

However, the index template always used the pattern `<index_name>-*`.  This meant if you used an
`index_separator` other than `-` the index template would not match and the ILM policy would not apply.

- [x] tests added
- [x] tests passing
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
