### PR TITLE
Fix failing tests on es6 client

### DIFF
--- a/test/plugin/test_elasticsearch_index_lifecycle_management.rb
+++ b/test/plugin/test_elasticsearch_index_lifecycle_management.rb
@@ -11,6 +11,9 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
     rescue LoadError
       omit "ILM testcase needs elasticsearch-xpack gem."
     end
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+      omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
+    end
     Fluent::Plugin::ElasticsearchIndexLifecycleManagement.module_eval(<<-CODE)
       def client
         Elasticsearch::Client.new url: 'localhost:9200'

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -3155,10 +3155,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   data(transport_errors_hash)
   def test_template_retry_transport_errors(error)
-    endpoint = if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.create("7.8.0")
-                 "_index_template".freeze
+    endpoint, use_legacy_template_flag = if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.create("7.8.0")
+                 ["_index_template".freeze, false]
                else
-                 "_template".freeze
+                 ["_template".freeze, true]
                end
     cwd = File.dirname(__FILE__)
     template_file = File.join(cwd, 'test_index_template.json')
@@ -3173,7 +3173,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       template_name   logstash
       template_file   #{template_file}
       max_retry_putting_template 0
-      use_legacy_template false
+      use_legacy_template #{use_legacy_template_flag}
     }
 
     retries = 0

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -2012,10 +2012,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     data("legacy_template" => [true, "_template"],
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_custom_and_time_placeholders(data)
+      use_legacy_template_flag, endpoint = data
       if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
-      use_legacy_template_flag, endpoint = data
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -383,6 +383,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     data("legacy_template" => [true, "_template"],
          "new_template"    => [false, "_index_template"])
     test 'valid configuration of index lifecycle management' do |data|
+      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+        omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
+      end
       use_legacy_template_flag, endpoint = data
       if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
@@ -422,6 +425,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     data("legacy_template" => [true, "_template"],
          "new_template"    => [false, "_index_template"])
     test 'valid configuration of overwriting ilm_policy' do |data|
+      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+        omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
+      end
       use_legacy_template_flag, endpoint = data
       if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
@@ -1051,6 +1057,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         require "elasticsearch/xpack"
       rescue LoadError
         omit "ILM testcase needs elasticsearch-xpack gem."
+      end
+      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+        omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
       end
     end
 
@@ -2442,6 +2451,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         require "elasticsearch/xpack"
       rescue LoadError
         omit "ILM testcase needs elasticsearch-xpack gem."
+      end
+      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+        omit "elastisearch-ruby v7.4.0 or later is needed."
       end
     end
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -384,6 +384,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     test 'valid configuration of index lifecycle management' do |data|
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = File.join(cwd, 'test_template.json')
 
@@ -420,6 +423,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     test 'valid configuration of overwriting ilm_policy' do |data|
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = File.join(cwd, 'test_template.json')
 
@@ -823,6 +829,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_already_present(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     config = %{
       host            logs.google.com
       port            777
@@ -853,6 +862,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -894,6 +906,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create_with_rollover_index_and_template_related_placeholders(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -959,6 +974,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create_with_rollover_index_and_template_related_placeholders_with_truncating_caches(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -1040,6 +1058,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1120,6 +1141,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_on_logstash_format(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1209,6 +1233,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_ilm_policy_overwrite(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1316,6 +1343,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_with_empty_index_date_pattern(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1396,6 +1426,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_custom_ilm(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1477,6 +1510,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_ilm_policies_and_placeholderstest_template_create_with_rollover_index_and_ilm_policies_and_placeholders(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1565,6 +1601,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
            "new_template"    => [false, "_index_template"])
       def test_tag_placeholder(data)
         use_legacy_template_flag, endpoint = data
+        if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+          omit "elastisearch-ruby v7.8.0 or later is needed."
+        end
         cwd = File.dirname(__FILE__)
         template_file = if use_legacy_template_flag
                           File.join(cwd, 'test_template.json')
@@ -1652,6 +1691,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
            "new_template"    => [false, "_index_template"])
       def test_tag_placeholder_with_multiple_policies(data)
         use_legacy_template_flag, endpoint = data
+        if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+          omit "elastisearch-ruby v7.8.0 or later is needed."
+        end
         cwd = File.dirname(__FILE__)
         template_file = if use_legacy_template_flag
                           File.join(cwd, 'test_template.json')
@@ -1740,6 +1782,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_placeholders(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1867,6 +1912,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_placeholders_and_index_separator(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_template.json')
@@ -1955,6 +2003,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     data("legacy_template" => [true, "_template"],
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_custom_and_time_placeholders(data)
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       use_legacy_template_flag, endpoint = data
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
@@ -2050,6 +2101,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_create(data)
     use_legacy_template_flag, endpoint = data
+
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_alias_template.json')
@@ -2092,6 +2147,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_create_with_customize_template_related_placeholders(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_alias_template.json')
@@ -2142,6 +2200,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_installation_for_host_placeholder(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -2188,6 +2249,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_create(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_alias_template.json')
@@ -2246,6 +2310,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_create_and_deflector_alias(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_alias_template.json')
@@ -2305,6 +2372,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_create_with_logstash_format(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_alias_template.json')
@@ -2379,6 +2449,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_default_ilm(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_alias_template.json')
@@ -2463,6 +2536,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_default_ilm_and_ilm_policy_overwrite(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_alias_template.json')
@@ -2577,6 +2653,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_default_ilm_and_placeholders(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_alias_template.json')
@@ -2720,6 +2799,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_custom_ilm(data)
       use_legacy_template_flag, endpoint = data
+      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        omit "elastisearch-ruby v7.8.0 or later is needed."
+      end
       cwd = File.dirname(__FILE__)
       template_file = if use_legacy_template_flag
                         File.join(cwd, 'test_alias_template.json')
@@ -2798,6 +2880,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_overwrite(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -2840,6 +2925,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_overwrite(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -2883,6 +2971,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_overwrite(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -2969,6 +3060,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create_for_host_placeholder(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -3017,6 +3111,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_retry_install_fails(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -3058,6 +3155,11 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   data(transport_errors_hash)
   def test_template_retry_transport_errors(error)
+    endpoint = if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.create("7.8.0")
+                 "_index_template".freeze
+               else
+                 "_template".freeze
+               end
     cwd = File.dirname(__FILE__)
     template_file = File.join(cwd, 'test_index_template.json')
 
@@ -3075,7 +3177,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     }
 
     retries = 0
-    stub_request(:get, "https://logs.google.com:778/es//_index_template/logstash")
+    stub_request(:get, "https://logs.google.com:778/es//#{endpoint}/logstash")
       .with(basic_auth: ['john', 'doe']) do |req|
       retries += 1
       raise error
@@ -3092,6 +3194,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_retry_install_does_not_fail(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -3130,6 +3235,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_create(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -3184,6 +3292,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_overwrite(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -3238,6 +3349,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_are_also_used(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')
@@ -3294,6 +3408,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_can_be_partially_created_if_error_occurs(data)
     use_legacy_template_flag, endpoint = data
+    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      omit "elastisearch-ruby v7.8.0 or later is needed."
+    end
     cwd = File.dirname(__FILE__)
     template_file = if use_legacy_template_flag
                       File.join(cwd, 'test_template.json')


### PR DESCRIPTION
Fix failing testcases on elasticsearch-ruby 6.x.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
