### PR TITLE
Unsplit huge records by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1279,7 +1279,7 @@ Default value is `true`.
 
 Configure `bulk_message` request splitting threshold size.
 
-Default value is `20MB`. (20 * 1024 * 1024)
+Default value is `-1`(unlimited).
 
 If you specify this size as negative number, `bulk_message` request splitting feature will be disabled.
 

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -3751,6 +3751,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure(Fluent::Config::Element.new(
                        'ROOT', '', {
                          '@type' => 'elasticsearch',
+                         'bulk_message_request_threshold' => 20 * 1024 * 1024,
                        }, [
                          Fluent::Config::Element.new('buffer', 'tag', {
                                                        'chunk_keys' => ['tag', 'time'],


### PR DESCRIPTION
Because this feature should be enabled by hand not automatically.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

Reported on https://groups.google.com/g/fluentd/c/8HEcUBIJaAA/m/0dnRObc8BAAJ

(check all that apply)
- [ ] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
