### PR TITLE
Add cloud_id & cloud_auth settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Current maintainers: @cosmo0920
 * [Configuration](#configuration)
   + [host](#host)
   + [port](#port)
+  + [cloud_id](#cloud_id)
+  + [cloud_auth](#cloud_auth)
   + [emit_error_for_missing_id](#emit_error_for_missing_id)
   + [hosts](#hosts)
   + [user, password, path, scheme, ssl_verify](#user-password-path-scheme-ssl_verify)
@@ -186,6 +188,26 @@ port 9201 # defaults to 9200
 ```
 
 You can specify Elasticsearch port by this parameter.
+
+### cloud_id
+
+```
+cloud_id test-dep:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyRiYZTA1Ng== 
+```
+
+You can specify Elasticsearch cloud_id by this parameter.
+
+If you specify `cloud_id` option then `cloud_auth` option is required.
+If you specify `cloud_id` option, `host`, `port`, `user` and `password` options are ignored.
+
+### cloud_auth
+
+```
+cloud_auth 'elastic:slkjdaooewkd87iqQ2O8EQYV'
+```
+
+You can specify Elasticsearch cloud_auth by this parameter.
+
 
 ### emit_error_for_missing_id
 

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -77,6 +77,8 @@ module Fluent::Plugin
     config_param :port, :integer, :default => 9200
     config_param :user, :string, :default => nil
     config_param :password, :string, :default => nil, :secret => true
+    config_param :cloud_id, :string, :default => nil
+    config_param :cloud_auth, :string, :default => nil
     config_param :path, :string, :default => nil
     config_param :scheme, :enum, :list => [:https, :http], :default => :http
     config_param :hosts, :string, :default => nil
@@ -291,7 +293,13 @@ EOC
         @dump_proc = Yajl.method(:dump)
       end
 
+      raise Fluent::ConfigError, "`cloud_auth` must be present if `cloud_id` is present" if @cloud_id && @cloud_auth.nil?
       raise Fluent::ConfigError, "`password` must be present if `user` is present" if @user && @password.nil?
+
+      if @cloud_auth
+        @user = @cloud_auth.split(':', -1)[0]
+        @password = @cloud_auth.split(':', -1)[1]
+      end
 
       if @user && m = @user.match(/%{(?<user>.*)}/)
         @user = URI.encode_www_form_component(m["user"])
@@ -555,7 +563,17 @@ EOC
       return Time.at(event_time).to_datetime
     end
 
+    def cloud_client
+      Elasticsearch::Client.new(
+        cloud_id: @cloud_id,
+        user: @user,
+        password: @password
+      )
+    end
+
     def client(host = nil, compress_connection = false)
+      return cloud_client if @cloud_id
+
       # check here to see if we already have a client connection for the given host
       connection_options = get_connection_options(host)
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -322,15 +322,17 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_equal true, instance.client(nil, compressable).transport.options[:compression]
   end
 
-  test 'check cloud_id based client' do
+  test 'check configure cloud_id based client' do
 
     config = %{
-      cloud_id "someID"
+      cloud_id "name:bG9jYWxob3N0JGFiY2QkZWZnaA=="
       cloud_auth "some:auth"
     }
     instance = driver(config).instance
 
-    assert_equal "someID", instance.client.cloud_id
+    assert_equal "name:bG9jYWxob3N0JGFiY2QkZWZnaA==", instance.cloud_id
+    assert_equal "some", instance.user
+    assert_equal "auth", instance.password
   end
 
   test 'configure Content-Type' do

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -322,6 +322,17 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_equal true, instance.client(nil, compressable).transport.options[:compression]
   end
 
+  test 'check cloud_id based client' do
+
+    config = %{
+      cloud_id "someID"
+      cloud_auth "some:auth"
+    }
+    instance = driver(config).instance
+
+    assert_equal "someID", instance.client.cloud_id
+  end
+
   test 'configure Content-Type' do
     config = %{
       content_type application/x-ndjson


### PR DESCRIPTION
Implementation for https://github.com/uken/fluent-plugin-elasticsearch/issues/849.

Config sample:

```
<match my.logs>
  @type elasticsearch
  include_timestamp true
  include_tag_key true
  tag_key tags
  cloud_auth 'elastic:somesome'
  cloud_id 'dep:ZXVyb3BlLXdlc3QxLm.....ZTA1Ng=='
</match>
```

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)


Closes https://github.com/uken/fluent-plugin-elasticsearch/issues/849