### PR TITLE
Handle elasticsearch-ruby 7.14 properly

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -498,6 +498,9 @@ EOC
       @_es_info ||= client.info
       begin
         unless version = @_es_info.dig("version", "number")
+          if version != @default_elasticsearch_version
+            log.warn "Elasticsearch version glitch exists. Actual #{version}, Expected: #{@default_elasticsearch_version}"
+          end
           version = @default_elasticsearch_version
         end
       rescue NoMethodError => e

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -498,9 +498,6 @@ EOC
       @_es_info ||= client.info
       begin
         unless version = @_es_info.dig("version", "number")
-          if version != @default_elasticsearch_version
-            log.warn "Elasticsearch version glitch exists. Actual #{version}, Expected: #{@default_elasticsearch_version}"
-          end
           version = @default_elasticsearch_version
         end
       rescue NoMethodError => e

--- a/test/plugin/test_elasticsearch_fallback_selector.rb
+++ b/test/plugin/test_elasticsearch_fallback_selector.rb
@@ -19,7 +19,7 @@ class ElasticsearchFallbackSelectorTest < Test::Unit::TestCase
   end
 
   def stub_elastic_info(url="http://localhost:9200/", version="6.4.2")
-    body ="{\"version\":{\"number\":\"#{version}\"}}"
+    body ="{\"version\":{\"number\":\"#{version}\", \"build_flavor\":\"default\"},\"tagline\" : \"You Know, for Search\"}"
     stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json' } })
   end
 

--- a/test/plugin/test_elasticsearch_index_lifecycle_management.rb
+++ b/test/plugin/test_elasticsearch_index_lifecycle_management.rb
@@ -27,9 +27,15 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
     CODE
   end
 
+  def stub_elastic_info(url="http://localhost:9200/", version="7.9.0")
+    body ="{\"version\":{\"number\":\"#{version}\", \"build_flavor\":\"default\"},\"tagline\" : \"You Know, for Search\"}"
+    stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json' } })
+  end
+
   def test_xpack_info
     stub_request(:get, "http://localhost:9200/_xpack").
       to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+    stub_elastic_info
     expected = {"features"=>{"ilm"=>{"available"=>true, "enabled"=>true}}}
     assert_equal(expected, xpack_info)
   end
@@ -37,18 +43,21 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
   def test_verify_ilm_working
     stub_request(:get, "http://localhost:9200/_xpack").
       to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+    stub_elastic_info
     assert_nothing_raised { verify_ilm_working }
   end
 
   def test_ilm_policy_doesnt_exists
     stub_request(:get, "http://localhost:9200/_ilm/policy/%7B:policy_id=%3E%22fluentd-policy%22%7D").
       to_return(:status => 404, :body => "", :headers => {})
+    stub_elastic_info
     assert_false(ilm_policy_exists?(policy_id: "fluentd-policy"))
   end
 
   def test_ilm_policy_exists
     stub_request(:get, "http://localhost:9200/_ilm/policy/%7B:policy_id=%3E%22fluent-policy%22%7D").
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info
     assert_true(ilm_policy_exists?(policy_id: "fluent-policy"))
   end
 
@@ -59,6 +68,7 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
       with(:body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}",
          :headers => {'Content-Type'=>'application/json'}).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info
     create_ilm_policy("fluent-policy")
 
     assert_requested(:put, "http://localhost:9200/_ilm/policy/fluent-policy", times: 1)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -60,7 +60,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   def stub_elastic_info(url="http://localhost:9200/", version="6.4.2")
-    body ="{\"version\":{\"number\":\"#{version}\"}}"
+    body ="{\"version\":{\"number\":\"#{version}\", \"build_flavor\":\"default\"},\"tagline\" : \"You Know, for Search\"}"
     stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json' } })
   end
 
@@ -298,16 +298,25 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    assert_equal nil, instance.client.transport.options[:transport_options][:headers]["Content-Encoding"]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal nil, instance.client.transport.transport.options[:transport_options][:headers]["Content-Encoding"]
+    else
+      assert_equal nil, instance.client.transport.options[:transport_options][:headers]["Content-Encoding"]
+    end
 
     stub_request(:post, "http://localhost:9200/_bulk").
       to_return(status: 200, body: "", headers: {})
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
     compressable = instance.compressable_connection
 
-    assert_equal "gzip", instance.client(nil, compressable).transport.options[:transport_options][:headers]["Content-Encoding"]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal "gzip", instance.client(nil, compressable).transport.transport.options[:transport_options][:headers]["Content-Encoding"]
+    else
+      assert_equal "gzip", instance.client(nil, compressable).transport.options[:transport_options][:headers]["Content-Encoding"]
+    end
   end
 
   test 'check compression option is passed to transport' do
@@ -318,16 +327,25 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    assert_equal false, instance.client.transport.options[:compression]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal false, instance.client.transport.transport.options[:compression]
+    else
+      assert_equal false, instance.client.transport.options[:compression]
+    end
 
     stub_request(:post, "http://localhost:9200/_bulk").
       to_return(status: 200, body: "", headers: {})
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
     compressable = instance.compressable_connection
 
-    assert_equal true, instance.client(nil, compressable).transport.options[:compression]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal true, instance.client(nil, compressable).transport.transport.options[:compression]
+    else
+      assert_equal true, instance.client(nil, compressable).transport.options[:compression]
+    end
   end
 
   test 'check configure cloud_id based client' do
@@ -414,7 +432,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     end
 
     def stub_elastic_info_bad(url="http://localhost:9200/", version="6.4.2")
-      body ="{\"version\":{\"number\":\"#{version}\"}}"
+      body ="{\"version\":{\"number\":\"#{version}\",\"build_flavor\":\"default\"},\"tagline\":\"You Know, for Search\"}"
       stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'text/plain' } })
     end
 
@@ -431,9 +449,15 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         scheme https
         @log_level info
       }
-      d = create_driver(config, 7, "\"7.10.1\"")
-      logs = d.logs
-      assert_logs_include(logs, /can not dig version information. Assuming Elasticsearch 7/)
+      if Gem::Version.new(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+        assert_raise(NoMethodError) do
+          d = create_driver(config, 7, "\"7.10.1\"")
+        end
+      else
+        d = create_driver(config, 7, "\"7.10.1\"")
+        logs = d.logs
+        assert_logs_include(logs, /can not dig version information. Assuming Elasticsearch 7/)
+      end
     end
   end
 
@@ -496,6 +520,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       stub_request(:put, "http://localhost:9200/_ilm/policy/logstash-policy").
         with(body: "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(status: 200, body: "", headers: {})
+      stub_elastic_info
 
       assert_nothing_raised {
         driver(config)
@@ -540,6 +565,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       stub_request(:put, "http://localhost:9200/_ilm/policy/logstash-policy").
         with(body: "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"75gb\",\"max_age\":\"50d\"}}}}}}").
         to_return(status: 200, body: "", headers: {})
+      stub_elastic_info
 
       assert_nothing_raised {
         driver(config)
@@ -556,6 +582,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         template_file #{template_file}
         ilm_policy_overwrite true
       }
+      stub_elastic_info
 
       assert_raise(Fluent::ConfigError) {
         driver(config)
@@ -938,6 +965,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:get, "https://logs.google.com:777/es//#{endpoint}/logstash").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -982,6 +1010,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -1045,6 +1074,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver(config)
 
     elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
+    stub_elastic_info("https://logs.google.com:777/es//")
     driver.run(default_tag: 'test.template') do
       driver.feed(sample_record)
     end
@@ -1110,6 +1140,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       with(basic_auth: ['john', 'doe'],
            body: "{\"aliases\":{\"myapp_deflector-test.template\":{\"is_write_index\":true}}}").
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -1220,6 +1251,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -1306,6 +1338,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -1397,6 +1430,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"60gb\",\"max_age\":\"45d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -1505,6 +1539,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -1589,6 +1624,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"70gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -1673,6 +1709,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"70gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -1764,6 +1801,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
           with(basic_auth: ['john', 'doe'],
                body: "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"70gb\",\"max_age\":\"30d\"}}}}}}").
           to_return(:status => 200, :body => "", :headers => {})
+        stub_elastic_info("https://logs.google.com:777/es//")
 
         driver(config)
 
@@ -1854,6 +1892,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
           with(basic_auth: ['john', 'doe'],
                body: "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"80gb\",\"max_age\":\"20d\"}}}}}}").
           to_return(:status => 200, :body => "", :headers => {})
+        stub_elastic_info("https://logs.google.com:777/es//")
 
         driver(config)
 
@@ -1979,6 +2018,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -2075,6 +2115,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -2171,6 +2212,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -2226,6 +2268,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/myapp_alias_template").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -2278,6 +2321,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver(config)
 
     stub_elastic("https://logs.google.com:777/es//_bulk")
+    stub_elastic_info("https://logs.google.com:777/es//")
     driver.run(default_tag: 'test.template') do
       driver.feed(sample_record)
     end
@@ -2329,6 +2373,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver(config)
 
     stub_elastic("https://logs-test.google.com:777/es//_bulk")
+    stub_elastic_info("https://logs-test.google.com:777/es//")
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -2389,6 +2434,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/mylogs").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -2451,6 +2497,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fw%7Bxxxx.ww%7D%7D-000001%3E/#{alias_endpoint}/myapp_deflector").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -2519,6 +2566,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver(config)
 
     elastic_request = stub_elastic("https://logs.google.com:777/es//_bulk")
+    stub_elastic_info("https://logs.google.com:777/es//")
     driver.run(default_tag: 'custom-test') do
       driver.feed(sample_record)
     end
@@ -2618,7 +2666,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
-
+      stub_elastic_info("https://logs.google.com:777/es//")
       driver(config)
 
       assert_requested(:put, "https://logs.google.com:777/es//#{endpoint}/mylogs", times: 1)
@@ -2707,6 +2755,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"60gb\",\"max_age\":\"45d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -2736,6 +2785,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       }
 
       # Should raise error because multiple alias indices IllegalArgument Error on executing ILM feature
+      stub_elastic_info("https://logs.google.com:777/es//")
       assert_raise(Fluent::ConfigError) do
         driver(config)
       end
@@ -2871,6 +2921,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
+      stub_elastic_info("https://logs.google.com:777/es//")
 
       driver(config)
 
@@ -2961,7 +3012,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         with(basic_auth: ['john', 'doe'],
              :body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"70gb\",\"max_age\":\"30d\"}}}}}}").
         to_return(:status => 200, :body => "", :headers => {})
-
+      stub_elastic_info("https://logs.google.com:777/es//")
       driver(config)
 
       assert_requested(:put, "https://logs.google.com:777/es//#{endpoint}/mylogs", times: 1)
@@ -3007,6 +3058,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -3053,6 +3105,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/myapp_alias_template").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -3115,6 +3168,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//%3Cmylogs-myapp-%7Bnow%2Fd%7D-000001%3E/#{alias_endpoint}/myapp_deflector").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -3141,7 +3195,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:get, "https://logs.google.com:777/es//_template/logstash").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 404, :body => "", :headers => {})
-
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     assert_raise(RuntimeError) {
       driver(config)
@@ -3193,7 +3247,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
     driver(config)
 
-    stub_elastic("https://logs.google.com:777/es//_bulk")
+    stub_elastic("https://logs-test.google.com:777/es//_bulk")
+    stub_elastic_info("https://logs-test.google.com:777/es//")
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -3233,6 +3288,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       connection_resets += 1
       raise Faraday::ConnectionFailed, "Test message"
     end
+    stub_elastic_info("https://logs.google.com:778/es//")
 
     assert_raise(Fluent::Plugin::ElasticsearchError::RetryableOperationExhaustedFailure) do
       driver(config)
@@ -3274,6 +3330,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       retries += 1
       raise error
     end
+    stub_elastic_info("https://logs.google.com:778/es//")
 
     assert_raise(Fluent::Plugin::ElasticsearchError::RetryableOperationExhaustedFailure) do
       driver(config)
@@ -3317,6 +3374,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       connection_resets += 1
       raise Faraday::ConnectionFailed, "Test message"
     end
+    stub_elastic_info("https://logs.google.com:778/es//")
 
     driver(config)
 
@@ -3372,6 +3430,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash3").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -3429,6 +3488,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash3").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -3487,6 +3547,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash2").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     driver(config)
 
@@ -3537,6 +3598,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     stub_request(:put, "https://logs.google.com:777/es//#{endpoint}/logstash2").
       with(basic_auth: ['john', 'doe']).
       to_return(:status => 200, :body => "", :headers => {})
+    stub_elastic_info("https://logs.google.com:777/es//")
 
     assert_raise(RuntimeError) {
       driver(config)
@@ -3553,6 +3615,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       path     /es/
       port     123
     }
+    stub_elastic_info("https://host1:50")
+    stub_elastic_info("https://host2:100")
+    stub_elastic_info("https://host3:123")
     instance = driver(config).instance
 
     assert_equal 3, instance.get_connection_options[:hosts].length
@@ -3575,6 +3640,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       user     default_user
       password default_password
     }
+    stub_elastic_info("https://john:password@host1:443/elastic/")
+    stub_elastic_info("http://host2")
     instance = driver(config).instance
 
     assert_equal 2, instance.get_connection_options[:hosts].length
@@ -3601,6 +3668,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       user     default_user
       password default_password
     }
+    stub_elastic_info("https://j%2Bhn:passw%40rd@host1:443/elastic/")
+    stub_elastic_info("http://host2")
+
     instance = driver(config).instance
 
     assert_equal 2, instance.get_connection_options[:hosts].length
@@ -3801,6 +3871,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
                           with(headers: { "Content-Type" => "application/json" })
     end
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -3812,6 +3883,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
                         with(headers: {'custom' => 'header1','and_others' => 'header2' })
+    stub_elastic_info
     driver.configure(%[custom_headers {"custom":"header1", "and_others":"header2"}])
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
@@ -3824,6 +3896,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       to_return(:status => 200, :body => "", :headers => {})
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
                         with(headers: {'Authorization'=>'ApiKey dGVzdGF1dGhoZWFkZXI='})
+    stub_elastic_info
     driver.configure(%[api_key testauthheader])
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
@@ -3834,6 +3907,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_write_message_with_bad_chunk
     driver.configure("target_index_key bad_value\n@log_level debug\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed({'bad_value'=>"\255"})
     end
@@ -3849,6 +3923,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_default_index(data)
     version, index_name = data
     stub_elastic
+    stub_elastic_info
     driver("", version)
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
@@ -3890,6 +3965,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
         to_return(:status => 200, :headers => {'Content-Type' => 'Application/json'}, :body => compressed_body)
+    stub_elastic_info("http://localhost:9200/")
 
     driver(config)
     driver.run(default_tag: 'test') do
@@ -3906,6 +3982,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_default_type(data)
     version, index_type = data
     stub_elastic
+    stub_elastic_info
     driver("", version)
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
@@ -3916,6 +3993,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_speficied_index
     driver.configure("index_name myindex\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -3935,6 +4013,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                        ]
                      ))
     request = stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record('huge_record' => ("a" * 20 * 1024 * 1024)))
       driver.feed(sample_record('huge_record' => ("a" * 20 * 1024 * 1024)))
@@ -3959,6 +4038,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         body: /{"index":{"_index":"fluentd","_type":"fluentd"}}\n{"age":26,"request_id":"42","parent_id":"parent","routing_id":"routing","#{chunk_id_key}":".*"}\n/) do |req|
       @index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
     end
+    stub_elastic_info
     driver.run(default_tag: 'test', shutdown: false) do
       driver.feed(sample_record)
     end
@@ -3988,6 +4068,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                        ]
                      ))
     request = stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record('huge_record' => ("a" * 20 * 1024 * 1024)))
       driver.feed(sample_record('huge_record' => ("a" * 20 * 1024 * 1024)))
@@ -4000,6 +4081,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_writes_to_speficied_index_with_tag_placeholder
       driver.configure("index_name myindex.${tag}\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
@@ -4019,6 +4101,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                          ]
                        ))
       stub_elastic
+      stub_elastic_info
       time = Time.parse Date.today.iso8601
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record)
@@ -4039,6 +4122,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       pipeline_id = "mypipeline"
       logstash_index = "myindex.#{pipeline_id}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
       end
@@ -4049,6 +4133,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_speficied_index_uppercase
     driver.configure("index_name MyIndex\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4060,6 +4145,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_target_index_key
     driver.configure("target_index_key @target_index\n")
     stub_elastic
+    stub_elastic_info
     record = sample_record.clone
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('@target_index' => 'local-override'))
@@ -4073,17 +4159,19 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       logstash_format true")
     time = Time.parse Date.today.iso8601
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record.merge('@target_index' => 'local-override'))
     end
     assert_equal('local-override', index_cmds.first['index']['_index'])
   end
 
-   def test_writes_to_target_index_key_logstash_uppercase
+  def test_writes_to_target_index_key_logstash_uppercase
     driver.configure("target_index_key @target_index
                       logstash_format true")
     time = Time.parse Date.today.iso8601
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record.merge('@target_index' => 'LOCAL-OVERRIDE'))
     end
@@ -4096,6 +4184,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     pipeline = "fluentd"
     driver.configure("pipeline #{pipeline}")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4192,6 +4281,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     ids = [my_id_value]
     indices = ["logstash-2021.04.28"]
     stub_elastic
+    stub_elastic_info
     stub_elastic_affinity_target_index_search(ids, indices)
     driver.run(default_tag: 'test') do
       driver.feed(sample_record('my_id' => my_id_value))
@@ -4209,6 +4299,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     ids = [my_id_value]
     indices = ["logstash-2021.04.28"]
     stub_elastic
+    stub_elastic_info
     stub_elastic_affinity_target_index_search(ids, indices)
     driver.run(default_tag: 'test') do
       driver.feed(sample_record('my_id' => my_id_value))
@@ -4225,6 +4316,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     my_id_value = "3408a2c8eecd4fbfb82e45012b54fa82"
     ids = [my_id_value]
     stub_elastic
+    stub_elastic_info
     stub_elastic_affinity_target_index_search_return_empty(ids)
     time = Time.parse Date.today.iso8601
     driver.run(default_tag: 'test') do
@@ -4243,6 +4335,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     my_id_value2 = "3408a2c8eecd4fbfb82e45012b54fa82"
     ids = [my_id_value, my_id_value2]
     indices = ["logstash-2021.04.29", "logstash-2021.04.28"]
+    stub_elastic_info
     stub_elastic_all_requests
     stub_elastic_affinity_target_index_search(ids, indices)
     driver.run(default_tag: 'test') do
@@ -4268,6 +4361,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     # Simulate the used sorting here, as search sorts indices in DESC order to pick only oldest index per single _id
     indices = ["logstash-2021.04.29", "logstash-2021.04.28"]
 
+    stub_elastic_info
     stub_elastic_all_requests
     stub_elastic_affinity_target_index_search(ids, indices)
     driver.run(default_tag: 'test') do
@@ -4286,6 +4380,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       pipeline = "fluentd-${tag}"
       driver.configure("pipeline #{pipeline}")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test.builtin.placeholder') do
         driver.feed(sample_record)
       end
@@ -4307,6 +4402,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       time = Time.parse Date.today.iso8601
       pipeline = "fluentd-#{time.getutc.strftime("%Y%m%d")}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record)
       end
@@ -4326,6 +4422,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       pipeline_id = "mypipeline"
       logstash_index = "fluentd-#{pipeline_id}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
       end
@@ -4336,6 +4433,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_target_index_key_fallack
     driver.configure("target_index_key @target_index\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4348,6 +4446,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "logstash-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -4361,6 +4460,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_speficied_type(data)
     driver('', data["es_version"]).configure("type_name mytype\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4374,6 +4474,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_speficied_type_with_placeholders(data)
     driver('', data["es_version"]).configure("type_name mytype.${tag}\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4388,6 +4489,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver('', data["es_version"])
       .configure("type_name mytype.${tag}\nsuppress_type_name true")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4402,6 +4504,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_target_type_key(data)
     driver('', data["es_version"]).configure("target_type_key @target_type\n")
     stub_elastic
+    stub_elastic_info
     record = sample_record.clone
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('@target_type' => 'local-override'))
@@ -4413,6 +4516,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_target_type_key_fallack_to_default
     driver.configure("target_type_key @target_type\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4423,6 +4527,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("target_type_key @target_type
                       type_name mytype")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4437,6 +4542,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_target_type_key_nested(data)
     driver('', data["es_version"]).configure("target_type_key kubernetes.labels.log_type\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('kubernetes' => {
         'labels' => {
@@ -4451,6 +4557,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_target_type_key_fallack_to_default_nested
     driver.configure("target_type_key kubernetes.labels.log_type\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('kubernetes' => {
         'labels' => {
@@ -4464,6 +4571,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_speficied_host
     driver.configure("host 192.168.33.50\n")
     elastic_request = stub_elastic("http://192.168.33.50:9200/_bulk")
+    stub_elastic_info("http://192.168.33.50:9200/")
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4473,6 +4581,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_writes_to_speficied_port
     driver.configure("port 9201\n")
     elastic_request = stub_elastic("http://localhost:9201/_bulk")
+    stub_elastic_info("http://localhost:9201")
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4488,6 +4597,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     hosts.each do |host_info|
       host, port = host_info
       stub_elastic_with_store_index_command_counts("http://#{host}:#{port}/_bulk")
+      stub_elastic_info("http://#{host}:#{port}/")
     end
 
     driver.run(default_tag: 'test') do
@@ -4524,6 +4634,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     ]}
 
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(original_hash)
     end
@@ -4537,6 +4648,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     expected_output = {"foo" => {"bar" => "baz"}}
 
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(original_hash)
     end
@@ -4545,6 +4657,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_makes_bulk_request
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
       driver.feed(sample_record.merge('age' => 27))
@@ -4552,8 +4665,9 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_equal(4, index_cmds.count)
   end
 
-  def test_all_records_are_preserved_in_bulk
+  def test_all_re
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
       driver.feed(sample_record.merge('age' => 27))
@@ -4569,6 +4683,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     dt = DateTime.new(2015, 6, 1, 0, 0, 1, "+01:00")
     logstash_index = "logstash-2015.05.31"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(dt.to_time.to_i, sample_record)
     end
@@ -4583,6 +4698,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     time = Date.today.to_time
     index = "logstash-#{time.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -4595,6 +4711,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -4609,6 +4726,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix#{separator}#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -4622,6 +4740,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       time = Time.parse Date.today.iso8601
       logstash_index = "myprefix-test-#{time.getutc.strftime("%Y.%m.%d")}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record)
       end
@@ -4644,6 +4763,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       time = Time.parse Date.today.iso8601
       logstash_index = "myprefix-#{time.getutc.strftime("%H")}-#{time.getutc.strftime("%Y.%m.%d")}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record)
       end
@@ -4664,6 +4784,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       pipeline_id = "mypipeline"
       logstash_index = "myprefix-#{pipeline_id}-#{time.getutc.strftime("%Y.%m.%d")}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
       end
@@ -4689,6 +4810,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       time = Time.parse Date.today.iso8601
       logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record.merge('indexformat' => '%Y.%m.%d'))
       end
@@ -4712,6 +4834,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       time = Time.parse Date.today.iso8601
       logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m")}"
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record.merge('indexformat' => '%Y.%m'))
       end
@@ -4724,6 +4847,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       driver.configure("host ${tag}\n")
       time = Time.parse Date.today.iso8601
       elastic_request = stub_elastic("http://extracted-host:9200/_bulk")
+      stub_elastic_info("http://extracted-host:9200/")
       driver.run(default_tag: 'extracted-host') do
         driver.feed(time.to_i, sample_record)
       end
@@ -4740,6 +4864,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         host, port = host_info
         host = "extracted-host" if host == '${tag}'
         stub_elastic_with_store_index_command_counts("http://#{host}:#{port}/_bulk")
+        stub_elastic_info("http://#{host}:#{port}")
       end
 
       driver.run(default_tag: 'extracted-host') do
@@ -4774,8 +4899,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                          ]
                        ))
       stub_elastic
+      stub_elastic_info
       time = Time.parse Date.today.iso8601
       elastic_request = stub_elastic("http://host-#{time.utc.strftime('%Y%m%d')}:9200/_bulk")
+      stub_elastic_info("http://host-#{time.utc.strftime('%Y%m%d')}:9200/")
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record)
       end
@@ -4796,6 +4923,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       second_pipeline_id = "2"
       first_request = stub_elastic("http://myhost-1:9200/_bulk")
       second_request = stub_elastic("http://myhost-2:9200/_bulk")
+      stub_elastic_info("http://myhost-1:9200/")
+      stub_elastic_info("http://myhost-2:9200/")
       driver.run(default_tag: 'test') do
         driver.feed(time.to_i, sample_record.merge({"pipeline_id" => first_pipeline_id}))
         driver.feed(time.to_i, sample_record.merge({"pipeline_id" => second_pipeline_id}))
@@ -4816,6 +4945,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       time = Time.parse Date.today.iso8601
       pipeline_id = "1"
       request = stub_elastic_unavailable("http://myhost-1:9200/_bulk")
+      stub_elastic_info("http://myhost-1:9200/")
       exception = assert_raise(Fluent::Plugin::ElasticsearchOutput::RecoverableRequestFailure) {
         driver.run(default_tag: 'test') do
           driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
@@ -4831,6 +4961,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -4845,6 +4976,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "logstash-#{time.getutc.strftime("%Y.%m")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -4858,6 +4990,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -4884,6 +5017,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_doesnt_add_logstash_timestamp_by_default
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -4893,6 +5027,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_adds_timestamp_when_logstash
     driver.configure("logstash_format true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.now
     time = Fluent::EventTime.from_time(ts.to_time)
     driver.run(default_tag: 'test') do
@@ -4905,6 +5040,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_adds_timestamp_when_include_timestamp
     driver.configure("include_timestamp true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.now
     time = Fluent::EventTime.from_time(ts.to_time)
     driver.run(default_tag: 'test') do
@@ -4917,6 +5053,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_uses_custom_timestamp_when_included_in_record
     driver.configure("logstash_format true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('@timestamp' => ts))
@@ -4928,6 +5065,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_uses_custom_timestamp_when_included_in_record_without_logstash
     driver.configure("include_timestamp true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('@timestamp' => ts))
@@ -4940,6 +5078,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601(9)
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -4953,6 +5092,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       time_precision 3
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     time = Time.now
     float_time = time.to_f
     driver.run(default_tag: 'test') do
@@ -4967,6 +5107,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     ts = "2001-02-03 13:14:01.673+02:00"
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -4981,6 +5122,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     ts = "2001-02-03 13:14:01.673+02:00"
     time = Time.parse(ts)
     current_zone_offset = Time.new(2001, 02, 03).to_datetime.offset
@@ -4998,6 +5140,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       time_key_format %Y-%m-%d %H:%M:%S.%N%z
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     ts = "2001-02-03 13:14:01.673+02:00"
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -5012,6 +5155,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       time_key vtm
                       time_key_exclude_timestamp true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -5023,6 +5167,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_key_format %Y-%m-%dT%H:%M:%S.%N%z\n")
     stub_elastic
+    stub_elastic_info
     ts = "2001-02-03T13:14:01.673+02:00"
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('@timestamp' => ts))
@@ -5037,6 +5182,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       index_name test
                       time_key_format %Y-%m-%dT%H:%M:%S.%N%z\n")
     stub_elastic
+    stub_elastic_info
     ts = "2001-02-03T13:14:01.673+02:00"
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('@timestamp' => ts))
@@ -5054,6 +5200,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_key_format %Y-%m-%dT%H:%M:%S.%N%z\n#{tag_config}\n")
     stub_elastic
+    stub_elastic_info
 
     ts = "2001/02/03 13:14:01,673+02:00"
     index = "logstash-#{Time.now.getutc.strftime("%Y.%m.%d")}"
@@ -5074,6 +5221,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_key_format %a %b %d %H:%M:%S %Z %Y\n")
     stub_elastic
+    stub_elastic_info
     ts = "Thu Nov 29 14:33:20 GMT 2001"
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('@timestamp' => ts))
@@ -5086,6 +5234,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_uses_nanosecond_precision_by_default
     driver.configure("logstash_format true\n")
     stub_elastic
+    stub_elastic_info
     time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
@@ -5098,6 +5247,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_precision 3\n")
     stub_elastic
+    stub_elastic_info
     time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
@@ -5108,6 +5258,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_doesnt_add_tag_key_by_default
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5117,6 +5268,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_adds_tag_key_when_configured
     driver.configure("include_tag_key true\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'mytag') do
       driver.feed(sample_record)
     end
@@ -5127,6 +5279,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_adds_id_key_when_configured
     driver.configure("id_key request_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5137,6 +5290,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_id_key_with_dot
       driver.configure("id_key nested.request_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5146,6 +5300,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_id_key_with_dollar_dot
       driver.configure("id_key $.nested.request_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5155,6 +5310,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_id_key_with_bracket
       driver.configure("id_key $['nested']['request_id']\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5165,6 +5321,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_doesnt_add_id_key_if_missing_when_configured
     driver.configure("id_key another_request_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5173,6 +5330,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_adds_id_key_when_not_configured
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5182,6 +5340,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_adds_parent_key_when_configured
     driver.configure("parent_key parent_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5192,6 +5351,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_parent_key_with_dot
       driver.configure("parent_key nested.parent_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5201,6 +5361,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_parent_key_with_dollar_dot
       driver.configure("parent_key $.nested.parent_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5210,6 +5371,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_parent_key_with_bracket
       driver.configure("parent_key $['nested']['parent_id']\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5220,6 +5382,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_doesnt_add_parent_key_if_missing_when_configured
     driver.configure("parent_key another_parent_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5228,6 +5391,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_adds_parent_key_when_not_configured
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5238,6 +5402,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_es6
       driver("routing_key routing_id\n", 6)
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
@@ -5247,6 +5412,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_es7
       driver("routing_key routing_id\n", 7)
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
@@ -5258,6 +5424,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_routing_key_with_dot
       driver.configure("routing_key nested.routing_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5267,6 +5434,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_routing_key_with_dollar_dot
       driver.configure("routing_key $.nested.routing_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5276,6 +5444,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     def test_adds_nested_routing_key_with_bracket
       driver.configure("routing_key $['nested']['routing_id']\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -5286,6 +5455,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_doesnt_add_routing_key_if_missing_when_configured
     driver.configure("routing_key another_routing_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5294,6 +5464,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_adds_routing_key_when_not_configured
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5303,6 +5474,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_remove_one_key
     driver.configure("remove_keys key1\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
     end
@@ -5313,6 +5485,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_remove_multi_keys
     driver.configure("remove_keys key1, key2\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
     end
@@ -5321,6 +5494,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   def test_request_error
+    stub_elastic_info
     stub_elastic_unavailable
     assert_raise(Fluent::Plugin::ElasticsearchOutput::RecoverableRequestFailure) {
       driver.run(default_tag: 'test', shutdown: false) do
@@ -5332,6 +5506,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_request_forever
     omit("retry_forever test is unstable.") if ENV["CI"]
     stub_elastic
+    stub_elastic_info
     driver.configure(Fluent::Config::Element.new(
                'ROOT', '', {
                  '@type' => 'elasticsearch',
@@ -5356,6 +5531,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       connection_resets += 1
       raise Faraday::ConnectionFailed, "Test message"
     end
+    stub_elastic_info
 
     assert_raise(Fluent::Plugin::ElasticsearchOutput::RecoverableRequestFailure) {
       driver.run(default_tag: 'test', shutdown: false) do
@@ -5372,6 +5548,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       connection_resets += 1
       raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
+    stub_elastic_info
 
     driver.configure("reconnect_on_error true\n")
 
@@ -5398,6 +5575,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       connection_resets += 1
       raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
+    stub_elastic_info
 
     driver.configure("reconnect_on_error false\n")
 
@@ -5441,6 +5619,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         })
      }
     end)
+    stub_elastic_info
 
     driver.run(default_tag: 'test') do
       driver.feed(1, sample_record)
@@ -5512,6 +5691,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         })
                      }
                    end)
+      stub_elastic_info
 
       # Check buffer fulfillment condition
       assert_raise(Fluent::Plugin::ElasticsearchOutput::RetryStreamEmitFailure) do
@@ -5558,6 +5738,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         })
      }
     end)
+    stub_elastic_info
+
     sample_record1 = sample_record('my_id' => 'abc')
     sample_record4 = sample_record('my_id' => 'xyz')
 
@@ -5607,6 +5789,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         })
      }
     end)
+    stub_elastic_info
+
     sample_record1 = sample_record('my_id' => 'abc')
     sample_record4 = sample_record('my_id' => 'xyz')
 
@@ -5677,6 +5861,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         })
      }
     end)
+    stub_elastic_info
 
     driver.run(default_tag: 'test') do
       driver.feed(1, sample_record)
@@ -5693,6 +5878,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_update_should_not_write_if_theres_no_id
     driver.configure("write_operation update\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5702,6 +5888,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_upsert_should_not_write_if_theres_no_id
     driver.configure("write_operation upsert\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5711,6 +5898,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_create_should_not_write_if_theres_no_id
     driver.configure("write_operation create\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5721,6 +5909,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("write_operation update
                       id_key request_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5734,6 +5923,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       id_key request_id
                       remove_keys_on_update parent_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5745,6 +5935,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("write_operation upsert
                       id_key request_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5758,6 +5949,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       id_key request_id
                       remove_keys_on_update parent_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5772,6 +5964,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       id_key request_id
                       remove_keys_on_update parent_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5785,6 +5978,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       id_key id
                       remove_keys_on_update foo,baz")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed("id" => 1, "foo" => "bar", "baz" => "quix", "zip" => "zam")
     end
@@ -5809,6 +6003,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       id_key id
                       remove_keys_on_update_key keys_to_skip")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed("id" => 1, "foo" => "bar", "baz" => "quix", "keys_to_skip" => ["baz"])
     end
@@ -5833,6 +6028,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       remove_keys_on_update foo,bar
                       remove_keys_on_update_key keys_to_skip")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed("id" => 1, "foo" => "bar", "baz" => "quix", "keys_to_skip" => ["baz"])
     end
@@ -5857,6 +6053,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     driver.configure("write_operation create
                       id_key request_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -5865,6 +6062,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_include_index_in_url
     stub_elastic('http://localhost:9200/logstash-2018.01.01/_bulk')
+    stub_elastic_info('http://localhost:9200/')
 
     driver.configure("index_name logstash-2018.01.01
                       include_index_in_url true")
@@ -5878,8 +6076,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
   def test_use_simple_sniffer
     require 'fluent/plugin/elasticsearch_simple_sniffer'
-    stub_elastic_info
     stub_elastic
+    stub_elastic_info
     config = %[
       sniffer_class_name Fluent::Plugin::ElasticsearchSimpleSniffer
       log_level debug
@@ -5903,6 +6101,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       remove_keys id
                       suppress_doc_wrap true')
     stub_elastic
+    stub_elastic_info
     doc_body = {'field' => 'value'}
     script_body = {'source' => 'ctx._source.counter += params.param1',
                    'lang' => 'painless',
@@ -5929,6 +6128,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
                       remove_keys id
                       suppress_doc_wrap true')
     stub_elastic
+    stub_elastic_info
     doc_body = {'field' => 'value'}
     script_body = {'source' => 'ctx._source.counter += params.param1',
                    'lang' => 'painless',
@@ -5955,6 +6155,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_ignore_exception
     driver.configure('ignore_exceptions ["Elasticsearch::Transport::Transport::Errors::ServiceUnavailable"]')
     stub_elastic_unavailable
+    stub_elastic_info
 
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
@@ -5964,6 +6165,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_ignore_exception_with_superclass
     driver.configure('ignore_exceptions ["Elasticsearch::Transport::Transport::ServerError"]')
     stub_elastic_unavailable
+    stub_elastic_info
 
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
@@ -5973,6 +6175,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_ignore_excetion_handles_appropriate_ones
     driver.configure('ignore_exceptions ["Faraday::ConnectionFailed"]')
     stub_elastic_unavailable
+    stub_elastic_info
 
     assert_raise(Fluent::Plugin::ElasticsearchOutput::RecoverableRequestFailure) {
       driver.run(default_tag: 'test', shutdown: false) do

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -45,6 +45,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     }.configure(conf)
   end
 
+  def elasticsearch_transport_layer_decoupling?
+    Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+  end
+
   def default_type_name
     Fluent::Plugin::ElasticsearchOutput::DEFAULT_TYPE_NAME
   end
@@ -298,7 +302,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal nil, instance.client.transport.transport.options[:transport_options][:headers]["Content-Encoding"]
     else
       assert_equal nil, instance.client.transport.options[:transport_options][:headers]["Content-Encoding"]
@@ -312,7 +316,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     end
     compressable = instance.compressable_connection
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal "gzip", instance.client(nil, compressable).transport.transport.options[:transport_options][:headers]["Content-Encoding"]
     else
       assert_equal "gzip", instance.client(nil, compressable).transport.options[:transport_options][:headers]["Content-Encoding"]
@@ -327,7 +331,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal false, instance.client.transport.transport.options[:compression]
     else
       assert_equal false, instance.client.transport.options[:compression]
@@ -341,7 +345,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     end
     compressable = instance.compressable_connection
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal true, instance.client(nil, compressable).transport.transport.options[:compression]
     else
       assert_equal true, instance.client(nil, compressable).transport.options[:compression]
@@ -449,7 +453,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         scheme https
         @log_level info
       }
-      if Gem::Version.new(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      if elasticsearch_transport_layer_decoupling?
         assert_raise(NoMethodError) do
           d = create_driver(config, 7, "\"7.10.1\"")
         end

--- a/test/plugin/test_out_elasticsearch_data_stream.rb
+++ b/test/plugin/test_out_elasticsearch_data_stream.rb
@@ -91,7 +91,13 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
     end
   end
 
-  def stub_default(name="foo")
+  def stub_elastic_info(url="http://localhost:9200/", version="7.9.0")
+    body ="{\"version\":{\"number\":\"#{version}\", \"build_flavor\":\"default\"},\"tagline\" : \"You Know, for Search\"}"
+    stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json' } })
+  end
+
+  def stub_default(name="foo", host="http://localhost:9200")
+    stub_elastic_info(host)
     stub_ilm_policy(name)
     stub_index_template(name)
     stub_nonexistent_data_stream?(name)
@@ -214,6 +220,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
     stub_index_template
     stub_existent_data_stream?
     stub_data_stream
+    stub_elastic_info
     conf = config_element(
       'ROOT', '', {
         '@type' => ELASTIC_DATA_STREAM_TYPE,
@@ -327,6 +334,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
       connection_resets += 1
       raise Faraday::ConnectionFailed, "Test message"
     end
+    stub_elastic_info("https://logs.google.com:778/")
 
     assert_raise(Fluent::Plugin::ElasticsearchError::RetryableOperationExhaustedFailure) do
       driver(config)

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -34,6 +34,10 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }.configure(conf)
   end
 
+  def elasticsearch_transport_layer_decoupling?
+    Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+  end
+
   def default_type_name
     Fluent::Plugin::ElasticsearchOutput::DEFAULT_TYPE_NAME
   end
@@ -157,7 +161,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal nil, instance.client.transport.transport.options[:transport_options][:headers]["Content-Encoding"]
     else
       assert_equal nil, instance.client.transport.options[:transport_options][:headers]["Content-Encoding"]
@@ -171,7 +175,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     end
     compressable = instance.compressable_connection
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal "gzip", instance.client(nil, compressable).transport.transport.options[:transport_options][:headers]["Content-Encoding"]
     else
       assert_equal "gzip", instance.client(nil, compressable).transport.options[:transport_options][:headers]["Content-Encoding"]
@@ -186,7 +190,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal false, instance.client.transport.transport.options[:compression]
     else
       assert_equal false, instance.client.transport.options[:compression]
@@ -200,7 +204,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     end
     compressable = instance.compressable_connection
 
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if elasticsearch_transport_layer_decoupling?
       assert_equal true, instance.client(nil, compressable).transport.transport.options[:compression]
     else
       assert_equal true, instance.client(nil, compressable).transport.options[:compression]

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -54,6 +54,11 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     end
   end
 
+  def stub_elastic_info(url="http://localhost:9200/", version="6.4.2")
+    body ="{\"version\":{\"number\":\"#{version}\", \"build_flavor\":\"default\"},\"tagline\" : \"You Know, for Search\"}"
+    stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json' } })
+  end
+
   def stub_elastic_unavailable(url="http://localhost:9200/_bulk")
     stub_request(:post, url).to_return(:status => [503, "Service Unavailable"])
   end
@@ -152,16 +157,25 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    assert_equal nil, instance.client.transport.options[:transport_options][:headers]["Content-Encoding"]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal nil, instance.client.transport.transport.options[:transport_options][:headers]["Content-Encoding"]
+    else
+      assert_equal nil, instance.client.transport.options[:transport_options][:headers]["Content-Encoding"]
+    end
 
     stub_request(:post, "http://localhost:9200/_bulk").
       to_return(status: 200, body: "", headers: {})
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
     compressable = instance.compressable_connection
 
-    assert_equal "gzip", instance.client(nil, compressable).transport.options[:transport_options][:headers]["Content-Encoding"]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal "gzip", instance.client(nil, compressable).transport.transport.options[:transport_options][:headers]["Content-Encoding"]
+    else
+      assert_equal "gzip", instance.client(nil, compressable).transport.options[:transport_options][:headers]["Content-Encoding"]
+    end
   end
 
   test 'check compression option is passed to transport' do
@@ -172,16 +186,25 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     }
     instance = driver(config).instance
 
-    assert_equal false, instance.client.transport.options[:compression]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal false, instance.client.transport.transport.options[:compression]
+    else
+      assert_equal false, instance.client.transport.options[:compression]
+    end
 
     stub_request(:post, "http://localhost:9200/_bulk").
       to_return(status: 200, body: "", headers: {})
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
     compressable = instance.compressable_connection
 
-    assert_equal true, instance.client(nil, compressable).transport.options[:compression]
+    if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+      assert_equal true, instance.client(nil, compressable).transport.transport.options[:compression]
+    else
+      assert_equal true, instance.client(nil, compressable).transport.options[:compression]
+    end
   end
 
   test 'configure Content-Type' do
@@ -348,6 +371,8 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
                           with(headers: { "Content-Type" => "application/json" })
     end
+    stub_elastic_info('http://localhost:9200')
+
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -356,6 +381,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_writes_to_default_index
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -395,6 +421,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
     elastic_request = stub_request(:post, "http://localhost:9200/_bulk").
         to_return(:status => 200, :headers => {'Content-Type' => 'Application/json'}, :body => compressed_body)
+    stub_elastic_info
 
     driver(config)
     driver.run(default_tag: 'test') do
@@ -406,6 +433,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_writes_to_default_type
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -415,6 +443,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_writes_to_specified_index
     driver.configure("index_name myindex\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -424,6 +453,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_writes_to_specified_index_uppercase
     driver.configure("index_name MyIndex\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -433,6 +463,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_writes_to_specified_type
     driver.configure("type_name mytype\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -442,6 +473,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_writes_to_specified_host
     driver.configure("host 192.168.33.50\n")
     elastic_request = stub_elastic("http://192.168.33.50:9200/_bulk")
+    stub_elastic_info("http://192.168.33.50:9200/")
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -451,6 +483,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_writes_to_specified_port
     driver.configure("port 9201\n")
     elastic_request = stub_elastic("http://localhost:9201/_bulk")
+    stub_elastic_info("http://localhost:9201/")
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -466,6 +499,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     hosts.each do |host_info|
       host, port = host_info
       stub_elastic_with_store_index_command_counts("http://#{host}:#{port}/_bulk")
+      stub_elastic_info("http://#{host}:#{port}/")
     end
 
     driver.run(default_tag: 'test') do
@@ -501,6 +535,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     ]}
 
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(original_hash)
     end
@@ -514,6 +549,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     expected_output = {"foo" => {"bar" => "baz"}}
 
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(original_hash)
     end
@@ -522,6 +558,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_makes_bulk_request
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
       driver.feed(sample_record.merge('age' => 27))
@@ -531,6 +568,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_all_records_are_preserved_in_bulk
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
       driver.feed(sample_record.merge('age' => 27))
@@ -544,6 +582,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "logstash-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -556,6 +595,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     utc_index = "logstash-#{time.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -568,6 +608,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -582,6 +623,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix#{separator}#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -594,18 +636,20 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m.%d")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
     assert_equal(logstash_index, index_cmds.first['index']['_index'])
   end
 
-    def test_writes_to_logstash_index_with_specified_dateformat
+  def test_writes_to_logstash_index_with_specified_dateformat
     driver.configure("logstash_format true
                       logstash_dateformat %Y.%m")
     time = Time.parse Date.today.iso8601
     logstash_index = "logstash-#{time.getutc.strftime("%Y.%m")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -619,6 +663,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     time = Time.parse Date.today.iso8601
     logstash_index = "myprefix-#{time.getutc.strftime("%Y.%m")}"
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(time.to_i, sample_record)
     end
@@ -627,6 +672,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_doesnt_add_logstash_timestamp_by_default
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -636,6 +682,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_adds_logstash_timestamp_when_configured
     driver.configure("logstash_format true\n")
     stub_elastic
+    stub_elastic_info
     time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
@@ -648,6 +695,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_precision 3\n")
     stub_elastic
+    stub_elastic_info
     time = Fluent::EventTime.new(Time.now.to_i, 123456789)
     driver.run(default_tag: 'test') do
       driver.feed(time, sample_record)
@@ -659,6 +707,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_uses_custom_timestamp_when_included_in_record
     driver.configure("include_timestamp true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('@timestamp' => ts))
@@ -670,6 +719,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_uses_custom_timestamp_when_included_in_record_logstash
     driver.configure("logstash_format true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('@timestamp' => ts))
@@ -682,6 +732,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("logstash_format true
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -694,6 +745,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("include_timestamp true
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -707,6 +759,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
                       index_name test
                       time_key vtm\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -721,6 +774,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
                       time_key vtm
                       time_key_exclude_timestamp true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -733,6 +787,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
                       time_key vtm
                       time_key_exclude_timestamp true\n")
     stub_elastic
+    stub_elastic_info
     ts = DateTime.new(2001,2,3).iso8601
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge!('vtm' => ts))
@@ -742,6 +797,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_doesnt_add_tag_key_by_default
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -751,6 +807,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_adds_tag_key_when_configured
     driver.configure("include_tag_key true\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'mytag') do
       driver.feed(sample_record)
     end
@@ -761,6 +818,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_adds_id_key_when_configured
     driver.configure("id_key request_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -771,6 +829,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_id_key_with_dot
       driver.configure("id_key nested.request_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -780,6 +839,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_id_key_with_dollar_dot
       driver.configure("id_key $.nested.request_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -789,6 +849,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_id_key_with_bracket
       driver.configure("id_key $['nested']['request_id']\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -799,6 +860,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_doesnt_add_id_key_if_missing_when_configured
     driver.configure("id_key another_request_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -807,6 +869,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_adds_id_key_when_not_configured
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -816,6 +879,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_adds_parent_key_when_configured
     driver.configure("parent_key parent_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -826,6 +890,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_parent_key_with_dot
       driver.configure("parent_key nested.parent_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -835,6 +900,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_parent_key_with_dollar_dot
       driver.configure("parent_key $.nested.parent_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -844,6 +910,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_parent_key_with_bracket
       driver.configure("parent_key $['nested']['parent_id']\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -854,6 +921,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_doesnt_add_parent_key_if_missing_when_configured
     driver.configure("parent_key another_parent_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -862,6 +930,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_adds_parent_key_when_not_configured
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -872,6 +941,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_es6
       driver("routing_key routing_id\n", 6)
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
@@ -881,6 +951,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_es7
       driver("routing_key routing_id\n", 7)
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(sample_record)
       end
@@ -892,6 +963,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_routing_key_with_dot
       driver.configure("routing_key nested.routing_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -901,6 +973,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_routing_key_with_dollar_dot
       driver.configure("routing_key $.nested.routing_id\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -910,6 +983,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     def test_adds_nested_routing_key_with_bracket
       driver.configure("routing_key $['nested']['routing_id']\n")
       stub_elastic
+      stub_elastic_info
       driver.run(default_tag: 'test') do
         driver.feed(nested_sample_record)
       end
@@ -920,6 +994,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_doesnt_add_routing_key_if_missing_when_configured
     driver.configure("routing_key another_routing_id\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -928,6 +1003,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_adds_routing_key_when_not_configured
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -937,6 +1013,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_remove_one_key
     driver.configure("remove_keys key1\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
     end
@@ -947,6 +1024,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_remove_multi_keys
     driver.configure("remove_keys key1, key2\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record.merge('key1' => 'v1', 'key2' => 'v2'))
     end
@@ -956,6 +1034,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_request_error
     stub_elastic_unavailable
+    stub_elastic_info
     assert_raise(Fluent::Plugin::ElasticsearchOutput::RecoverableRequestFailure) {
       driver.run(default_tag: 'test', shutdown: false) do
         driver.feed(sample_record)
@@ -967,6 +1046,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     omit("retry_forever test is unstable.") if ENV["CI"]
 
     stub_elastic
+    stub_elastic_info
     driver.configure(Fluent::Config::Element.new(
                'ROOT', '', {
                  '@type' => 'elasticsearch',
@@ -986,6 +1066,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_tag_parts_index_error_event
     stub_elastic
+    stub_elastic_info
     driver.configure("logstash_prefix ${tag_parts[1]}\n")
     flexmock(driver.instance.router).should_receive(:emit_error_event)
       .with('test', Fluent::EventTime, Hash, TypeError).once
@@ -1001,6 +1082,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       connection_resets += 1
       raise Faraday::ConnectionFailed, "Test message"
     end
+    stub_elastic_info
 
     assert_raise(Fluent::Plugin::ElasticsearchOutput::RecoverableRequestFailure) {
       driver.run(default_tag: 'test', shutdown: false) do
@@ -1017,6 +1099,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       connection_resets += 1
       raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
+    stub_elastic_info
 
     driver.configure("reconnect_on_error true\n")
 
@@ -1043,6 +1126,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
       connection_resets += 1
       raise ZeroDivisionError, "any not host_unreachable_exceptions exception"
     end
+    stub_elastic_info
 
     driver.configure("reconnect_on_error false\n")
 
@@ -1063,6 +1147,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_update_should_not_write_if_theres_no_id
     driver.configure("write_operation update\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -1072,6 +1157,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_upsert_should_not_write_if_theres_no_id
     driver.configure("write_operation upsert\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -1081,6 +1167,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   def test_create_should_not_write_if_theres_no_id
     driver.configure("write_operation create\n")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -1091,6 +1178,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("write_operation update
                       id_key request_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -1102,6 +1190,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("write_operation upsert
                       id_key request_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -1113,6 +1202,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
     driver.configure("write_operation create
                       id_key request_id")
     stub_elastic
+    stub_elastic_info
     driver.run(default_tag: 'test') do
       driver.feed(sample_record)
     end
@@ -1121,6 +1211,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
 
   def test_include_index_in_url
     stub_elastic('http://localhost:9200/logstash-2018.01.01/_bulk')
+    stub_elastic_info('http://localhost:9200/')
 
     driver.configure("index_name logstash-2018.01.01
                       include_index_in_url true")


### PR DESCRIPTION
fixes #912

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
