### PR TITLE
Set elasticsearch version

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'fluentd', '>= 0.14.22'
   s.add_runtime_dependency 'excon', '>= 0'
-  s.add_runtime_dependency 'elasticsearch'
+  s.add_runtime_dependency 'elasticsearch', '~> 7.17.0'
 
 
   s.add_development_dependency 'rake', '>= 0'


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)

With elasticsearch v 8.0.0 this gem is not working. The simplest option to make this version is to set elasticseatch gem version to tested release 7.x.x, which is the best practice anyway.


Close #944