### PR TITLE
Use elasticsearch/api instead of elasticsearch/xpack

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -18,9 +18,10 @@ module Fluent::Plugin
       super
 
       begin
+        require 'elasticsearch/api'
         require 'elasticsearch/xpack'
       rescue LoadError
-        raise Fluent::ConfigError, "'elasticsearch/xpack'' is required for <@elasticsearch_data_stream>."
+        raise Fluent::ConfigError, "'elasticsearch/api', 'elasticsearch/xpack' are required for <@elasticsearch_data_stream>."
       end
 
       # ref. https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html


### PR DESCRIPTION
Since elasticseach-ruby 7.11.0 indices.put_index_template is moved to elasticsearch/api.

ref. https://github.com/elastic/elasticsearch-ruby/blob/master/CHANGELOG.md#7110
