### PR TITLE
Fix overwriting of index template and index lifecycle policy on existing data streams

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -67,6 +67,7 @@ module Fluent::Plugin
     end
 
     def create_ilm_policy(name)
+      return if data_stream_exist?(name)
       params = {
         policy_id: "#{name}_policy",
         body: File.read(File.join(File.dirname(__FILE__), "default-ilm-policy.json"))
@@ -79,6 +80,7 @@ module Fluent::Plugin
     end
 
     def create_index_template(name)
+      return if data_stream_exist?(name)
       body = {
         "index_patterns" => ["#{name}*"],
         "data_stream" => {},


### PR DESCRIPTION
Addresses https://github.com/uken/fluent-plugin-elasticsearch/issues/871

Currently, the `elasticsearch_data_stream` type creates a data stream, along with associated index template and index lifecycle policy. The `create_data_stream` method checks whether the data stream exists before creating it. We should do the same before overwriting the index template and index lifecycle policy.

This update simply runs `data_stream_exist?` at the top of `create_ilm_policy` and `create_index_template`, as is currently done in `create_data_stream`. The current approach leaves room for adding support for passing in an ILM policy and index template, but that's currently not supported. These calls to `data_stream_exist?` will need to be removed if such support is added (which is ultimately a more robust solution long-term).

With this change, users will be able to update the ILM policy and the index template after creation, and those updates won't be clobbered every time a fluentd process starts up (e.g., if a fluentd pod on Kubernetes dies and is rescheduled). 

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
