### PR TITLE
Support Buffer in Data Stream Output

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -1,3 +1,4 @@
+
 require_relative 'out_elasticsearch'
 
 module Fluent::Plugin
@@ -200,7 +201,7 @@ module Fluent::Plugin
           log.error "Could not bulk insert to Data Stream: #{data_stream_name} #{response}"
         end
       rescue => e
-        log.error "Could not bulk insert to Data Stream: #{data_stream_name} #{e.message}"
+        raise RecoverableRequestFailure, "could not push logs to Elasticsearch cluster (#{data_stream_name}): #{e.message}"
       end
     end
 


### PR DESCRIPTION
In order for messages to be buffered by the Fluentd framework the
output needs to raise a RecoverableRequestFailure exception when it
encounters a transient error.  Without this messages are dropped if the
Elasticsearch service is temporarily unavailable (e.g. when restarting).

Signed-off-by: Seumas Dunlop <seumas.dunlop@coralbay.tv>

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
