### PR TITLE
fixing execution order for dynamic data stream creation

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -199,9 +199,9 @@ module Fluent::Plugin
         data_stream_ilm_name = extract_placeholders(@data_stream_ilm_name, chunk)
         unless @data_stream_names.include?(data_stream_name)
           begin
-            create_data_stream(data_stream_name)
             create_ilm_policy(data_stream_name, data_stream_template_name, data_stream_ilm_name, host)
             create_index_template(data_stream_name, data_stream_template_name, data_stream_ilm_name, host)
+            create_data_stream(data_stream_name)
             @data_stream_names << data_stream_name
           rescue => e
             raise Fluent::ConfigError, "Failed to create data stream: <#{data_stream_name}> #{e.message}"


### PR DESCRIPTION
Should fix partial issue in #925

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

I will first test this in our test environment before ticking either of the boxes.