### PR TITLE
Use log.debug to dump ES 8.x _type information

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -349,7 +349,7 @@ EOC
           @type_name = '_doc'.freeze
         end
         if @last_seen_major_version >= 8 && @type_name != DEFAULT_TYPE_NAME_ES_7x
-          log.info "Detected ES 8.x or above: This parameter has no effect."
+          log.debug "Detected ES 8.x or above: This parameter has no effect."
           @type_name = nil
         end
       end
@@ -930,7 +930,7 @@ EOC
           log.warn "Detected ES 7.x: `_doc` will be used as the document `_type`."
           target_type = '_doc'.freeze
         elsif @last_seen_major_version >=8
-          log.warn "Detected ES 8.x or above: document type will not be used."
+          log.debug "Detected ES 8.x or above: document type will not be used."
           target_type = nil
         end
       else
@@ -940,7 +940,7 @@ EOC
           log.warn "Detected ES 7.x: `_doc` will be used as the document `_type`."
           target_type = '_doc'.freeze
         elsif @last_seen_major_version >= 8
-          log.warn "Detected ES 8.x or above: document type will not be used."
+          log.debug "Detected ES 8.x or above: document type will not be used."
           target_type = nil
         else
           target_type = type_name


### PR DESCRIPTION
When using ES 8.x, `_type` metadata will not be specified due to removal
mapping of types.

ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

Related to https://github.com/uken/fluent-plugin-elasticsearch/issues/847.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
