### PR TITLE
Fix default values of datastream parameters

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -9,8 +9,8 @@ module Fluent::Plugin
     helpers :event_emitter
 
     config_param :data_stream_name, :string
-    config_param :data_stream_ilm_name, :string, :default => :data_stream_name
-    config_param :data_stream_template_name, :string, :default => :data_stream_name
+    config_param :data_stream_ilm_name, :string, :default => nil
+    config_param :data_stream_template_name, :string, :default => nil
     # Elasticsearch 7.9 or later always support new style of index template.
     config_set_default :use_legacy_template, false
 
@@ -26,6 +26,9 @@ module Fluent::Plugin
       rescue LoadError
         raise Fluent::ConfigError, "'elasticsearch/api', 'elasticsearch/xpack' are required for <@elasticsearch_data_stream>."
       end
+
+      @data_stream_ilm_name = "#{@data_stream_name}_policy" if @data_stream_ilm_name.nil?
+      @data_stream_template_name = "#{@data_stream_name}_template" if @data_stream_template_name.nil?
 
       # ref. https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html
       unless placeholder?(:data_stream_name_placeholder, @data_stream_name)
@@ -93,7 +96,7 @@ module Fluent::Plugin
         "data_stream" => {},
         "template" => {
           "settings" => {
-            "index.lifecycle.name" => "#{ilm_name}_policy"
+            "index.lifecycle.name" => "#{ilm_name}"
           }
         }
       }


### PR DESCRIPTION
Follow-up to issue #925.
I fixed the default values assigned to the datastream parameters  
and added some edge-case tests.

Signed-off-by: Giorgia Fiscaletti <giorgia.fiscaletti@mia-platform.eu>

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
