### PR TITLE
feat: retry on transport errors

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -32,10 +32,10 @@ module Fluent::ElasticsearchIndexTemplate
     return false
   end
 
-  def retry_operate(max_retries, fail_on_retry_exceed = true)
+  def retry_operate(max_retries, fail_on_retry_exceed = true, catch_trasport_exceptions = true)
     return unless block_given?
     retries = 0
-    transport_errors = Elasticsearch::Transport::Transport::Errors.constants.map{ |c| Elasticsearch::Transport::Transport::Errors.const_get c }
+    transport_errors = Elasticsearch::Transport::Transport::Errors.constants.map{ |c| Elasticsearch::Transport::Transport::Errors.const_get c } if catch_trasport_exceptions
     begin
       yield
     rescue *client.transport.host_unreachable_exceptions, *transport_errors, Timeout::Error => e

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -35,9 +35,10 @@ module Fluent::ElasticsearchIndexTemplate
   def retry_operate(max_retries, fail_on_retry_exceed = true)
     return unless block_given?
     retries = 0
+    transport_errors = Elasticsearch::Transport::Transport::Errors.constants().map{ |c| Elasticsearch::Transport::Transport::Errors.const_get c }
     begin
       yield
-    rescue *client.transport.host_unreachable_exceptions, Timeout::Error => e
+    rescue *client.transport.host_unreachable_exceptions, *transport_errors, Timeout::Error => e
       @_es = nil
       @_es_info = nil
       if retries < max_retries

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -35,7 +35,7 @@ module Fluent::ElasticsearchIndexTemplate
   def retry_operate(max_retries, fail_on_retry_exceed = true)
     return unless block_given?
     retries = 0
-    transport_errors = Elasticsearch::Transport::Transport::Errors.constants().map{ |c| Elasticsearch::Transport::Transport::Errors.const_get c }
+    transport_errors = Elasticsearch::Transport::Transport::Errors.constants.map{ |c| Elasticsearch::Transport::Transport::Errors.const_get c }
     begin
       yield
     rescue *client.transport.host_unreachable_exceptions, *transport_errors, Timeout::Error => e

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -171,6 +171,7 @@ EOC
     config_param :ilm_policy_overwrite, :bool, :default => false
     config_param :truncate_caches_interval, :time, :default => nil
     config_param :use_legacy_template, :bool, :default => true
+    config_param :catch_transport_exception_on_retry, :bool, :default => true
 
     config_section :metadata, param_name: :metainfo, multi: false do
       config_param :include_chunk_id, :bool, :default => false
@@ -261,7 +262,9 @@ EOC
           verify_ilm_working if @enable_ilm
         end
         if @templates
-          retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
+          retry_operate(@max_retry_putting_template,
+                        @fail_on_putting_template_retry_exceed,
+                        @catch_transport_exception_on_retry) do
             templates_hash_install(@templates, @template_overwrite)
           end
         end
@@ -470,7 +473,9 @@ EOC
 
     def handle_last_seen_es_major_version
       if @verify_es_version_at_startup && !dry_run?
-        retry_operate(@max_retry_get_es_version, @fail_on_detecting_es_version_retry_exceed) do
+        retry_operate(@max_retry_get_es_version,
+                      @fail_on_detecting_es_version_retry_exceed,
+                      @catch_transport_exception_on_retry) do
           detect_es_major_version
         end
       else
@@ -989,7 +994,9 @@ EOC
             log.debug("Template #{template_name} already exists (cached)")
           end
         else
-          retry_operate(@max_retry_putting_template, @fail_on_putting_template_retry_exceed) do
+          retry_operate(@max_retry_putting_template,
+                        @fail_on_putting_template_retry_exceed,
+                        @catch_transport_exception_on_retry) do
             if customize_template
               template_custom_install(template_name, @template_file, @template_overwrite, customize_template, @enable_ilm, deflector_alias, ilm_policy_id, host, target_index, @index_separator)
             else

--- a/test/plugin/test_elasticsearch_fallback_selector.rb
+++ b/test/plugin/test_elasticsearch_fallback_selector.rb
@@ -58,6 +58,7 @@ class ElasticsearchFallbackSelectorTest < Test::Unit::TestCase
       with_transporter_log true
       reload_connections true
       reload_after 10
+      catch_transport_exception_on_retry false # For fallback testing
     ]
     assert_raise(Elasticsearch::Transport::Transport::Errors::NotFound) do
       driver(config)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -3052,6 +3052,42 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_equal(4, connection_resets)
   end
 
+  transport_errors_handled_separately = [Elasticsearch::Transport::Transport::Errors::NotFound]
+  transport_errors = Elasticsearch::Transport::Transport::Errors.constants().map { |err| [err, Elasticsearch::Transport::Transport::Errors.const_get(err)]  }
+  transport_errors_hash = Hash[transport_errors.select { |err| !transport_errors_handled_separately.include?(err[1]) } ]
+
+  data(transport_errors_hash)
+  def test_template_retry_transport_errors(error)
+    cwd = File.dirname(__FILE__)
+    template_file = File.join(cwd, 'test_index_template.json')
+
+    config = %{
+      host            logs.google.com
+      port            778
+      scheme          https
+      path            /es/
+      user            john
+      password        doe
+      template_name   logstash
+      template_file   #{template_file}
+      max_retry_putting_template 0
+      use_legacy_template false
+    }
+
+    retries = 0
+    stub_request(:get, "https://logs.google.com:778/es//_index_template/logstash")
+      .with(basic_auth: ['john', 'doe']) do |req|
+      retries += 1
+      raise error
+    end
+
+    assert_raise(Fluent::Plugin::ElasticsearchError::RetryableOperationExhaustedFailure) do
+      driver(config)
+    end
+
+    assert_equal(1, retries)
+  end
+
   data("legacy_template" => [true, "_template"],
        "new_template"    => [false, "_index_template"])
   def test_template_retry_install_does_not_fail(data)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -3053,7 +3053,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   transport_errors_handled_separately = [Elasticsearch::Transport::Transport::Errors::NotFound]
-  transport_errors = Elasticsearch::Transport::Transport::Errors.constants().map { |err| [err, Elasticsearch::Transport::Transport::Errors.const_get(err)]  }
+  transport_errors = Elasticsearch::Transport::Transport::Errors.constants.map { |err| [err, Elasticsearch::Transport::Transport::Errors.const_get(err)]  }
   transport_errors_hash = Hash[transport_errors.select { |err| !transport_errors_handled_separately.include?(err[1]) } ]
 
   data(transport_errors_hash)


### PR DESCRIPTION
Related to: https://github.com/uken/fluent-plugin-elasticsearch/issues/844

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
