### PR TITLE
Initial support for Elasticsearch Data Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Current maintainers: @cosmo0920
     + [chunk_id_key](#chunk_id_key)
 * [Configuration - Elasticsearch Input](#configuration---elasticsearch-input)
 * [Configuration - Elasticsearch Filter GenID](#configuration---elasticsearch-filter-genid)
+* [Configuration - Elasticsearch Output Data Stream](#configuration---elasticsearch-output-data-stream)
 * [Elasticsearch permissions](#elasticsearch-permissions)
 * [Troubleshooting](#troubleshooting)
 * [Contact](#contact)
@@ -1410,6 +1411,29 @@ features in the plugin configuration
 
 The list of privileges along with their description can be found in
 [security privileges](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html).
+
+## Configuration - Elasticsearch Output Data Stream
+
+Since Elasticsearch 7.9, Data Streams was introduced.
+
+You can enable this feature by specifying `@type elasticsearch_data_stream`.
+
+```
+@type elasticsearch_data_stream
+data_stream_name test
+```
+
+When `@type elasticsearch_data_stream` is used, ILM default policy is set to the specified data stream.
+Then, the matching index template is also created automatically.
+
+### data_stream_name
+
+You can specify Elasticsearch data stream name by this parameter.
+This parameter is mandatory for `elasticsearch_data_stream`.
+
+There are some limitations about naming rule.
+
+In more detail, please refer to the [Path parameters](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html#indices-create-data-stream-api-path-params).
 
 ## Troubleshooting
 

--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -1,0 +1,165 @@
+require_relative 'out_elasticsearch'
+
+module Fluent::Plugin
+  class ElasticsearchOutputDataStream < ElasticsearchOutput
+
+    Fluent::Plugin.register_output('elasticsearch_data_stream', self)
+
+    helpers :event_emitter
+
+    config_param :data_stream_name, :string
+
+    INVALID_START_CHRACTERS = ["-", "_", "+", "."]
+    INVALID_CHARACTERS = ["\\", "/", "*", "?", "\"", "<", ">", "|", " ", ",", "#", ":"]
+
+    def configure(conf)
+      super
+
+      # ref. https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html
+      unless valid_data_stream_name?
+        unless start_with_valid_characters?
+          if not_dots?
+            raise Fluent::ConfigError, "'data_stream_name' must not start with #{INVALID_START_CHRACTERS.join(",")}: <#{@data_stream_name}>"
+          else
+            raise Fluent::ConfigError, "'data_stream_name' must not be . or ..: <#{@data_stream_name}>"
+          end
+        end
+        unless valid_characters?
+          raise Fluent::ConfigError, "'data_stream_name' must not contain invalid characters #{INVALID_CHARACTERS.join(",")}: <#{@data_stream_name}>"
+        end
+        unless lowercase_only?
+          raise Fluent::ConfigError, "'data_stream_name' must be lowercase only: <#{@data_stream_name}>"
+        end
+        if @data_stream_name.bytes.size > 255
+          raise Fluent::ConfigError, "'data_stream_name' must not be longer than 255 bytes: <#{@data_stream_name}>"
+        end
+      end
+
+      begin
+        require 'elasticsearch/xpack'
+      rescue LoadError
+        raise Fluent::ConfigError, "'elasticsearch/xpack'' is required for <@elasticsearch_data_stream>."
+      end
+
+      begin
+        @client = client
+        create_ilm_policy
+        create_index_template
+        create_data_stream
+      rescue => e
+        raise Fluent::ConfigError, "Failed to create data stream: <#{@data_stream_name}> #{e.message}"
+      end
+    end
+
+    def create_ilm_policy
+      params = {
+        policy_id: "#{@data_stream_name}_policy",
+        body: File.read(File.join(File.dirname(__FILE__), "default-ilm-policy.json"))
+      }
+      @client.xpack.ilm.put_policy(params)
+    end
+
+    def create_index_template
+      body = {
+        "index_patterns" => ["#{@data_stream_name}*"],
+        "data_stream" => {},
+        "template" => {
+          "settings" => {
+            "index.lifecycle.name" => "#{@data_stream_name}_policy"
+          }
+        }
+      }
+      params = {
+        name: @data_stream_name,
+        body: body
+      }
+      @client.indices.put_index_template(params)
+    end
+
+    def create_data_stream
+      params = {
+        "name": @data_stream_name,
+      }
+      response = @client.indices.get_data_stream(params)
+      unless response.is_a?(Elasticsearch::Transport::Transport::Errors::NotFound)
+        log.info "Specified data stream exists: <#{@data_stream_name}>"
+        return
+      end
+      @client.indices.create_data_stream(params)
+    end
+
+    def valid_data_stream_name?
+      lowercase_only? and
+        valid_characters? and
+        start_with_valid_characters? and
+        not_dots? and
+        @data_stream_name.bytes.size <= 255
+    end
+
+    def lowercase_only?
+      @data_stream_name.downcase == @data_stream_name
+    end
+
+    def valid_characters?
+      not (INVALID_CHARACTERS.each.any? do |v| @data_stream_name.include?(v) end)
+    end
+
+    def start_with_valid_characters?
+      not (INVALID_START_CHRACTERS.each.any? do |v| @data_stream_name.start_with?(v) end)
+    end
+
+    def not_dots?
+      not (@data_stream_name == "." or @data_stream_name == "..")
+    end
+    
+    def client_library_version
+      Elasticsearch::VERSION
+    end
+
+    def multi_workers_ready?
+      true
+    end
+
+    def write(chunk)
+      bulk_message = ""
+      headers = {
+        CREATE_OP => {}
+      }
+      tag = chunk.metadata.tag
+      chunk.msgpack_each do |time, record|
+        next unless record.is_a? Hash
+
+        begin
+          record.merge!({"@timestamp" => Time.at(time).iso8601(@time_precision)})
+          bulk_message = append_record_to_messages(CREATE_OP, {}, headers, record, bulk_message)
+        rescue => e
+          router.emit_error_event(tag, time, record, e)
+        end
+      end
+      
+      params = {
+        index: @data_stream_name,
+        body: bulk_message
+      }
+      begin
+        response = @client.bulk(params)
+        if response['errors']
+          log.error "Could not bulk insert to Data Stream: #{@data_stream_name} #{response}"
+        end
+      rescue => e
+        log.error "Could not bulk insert to Data Stream: #{@data_stream_name} #{e.message}"
+      end
+    end
+
+    def append_record_to_messages(op, meta, header, record, msgs)
+      header[CREATE_OP] = meta
+      msgs << @dump_proc.call(header) << BODY_DELIMITER
+      msgs << @dump_proc.call(record) << BODY_DELIMITER
+      msgs
+    end
+
+    def retry_stream_retryable?
+      @buffer.storable?
+    end
+  end
+end

--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -80,10 +80,14 @@ module Fluent::Plugin
       params = {
         "name": @data_stream_name,
       }
-      response = @client.indices.get_data_stream(params)
-      unless response.is_a?(Elasticsearch::Transport::Transport::Errors::NotFound)
-        log.info "Specified data stream exists: <#{@data_stream_name}>"
-        return
+      begin
+        response = @client.indices.get_data_stream(params)
+        unless response.is_a?(Elasticsearch::Transport::Transport::Errors::NotFound)
+          log.info "Specified data stream exists: <#{@data_stream_name}>"
+          return
+        end
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        log.info "Specified data stream does not exist. Will be created: <#{e}>"
       end
       @client.indices.create_data_stream(params)
     end

--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -115,7 +115,7 @@ module Fluent::Plugin
     def not_dots?
       not (@data_stream_name == "." or @data_stream_name == "..")
     end
-    
+
     def client_library_version
       Elasticsearch::VERSION
     end
@@ -140,7 +140,7 @@ module Fluent::Plugin
           router.emit_error_event(tag, time, record, e)
         end
       end
-      
+
       params = {
         index: @data_stream_name,
         body: bulk_message

--- a/test/plugin/test_out_elasticsearch_data_stream.rb
+++ b/test/plugin/test_out_elasticsearch_data_stream.rb
@@ -1,0 +1,239 @@
+require_relative '../helper'
+require 'date'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/output'
+require 'flexmock/test_unit'
+require 'fluent/plugin/out_elasticsearch_data_stream'
+
+class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
+  include FlexMock::TestCase
+  include Fluent::Test::Helpers
+
+  attr_accessor :bulk_records
+
+  REQUIRED_ELASTIC_MESSAGE = "Elasticsearch 7.9.0 or later is needed."
+  ELASTIC_DATA_STREAM_TYPE = "elasticsearch_data_stream"
+
+  def setup
+    Fluent::Test.setup
+    @driver = nil
+    log = Fluent::Engine.log
+    log.out.logs.slice!(0, log.out.logs.length)
+  end
+
+  def driver(conf='', es_version=5, client_version="\"5.0\"")
+    # For request stub to detect compatibility.
+    @es_version ||= es_version
+    @client_version ||= client_version
+    Fluent::Plugin::ElasticsearchOutputDataStream.module_eval(<<-CODE)
+      def detect_es_major_version
+        #{@es_version}
+      end
+    CODE
+    @driver ||= Fluent::Test::Driver::Output.new(Fluent::Plugin::ElasticsearchOutputDataStream) {
+      # v0.12's test driver assume format definition. This simulates ObjectBufferedOutput format
+      if !defined?(Fluent::Plugin::Output)
+        def format(tag, time, record)
+          [time, record].to_msgpack
+        end
+      end
+    }.configure(conf)
+  end
+
+  def sample_data_stream
+    {
+      'data_streams': [
+                        {
+                          'name' => 'my-data-stream',
+                          'timestamp_field' => {
+                            'name' => '@timestamp'
+                          }
+                        }
+                      ]
+    }
+  end
+
+  def sample_record
+    {'@timestamp' => Time.now.iso8601, 'message' => 'Sample record'}
+  end
+
+  RESPONSE_ACKNOWLEDGED = {"acknowledged": true}
+  DUPLICATED_DATA_STREAM_EXCEPTION = {"error": {}, "status": 400}
+  NONEXISTENT_DATA_STREAM_EXCEPTION = {"error": {}, "status": 404}
+
+  def stub_ilm_policy(url="http://localhost:9200/_ilm/policy/foo_policy")
+    stub_request(:put, url).to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+  end
+
+  def stub_index_template(url="http://localhost:9200/_index_template/foo")
+    stub_request(:put, url).to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+  end
+
+  def stub_data_stream(url="http://localhost:9200/_data_stream/foo")
+    stub_request(:put, url).to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+  end
+
+  def stub_existent_data_stream?(url="http://localhost:9200/_data_stream/foo")
+    stub_request(:get, url).to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+  end
+
+  def stub_nonexistent_data_stream?(url="http://localhost:9200/_data_stream/foo")
+    stub_request(:get, url).to_return(:status => [200, Elasticsearch::Transport::Transport::Errors::NotFound])
+  end
+
+  def stub_bulk_feed(url="http://localhost:9200/foo/_bulk")
+    stub_request(:post, url).with do |req|
+      # bulk data must be pair of OP and records
+      # {"create": {}}\n
+      # {"@timestamp": ...}
+      @bulk_records = req.body.split("\n").size / 2
+    end
+  end
+
+  def stub_default
+    stub_ilm_policy
+    stub_index_template
+    stub_existent_data_stream?
+    stub_data_stream
+  end
+
+  def data_stream_supported?
+    Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.create("7.9.0")
+  end
+
+  # ref. https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html
+  class DataStreamNameTest < self
+
+    def test_missing_data_stream_name
+      conf = config_element(
+        'ROOT', '', {
+          '@type' => 'elasticsearch_datastream'
+        })
+      assert_raise Fluent::ConfigError.new("'data_stream_name' parameter is required") do
+        driver(conf).run
+      end
+    end
+
+    def test_invalid_uppercase
+      conf = config_element(
+        'ROOT', '', {
+          '@type' => 'elasticsearch_datastream',
+          'data_stream_name' => 'TEST'
+        })
+      assert_raise Fluent::ConfigError.new("'data_stream_name' must be lowercase only: <TEST>") do
+        driver(conf)
+      end
+    end
+
+    data("backslash" => "\\",
+         "slash" => "/",
+         "asterisk" => "*",
+         "question" => "?",
+         "doublequote" => "\"",
+         "lt" => "<",
+         "gt" => ">",
+         "bar" => "|",
+         "space" => " ",
+         "comma" => ",",
+         "sharp" => "#",
+         "colon" => ":")
+    def test_invalid_characters(data)
+      c, _ = data
+      conf = config_element(
+        'ROOT', '', {
+          '@type' => ELASTIC_DATA_STREAM_TYPE,
+          'data_stream_name' => "TEST#{c}"
+        })
+      label = Fluent::Plugin::ElasticsearchOutputDataStream::INVALID_CHARACTERS.join(',')
+      assert_raise Fluent::ConfigError.new("'data_stream_name' must not contain invalid characters #{label}: <TEST#{c}>") do
+        driver(conf)
+      end
+    end
+
+    data("hyphen" => "-",
+         "underscore" => "_",
+         "plus" => "+",
+         "period" => ".")
+    def test_invalid_start_characters(data)
+      c, _ = data
+      conf = config_element(
+        'ROOT', '', {
+          '@type' => ELASTIC_DATA_STREAM_TYPE,
+          'data_stream_name' => "#{c}TEST"
+        })
+      label = Fluent::Plugin::ElasticsearchOutputDataStream::INVALID_START_CHRACTERS.join(',')
+      assert_raise Fluent::ConfigError.new("'data_stream_name' must not start with #{label}: <#{c}TEST>") do
+        driver(conf)
+      end
+    end
+
+    data("current" => ".",
+         "parents" => "..")
+    def test_invalid_dots
+      c, _ = data
+      conf = config_element(
+        'ROOT', '', {
+          '@type' => ELASTIC_DATA_STREAM_TYPE,
+          'data_stream_name' => "#{c}"
+        })
+      assert_raise Fluent::ConfigError.new("'data_stream_name' must not be . or ..: <#{c}>") do
+        driver(conf)
+      end
+    end
+
+    def test_invalid_length
+      c = "a" * 256
+      conf = config_element(
+        'ROOT', '', {
+          '@type' => ELASTIC_DATA_STREAM_TYPE,
+          'data_stream_name' => "#{c}"
+        })
+      assert_raise Fluent::ConfigError.new("'data_stream_name' must not be longer than 255 bytes: <#{c}>") do
+        driver(conf)
+      end
+    end
+  end
+
+  def test_datastream_configure
+    omit REQUIRED_ELASTIC_MESSAGE unless data_stream_supported?
+
+    stub_default
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => ELASTIC_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo'
+      })
+    assert_equal "foo", driver(conf).instance.data_stream_name
+  end
+
+  def test_nonexistent_data_stream
+    omit REQUIRED_ELASTIC_MESSAGE unless data_stream_supported?
+
+    stub_ilm_policy
+    stub_index_template
+    stub_nonexistent_data_stream?
+    stub_data_stream
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => ELASTIC_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo'
+      })
+    assert_equal "foo", driver(conf).instance.data_stream_name
+  end
+
+  def test_bulk_insert_feed
+    omit REQUIRED_ELASTIC_MESSAGE unless data_stream_supported?
+
+    stub_default
+    stub_bulk_feed
+    conf = config_element(
+      'ROOT', '', {
+        '@type' => ELASTIC_DATA_STREAM_TYPE,
+        'data_stream_name' => 'foo'
+      })
+    driver(conf).run(default_tag: 'test') do
+      driver.feed(sample_record)
+    end
+    assert_equal 1, @bulk_records
+  end
+end


### PR DESCRIPTION
ref. https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html

Typical usage of @type elasticsearch_data_stream

```
<match ...>
  @type elasticsearch_data_stream
  data_stream_name foo
</match>
```


(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
  need to talk about whether which section should be updated
- [x] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
  As a newly added feature and isolated.
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
  Not supported because initial support for data stream.
