### PR TITLE
Handle invalid Elasticsearch::Client#info response

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -493,7 +493,12 @@ EOC
 
     def detect_es_major_version
       @_es_info ||= client.info
-      unless version = @_es_info.dig("version", "number")
+      begin
+        unless version = @_es_info.dig("version", "number")
+          version = @default_elasticsearch_version
+        end
+      rescue NoMethodError => e
+        log.warn "#{@_es_info} can not dig version information. Assuming Elasticsearch #{@default_elasticsearch_version}", error: e
         version = @default_elasticsearch_version
       end
       version.to_i


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>

When `client.info` returns String object, `@_es_info.dig("version", "number")` does not handle for String instance.
We should handle and process in this case.

Related to #854 

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
