### PR TITLE
Make retryable DataStreams creation at configure phase

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -45,9 +45,13 @@ module Fluent::Plugin
       unless @use_placeholder
         begin
           @data_stream_names = [@data_stream_name]
-          create_ilm_policy(@data_stream_name, @data_stream_template_name, @data_stream_ilm_name)
-          create_index_template(@data_stream_name, @data_stream_template_name, @data_stream_ilm_name)
-          create_data_stream(@data_stream_name)
+          retry_operate(@max_retry_putting_template,
+                        @fail_on_putting_template_retry_exceed,
+                        @catch_transport_exception_on_retry) do
+            create_ilm_policy(@data_stream_name, @data_stream_template_name, @data_stream_ilm_name)
+            create_index_template(@data_stream_name, @data_stream_template_name, @data_stream_ilm_name)
+            create_data_stream(@data_stream_name)
+          end
         rescue => e
           raise Fluent::ConfigError, "Failed to create data stream: <#{@data_stream_name}> #{e.message}"
         end


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

Fixes https://github.com/uken/fluent-plugin-elasticsearch/issues/935

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
