### PR TITLE
Move to es 8.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,51 +3,63 @@
 ### [Unreleased]
 
 ### 5.1.5
+
 - Make retryable DataStreams creation at configure phase (#943)
 - Handle @hosts parameter on data_stream plugin (#942)
 - allow specifying custom ILM policies for data streams (#933)
 
 ### 5.1.4
+
 - Handle ES8 or above more strictly (#931)
 - fixing double "\_policy" in index lifecycle management policy for elasticsearch\_data\_stream output (#930)
 
 ### 5.1.3
--  fixing execution order for dynamic data stream creation (#928)
+
+- fixing execution order for dynamic data stream creation (#928)
 
 ### 5.1.2
--  Fix default values of datastream parameters (#926)
+
+- Fix default values of datastream parameters (#926)
 
 ### 5.1.1
+
 - Report appropriate error for data_stream parameters (#922)
 - Add ILM and template parameters for data streams (#920)
 - Support Buffer in Data Stream Output (#917)
 
 ### 5.1.0
+
 - Correct default target bytes value (#914)
 - Handle elasticsearch-ruby 7.14 properly (#913)
 
 ### 5.0.5
+
 - Drop json_parse_exception messages for bulk failures (#900)
 - GitHub Actions: Drop Ruby 2.5 due to EOL (#894)
 
 ### 5.0.4
+
 - test: out_elasticsearch: Remove a needless headers from affinity stub (#888)
 - Target Index Affinity (#883)
 
 ### 5.0.3
+
 - Fix use_legacy_template documentation (#880)
 - Add FAQ for dynamic index/template (#878)
 - Handle IPv6 address string on host and hosts parameters (#877)
 
 ### 5.0.2
+
 - GitHub Actions: Tweak Ruby versions on test (#875)
 - test: datastreams: Set nonexistent datastream as default (#874)
 - Fix overwriting of index template and index lifecycle policy on existing data streams (#872)
 
 ### 5.0.1
+
 - Use elasticsearch/api instead of elasticsearch/xpack (#870)
 
 ### 5.0.0
+
 - Support #retry_operate on data stream (#863)
 - Support placeholder in @data\_stream\_name for @type elasticsearch\_data\_stream (#862)
 - Extract troubleshooting section (#861)
@@ -55,15 +67,19 @@
 - Initial support for Elasticsearch Data Stream (#859)
 
 ### 4.3.3
+
 - Handle invalid Elasticsearch::Client#info response (#855)
 
 ### 4.3.2
+
 - Use log.debug to dump ES 8.x _type information (#852)
 
 ### 4.3.1
+
 - Unsplit huge records by default (#851)
 
 ### 4.3.0
+
 - Add cloud_id & cloud_auth settings (#850)
 - Fix failing tests on es6 client (#848)
 - feat: retry on transport errors (#846)
@@ -71,43 +87,53 @@
 - Remove unnecessary nil check (#826)
 
 ### 4.2.2
+
 - Remove unnecessary nil check (#826)
 - Fix ILM rollover index template pattern to apply index_separator (#825)
 - Fix ILM rollover alias creation when a placeholder is used in index_name (#823)
 - Add a note about the pitfalls of per-date indexes used with ILM (#822)
 
 ### 4.2.1
+
 - Update a broken link (#821)
 - Include chunk_id in records (#820)
 - Fix a failing testcase (#818)
 
 ### 4.2.0
+
 - ci: Add Ruby 2.7 jobs (#812)
 - Support Elasticsearch new style template (#810)
 
 ### 4.1.4
+
 - ElasticsearchGenID update docs for hash_type (#809)
 - Handle api key header (#808)
 - index_template: Handle error object entirely on index creation failure (#807)
 
 ### 4.1.3
+
 - Load multiple templates even if template_name and template_file given (#799)
 - Handle elasticsearch-ruby 7.9.0 using HTTP method changes (#795)
 
 ### 4.1.2
+
 - Use Hash#dig instead of Hash#[] on retrieving version information from Elasticsearch info API (#793)
 
 ### 4.1.1
+
 - Correct ILM explain on logstash_format case (#786)
 
 ### 4.1.0
+
 - Implement Fallback selector and configurable selector class (#782)
 
 ### 4.0.11
+
 - Add custom and time placeholders combination testcase for ILM (#781)
 - Really support ILM on `logstash_format` enabled environment (#779)
 
 ### 4.0.10
+
 - filter_elasticsearch_genid: Use entire record as hash seed (#777)
 - Suppress type in meta with suppress_type_name parameter (#774)
 - filter\_elasticsearch\_genid: Add hash generation mechanism from events (#773)
@@ -117,77 +143,93 @@
 - Document required permissions (#757)
 
 ### 4.0.9
+
 - Add possibility to configure multiple ILM policies (#753)
 - Document required permissions (#757)
 
 ### 4.0.8
+
 - Handle compressable connection usable state (#743)
 - Use newer tls protocol versions (#739)
 - Add GitHub Actions file (#740)
 
 ### 4.0.7
+
 - Added http_backend_excon_nonblock config in out_elasticsearch (#733)
 
 ### 4.0.6
+
 - Add fallback mechanism for handling to detect es version (#730)
 - Remove needless section (#728)
 - Handle exception if index already exists (#727)
 - Tweak test cases (#726)
 
 ### 4.0.5
--  add logstash_dateformat as placeholder (#718)
+
+- add logstash_dateformat as placeholder (#718)
 - Tweak travis.yml for suppressing validator warnings and add CI for Linux Arm64 architecture and macOS 10.14 (#724)
 - Elasticsearch ruby v7.5 (#723)
 - Add Oj serializer testcases for all job (#722)
 - Update documentation for ILM (#721)
 
 ### 4.0.4
+
 - Provide clearing caches timer (#719)
 
 ### 4.0.3
--  Use http.scheme settings for persisent scheme setup (#713)
+
+- Use http.scheme settings for persisent scheme setup (#713)
 
 ### 4.0.2
+
 - Support TLSv1.3 (#710)
 
 ### 4.0.1
+
 - Placeholders for template name and customize template (#708)
 - Add overwriting ilm policy config parameter (#707)
 - Fix a failing ILM config testcase (#706)
 
 ### 4.0.0
+
 - Restructuring ILM related features (#701)
 - Extract placeholders in pipeline parameter (#695)
 - fix typo in `README.md` (#698)
 - Reduce log noise when not using rollover_index (#692)
 
 ### 3.8.0
+
 - Add FAQ for specifying index.codec (#679)
 - Add FAQ for connect_write timeout reached error (#687)
 - Unblocking buffer overflow with block action (#688)
 
 ### 3.7.1
+
 - Make conpatible for Fluentd v1.8 (#677)
 - Handle flatten_hashes in elasticsearch_dynamic (#675)
 - Handle empty index_date_pattern parameter (#674)
 
 ### 3.7.0
+
 - Tweak for cosmetic change (#671)
-- Fix access to Elasticsearch::Transport::VERSION with explicit top level class path (#670)
+- Fix access to Elastic::Transport::VERSION with explicit top level class path (#670)
 - Implement Elasticsearch Input plugin (#669)
 
 ### 3.6.1
+
 - retry upsert on recoverable error. (#667)
 - Allow `_index` in chunk_keys (#665)
 - Support compression feature (#664)
 
 ### 3.6.0
+
 - Set order in newly created templates (#660)
 - Merge Support index lifecycle management into master (#659)
 - Support template installation with host placeholder (#654)
 - Support index lifecycle management (#651)
 
 ### 3.5.6
+
 - Support elasticsearch8 removal of mapping types (#656)
 - Upgrade webmock to 3 (#652)
 - Suppress `ruby -c` warnings (#649)
@@ -196,6 +238,7 @@
 - Validate `user` and `password` early (#636)
 
 ### 3.5.5
+
 - Fix arguments order of `assert_equal` (#635)
 - Add description for `port` option (#634)
 - Fix description position and add examples for `hosts` option (#633)
@@ -208,308 +251,396 @@
 - Add contribution guideline document (#618)
 
 ### 3.5.4
+
 - Add FAQ for Fluentd seems to hang if it unable to connect Elasticsearch (#617)
 - Check bulk_message size before appending (#616)
 - Add FAQ for Elasticsearch index mapping glitch (#614)
 - Display retry counts and interval (#613)
 
 ### 3.5.3
+
 - Handle nil items response (#611)
 
 ### 3.5.2
+
 - Fix `@meta_config_map` creation timing (#592)
 
 ### 3.5.1
+
 - Configurable split request size threshold (#586)
 
 ### 3.5.0
+
 - Adopt Elasticsearch ruby client v7 loggable class (#583)
 
 ### 3.4.3
+
 - Add fail_on_putting_template_retry_exceed config (#579)
 
 ### 3.4.2
+
 - Comparing DEFAULT_TYPE_NAME_ES_7x to target_type instead of type_name (#573)
 
 ### 3.4.1
+
 - Handle non-String value on parse_time (#570)
 
 ### 3.4.0
+
 - Check exclusive feature on #configure (#569)
 - Modify FAQ for highly load k8s EFK stack (#566)
 - Add FAQ for high load k8s EFK stack (#564)
 
 ### 3.3.3
+
 - Add unit test for exception message (#563)
 - Add ignore_exceptions config (#562)
 
 ### 3.3.2
+
 - Fix support for host, hosts placeholders (#560)
 - typo fixes in README.md (#559)
 
 ### 3.3.1
+
 - add new option to suppress doc wrapping (#557)
 - Include 2 (#555)
 
 ### 3.3.0
+
 - Support builtin placeholders for host and hosts parameter (#554)
 
 ### 3.2.4
+
 - Pass chunk for built in placeholders (#553)
 
 ### 3.2.3
+
 - Expose exception backtrace for typhoeus gem loading error (#550)
 
 ### 3.2.2
+
 - Don't validate ES cliuent version under dry-run mode (#547)
 
 ### 3.2.1
+
 - Don't attempt to connect to Elasticsearch in dry run mode (#543)
 - Add FAQ for typhoeus gem installation (#544)
 
 ### 3.2.0
+
 - Split huge record requests (#539)
 
 ### 3.1.1
+
 - Add document for custom_headers (#538)
 - out_elasticsearch: Add custom_headers parameter (#529)
 - Bundle irb on Ruby 2.6 or later (#537)
 
 ### 3.1.0
+
 - Retry obtaining Elasticsearch version (#532)
 - Fix broken id links (#530)
 
 ### 3.0.2
--  appveyor: Remove Ruby 2.1 CI targets on AppVeyor (#524)
+
+- appveyor: Remove Ruby 2.1 CI targets on AppVeyor (#524)
 - Follow removal of _routing field change on recent Elasticsearch (#523)
 - Travis: Tweak to use Ruby versions (#522)
 
 ### 3.0.1
+
 - Remove needless Elasticsearch version detection (#520)
 
 ### 3.0.0
+
 - Use fluentd core retry mechanism (#519)
 - Depends on builtin retrying mechanism (#518)
 - Loosen ConnectionRetryFailure condition when flush_thread_count > 1 and depends on Fluentd core retrying mechanism (#516)
 
 ### 2.12.5
+
 - Ensure sniffer class constants definition before calling #client (#515)
 
 ### 2.12.4
+
 - #506 Rollover index will be in effect in case of template overwrite also. (#513)
 
 ### 2.12.3
+
 - Added log_es_400_reason configuration item (#511)
 - Allow a user to specify the rollover index date pattern (#510)
 
 ### 2.12.2
+
 - Verify connection at startup (#504)
 - Add faq for glob pattern tag routing (#502)
 
 ### 2.12.1
+
 - Make configurable unrecoverable types (#501)
 - Add FAQ for TLS enabled nginx proxy TLS version incompatibility trouble (#496)
 - Add FAQs (#492)
 - Remove issuestats.com badges (#489)
 
 ### 2.12.0
+
 - Decoupling the custom template and rollover index creation #485 (#486)
 
 ### 2.11.11
+
 - Handle error not to acquire version information (#479)
 
 ### 2.11.10
+
 - Verbose error reason output (#469)
 
 ### 2.11.9
+
 - Use ConnectionRetryFailure in plugin specific retrying for consistency (#468)
 - Remove outdated generating hash_id_key code (#466)
 - Tweak behavior for UnrecoverableError and #detect_es_major_version (#465)
 
 ### 2.11.8
+
 - Serialize requests with Oj (#464)
 
 ### 2.11.7
+
 - Add mechanism to detect ES and its client version mismatch (#463)
 
 ### 2.11.6
+
 - 355 customize template (#431)
 
 ### 2.11.5
+
 - Uplift Merge pull request #459 from richm/v0.12-simple-sniffer (#461)
 
 ### 2.11.4
+
 - Persistent backend (#456)
 
 ### 2.11.3
+
 - Implement the `include_index_in_url` option for out_elasticsearch (#451)
 - Add an option `include_index_in_url` to allow URL-based conrtrols (#450)
 
 ### 2.11.2
+
 - Strictness scheme (#445)
 
 ### 2.11.0
+
 - Uplift Merge pull request #437 from jcantrill/fix_bulk_count (#438)
 
 ### 2.10.5
+
 - Uplift Merge pull request #435 from jcantrill/add_trace_logging (#436)
 
 ### 2.10.4
+
 - Use Fluent::UnrecoverableError as unrecoverable error class ancestors (#433)
 - Add parameter validation for retrying template installation (#429)
 
 ### 2.10.3
+
 - Add retry mechanism for template installation (#428)
 
 ### 2.10.2
+
 - Use logstash_prefix_separator on elasticsearch_dynamic (#427)
 
 ### 2.10.1
+
 - Uplift Merge pull request #419 from jcantrill/retry_prefix (#421)
 - Uplift Merge pull request #418 from jcantrill/emit_exception (#420)
 
 ### 2.10.0
+
 - Uplift Merge pull request #405 from jcantrill/sanitize_bulk (#414)
 
 ### 2.9.2
+
 - Uplift Merge pull request #410 from richm/v0.12-consistent-errors-and-tests (#411)
 - Add correct link for include_timestamp (#408)
 
 ### 2.9.1
+
 - Uplift Merge pull request #406 from richm/v0.12-successes-duplicates-no-retry (#407)
 
 ### 2.9.0
+
 - DLQ revisited v1 uplifted #398, #402 (#404)
 
 ### 2.8.6
+
 - auth: Fix missing auth tokens after reloading connections (#394)
 
 ### 2.8.5
+
 - Add deprecated option into content_type parameter (#391)
 
 ### 2.8.4
+
 - Use nanosecond precision in elasticsearch_dynamic (#387)
 
 ### 2.8.3
+
 - Specify SSL/TLS version in out_elasticsearch_dynamic (#385)
 
 ### 2.8.2
+
 - Revert content type header default value (#383)
 
 ### 2.8.1
+
 - Restore default value of type name #(377)
 
 ### 2.8.0
+
 - Remove outdated generating hash id support module (#373)
 - Check Elasticsearch major version (#371)
 
 ### 2.7.0
+
 - Configureable content type (#367)
 
 ### 2.6.1
+
 - Prevent error when using template in elasticsearch_dynamic for elementally use case (#363)
 
 ### 2.6.0
+
 - Handle high precision time format when using custom time_key (#360)
 
 ### 2.5.0
+
 - Using nested record in `id_key`, `parent_key`, and `routing_key` (#351)
 - Fix inverted case of a proper noun "Elasticsearch" (#349)
 
 ### 2.4.1
+
 - Add config parameter to enable elasticsearch-ruby's transporter logging (#342)
 
 ### 2.4.0
+
 - Add built-in placeholders support against type_name parameter (#338)
 
 ### 2.3.0
+
 - Allow overwriting existing index template (#239)
 
 ### 2.2.0
+
 - GA release 2.2.0.
 
 ### 2.2.0.rc.1
+
 - Separate generate hash id module and bundled new plugin for generating unique hash id (#331)
 
 ### 2.1.1
+
 - Raise ConfigError when specifying different @hash_config.hash_id_key and id_key configration (#327)
 - Small typo fix in README.md (#325)
 
 ### 2.1.0
+
 - Retry on certain errors from Elasticsearch (#322)
 
 ### 2.0.1
+
 - Releasing generating hash id mechanism to avoid records duplication feature.
 
 ### 2.0.1.rc.1
+
 - Add generating hash id mechanism to avoid records duplication (#318)
 
 ### 2.0.0
+
 - Release for Fluentd v0.14 stable.
 
 ### 2.0.0.rc.7
+
 - Add `include_timestamp` option (#310)
 
 ### 2.0.0.rc.6
+
 - Improve documentation (#304)
 - Handle dynamic_config misconfigurations (#305)
 - Escape basic authentication user information placeholders (#306)
 
 ### 2.0.0.rc.5
+
 - make configurable with `ssl_version` parameter (#299)
 - add `logstash_prefix_separator` config parameter (#297)
 
 ### 2.0.0.rc.4
+
 - fix license identifier in gemspec (#294)
 
 ### 2.0.0.rc.3
+
 - add built-in placeholders support (#288, #293)
 - permit multi workers feature (#291)
 
 ### 2.0.0.rc.2
+
 - add pipeline parameter (#290)
 
 ### 2.0.0.rc.1
+
 - Use v0.14 API to support nanosecond precision (#223)
 
 ### 1.9.5
+
 - sub-second time precision [(#249)](https://github.com/uken/fluent-plugin-elasticsearch/pull/249)
 
 ### 1.9.4
+
 - Include 'Content-Type' header in `transport_options`
 
 ### 1.9.3
+
 - Use latest elasticsearch-ruby (#240)
 - Log ES response errors (#230)
 
 ### 1.9.2
+
 - Fix elasticsearch_dynamic for v0.14 (#224)
 
 ### 1.9.1
+
 - Cast `reload_*` configs in out_elasticsearch_dynamic to bool (#220)
 
 ### 1.9.0
+
 - add `time_parse_error_tag` (#211)
 - add `reconnect_on_error` (#214)
 
 ### 1.9.0.rc.1
+
 - Optimize output plugins (#203)
 
 ### 1.8.0
+
 - fix typo in defaults for ssl_verify on elasticsearch_dynamic (#202)
 - add support for `templates` (#196)
 - rename `send` method to `send_bulk` (#206)
 
 ### 1.7.0
+
 - add support for `template_name` and `template_file` (#194)
 
 ### 1.6.0
+
 - add support for dot separated `target_index_key` and `target_type_key` (#175)
 - add `remove_keys_on_update` and `remove_keys_on_update_key` (#189)
 - fix support for fluentd v0.14 (#191)
 - remove support for elasticsearch v2 for now (#177)
 
 ### 1.5.0
+
 - add `routing_key` (#158)
 - add `time_key_exclude_timestamp` to exclude `@timestamp` (#161)
 - convert index names to lowercase (#163)
@@ -518,78 +649,100 @@
 - add `target_type_key` (#169)
 
 ### 1.4.0
+
 - add `target_index_key` to specify target index (#153)
 - add `time_key_format` for faster time format parsing (#154)
 
 ### 1.3.0
+
 - add `write_operation`
 
 ### 1.2.1
+
 - fix `resurrect_after` in out_elasticsearch_dynamic
 
 ### 1.2.0
+
 - out_elasticsearch_dynamic get memory improvement and fix for race condition (#133)
 - Add `resurrect_after` option (#136)
 
 ### 1.1.0
+
 - Support SSL client verification and custom CA file (#123)
 - Release experimental `type elasticsearch_dynamic` (#127)
 
 ### 1.0.0
+
 - password config param is now marked as secret and won't be displayed in logs.
 
 ### 0.9.0
+
 - Add `ssl_verify` option (#108)
 
 ### 0.8.0
+
 - Replace Patron with Excon HTTP client (#93)
 
 ### 0.7.0
+
 - Add new option `time_key` (#85)
 
 ### 0.6.1
+
 - 0.10.43 is minimum version required of fluentd (#79)
 
 ### 0.6.0
+
 - added `reload_on_failure` and `reload_connections` flags (#78)
 
 ### 0.5.1
+
 - fix legacy hosts option, port should be optional (#75)
 
 ### 0.5.0
+
 - add full connection URI support (#65)
 - use `@timestamp` for index (#41)
 - add support for elasticsearch gem version 1 (#71)
 - fix connection reset & retry when connection is lost (#67)
 
 ### 0.4.0
+
 - add `request_timeout` config (#59)
 - fix lockup when non-hash values are sent (#52)
 
 ### 0.3.1
+
 - force using patron (#46)
 - do not generate @timestamp if already part of message (#35)
 
 ### 0.3.0
+
 - add `parent_key` option (#28)
 - have travis-ci build on multiple rubies (#30)
 - add `utc_index` and `hosts` options, switch to using `elasticsearch` gem (#26, #29)
 
 ### 0.2.0
+
 - fix encoding issues with JSON conversion and again when sending to elasticsearch (#19, #21)
 - add logstash_dateformat option (#20)
 
 ### 0.1.4
+
 - add logstash_prefix option
 
 ### 0.1.3
+
 - raising an exception on non-success response from elasticsearch
 
 ### 0.1.2
+
 - add id_key option
 
 ### 0.1.1
+
 - fix timezone in logstash key
 
 ### 0.1.0
- - Initial gem release.
+
+- Initial gem release.

--- a/README.md
+++ b/README.md
@@ -15,99 +15,99 @@ Current maintainers: [Hiroshi Hatake | @cosmo0920](https://github.com/cosmo0920)
 
 * [Installation](#installation)
 * [Usage](#usage)
-  + [Index templates](#index-templates)
+  * [Index templates](#index-templates)
 * [Configuration](#configuration)
-  + [host](#host)
-  + [port](#port)
-  + [cloud_id](#cloud_id)
-  + [cloud_auth](#cloud_auth)
-  + [emit_error_for_missing_id](#emit_error_for_missing_id)
-  + [hosts](#hosts)
-  + [user, password, path, scheme, ssl_verify](#user-password-path-scheme-ssl_verify)
-  + [logstash_format](#logstash_format)
-  + [logstash_prefix](#logstash_prefix)
-  + [logstash_prefix_separator](#logstash_prefix_separator)
-  + [logstash_dateformat](#logstash_dateformat)
-  + [pipeline](#pipeline)
-  + [time_key_format](#time_key_format)
-  + [time_precision](#time_precision)
-  + [time_key](#time_key)
-  + [time_key_exclude_timestamp](#time_key_exclude_timestamp)
-  + [include_timestamp](#include_timestamp)
-  + [utc_index](#utc_index)
-  + [suppress_type_name](#suppress_type_name)
-  + [target_index_key](#target_index_key)
-  + [target_type_key](#target_type_key)
-  + [target_index_affinity](#target_index_affinity)
-  + [template_name](#template_name)
-  + [template_file](#template_file)
-  + [template_overwrite](#template_overwrite)
-  + [customize_template](#customize_template)
-  + [rollover_index](#rollover_index)
-  + [index_date_pattern](#index_date_pattern)
-  + [deflector_alias](#deflector_alias)
-  + [application_name](#application_name)
-  + [index_prefix](#index_prefix)
-  + [templates](#templates)
-  + [max_retry_putting_template](#max_retry_putting_template)
-  + [fail_on_putting_template_retry_exceed](#fail_on_putting_template_retry_exceed)
-  + [fail_on_detecting_es_version_retry_exceed](#fail_on_detecting_es_version_retry_exceed)
-  + [max_retry_get_es_version](#max_retry_get_es_version)
-  + [request_timeout](#request_timeout)
-  + [reload_connections](#reload_connections)
-  + [reload_on_failure](#reload_on_failure)
-  + [resurrect_after](#resurrect_after)
-  + [include_tag_key, tag_key](#include_tag_key-tag_key)
-  + [id_key](#id_key)
-  + [parent_key](#parent_key)
-  + [routing_key](#routing_key)
-  + [remove_keys](#remove_keys)
-  + [remove_keys_on_update](#remove_keys_on_update)
-  + [remove_keys_on_update_key](#remove_keys_on_update_key)
-  + [retry_tag](#retry_tag)
-  + [write_operation](#write_operation)
-  + [time_parse_error_tag](#time_parse_error_tag)
-  + [reconnect_on_error](#reconnect_on_error)
-  + [with_transporter_log](#with_transporter_log)
-  + [content_type](#content_type)
-  + [include_index_in_url](#include_index_in_url)
-  + [http_backend](#http_backend)
-  + [http_backend_excon_nonblock](#http_backend_excon_nonblock)
-  + [prefer_oj_serializer](#prefer_oj_serializer)
-  + [compression_level](#compression_level)
-  + [Client/host certificate options](#clienthost-certificate-options)
-  + [Proxy Support](#proxy-support)
-  + [Buffer options](#buffer-options)
-  + [Hash flattening](#hash-flattening)
-  + [Generate Hash ID](#generate-hash-id)
-  + [sniffer_class_name](#sniffer-class-name)
-  + [selector_class_name](#selector-class-name)
-  + [reload_after](#reload-after)
-  + [validate_client_version](#validate-client-version)
-  + [unrecoverable_error_types](#unrecoverable-error-types)
-  + [verify_es version at startup](#verify_es_version_at_startup)
-  + [default_elasticsearch_version](#default_elasticsearch_version)
-  + [custom_headers](#custom_headers)
-  + [api_key](#api_key)
-  + [Not seeing a config you need?](#not-seeing-a-config-you-need)
-  + [Dynamic configuration](#dynamic-configuration)
-  + [Placeholders](#placeholders)
-  + [Multi workers](#multi-workers)
-  + [log_es_400_reason](#log_es_400_reason)
-  + [suppress_doc_wrap](#suppress_doc_wrap)
-  + [ignore_exceptions](#ignore_exceptions)
-  + [exception_backup](#exception_backup)
-  + [bulk_message_request_threshold](#bulk_message_request_threshold)
-  + [enable_ilm](#enable_ilm)
-  + [ilm_policy_id](#ilm_policy_id)
-  + [ilm_policy](#ilm_policy)
-  + [ilm_policies](#ilm_policies)
-  + [ilm_policy_overwrite](#ilm_policy_overwrite)
-  + [truncate_caches_interval](#truncate_caches_interval)
-  + [use_legacy_template](#use_legacy_template)
-  + [metadata section](#metadata-section)
-    + [include_chunk_id](#include_chunk_id)
-    + [chunk_id_key](#chunk_id_key)
+  * [host](#host)
+  * [port](#port)
+  * [cloud_id](#cloud_id)
+  * [cloud_auth](#cloud_auth)
+  * [emit_error_for_missing_id](#emit_error_for_missing_id)
+  * [hosts](#hosts)
+  * [user, password, path, scheme, ssl_verify](#user-password-path-scheme-ssl_verify)
+  * [logstash_format](#logstash_format)
+  * [logstash_prefix](#logstash_prefix)
+  * [logstash_prefix_separator](#logstash_prefix_separator)
+  * [logstash_dateformat](#logstash_dateformat)
+  * [pipeline](#pipeline)
+  * [time_key_format](#time_key_format)
+  * [time_precision](#time_precision)
+  * [time_key](#time_key)
+  * [time_key_exclude_timestamp](#time_key_exclude_timestamp)
+  * [include_timestamp](#include_timestamp)
+  * [utc_index](#utc_index)
+  * [suppress_type_name](#suppress_type_name)
+  * [target_index_key](#target_index_key)
+  * [target_type_key](#target_type_key)
+  * [target_index_affinity](#target_index_affinity)
+  * [template_name](#template_name)
+  * [template_file](#template_file)
+  * [template_overwrite](#template_overwrite)
+  * [customize_template](#customize_template)
+  * [rollover_index](#rollover_index)
+  * [index_date_pattern](#index_date_pattern)
+  * [deflector_alias](#deflector_alias)
+  * [application_name](#application_name)
+  * [index_prefix](#index_prefix)
+  * [templates](#templates)
+  * [max_retry_putting_template](#max_retry_putting_template)
+  * [fail_on_putting_template_retry_exceed](#fail_on_putting_template_retry_exceed)
+  * [fail_on_detecting_es_version_retry_exceed](#fail_on_detecting_es_version_retry_exceed)
+  * [max_retry_get_es_version](#max_retry_get_es_version)
+  * [request_timeout](#request_timeout)
+  * [reload_connections](#reload_connections)
+  * [reload_on_failure](#reload_on_failure)
+  * [resurrect_after](#resurrect_after)
+  * [include_tag_key, tag_key](#include_tag_key-tag_key)
+  * [id_key](#id_key)
+  * [parent_key](#parent_key)
+  * [routing_key](#routing_key)
+  * [remove_keys](#remove_keys)
+  * [remove_keys_on_update](#remove_keys_on_update)
+  * [remove_keys_on_update_key](#remove_keys_on_update_key)
+  * [retry_tag](#retry_tag)
+  * [write_operation](#write_operation)
+  * [time_parse_error_tag](#time_parse_error_tag)
+  * [reconnect_on_error](#reconnect_on_error)
+  * [with_transporter_log](#with_transporter_log)
+  * [content_type](#content_type)
+  * [include_index_in_url](#include_index_in_url)
+  * [http_backend](#http_backend)
+  * [http_backend_excon_nonblock](#http_backend_excon_nonblock)
+  * [prefer_oj_serializer](#prefer_oj_serializer)
+  * [compression_level](#compression_level)
+  * [Client/host certificate options](#clienthost-certificate-options)
+  * [Proxy Support](#proxy-support)
+  * [Buffer options](#buffer-options)
+  * [Hash flattening](#hash-flattening)
+  * [Generate Hash ID](#generate-hash-id)
+  * [sniffer_class_name](#sniffer-class-name)
+  * [selector_class_name](#selector-class-name)
+  * [reload_after](#reload-after)
+  * [validate_client_version](#validate-client-version)
+  * [unrecoverable_error_types](#unrecoverable-error-types)
+  * [verify_es version at startup](#verify_es_version_at_startup)
+  * [default_elasticsearch_version](#default_elasticsearch_version)
+  * [custom_headers](#custom_headers)
+  * [api_key](#api_key)
+  * [Not seeing a config you need?](#not-seeing-a-config-you-need)
+  * [Dynamic configuration](#dynamic-configuration)
+  * [Placeholders](#placeholders)
+  * [Multi workers](#multi-workers)
+  * [log_es_400_reason](#log_es_400_reason)
+  * [suppress_doc_wrap](#suppress_doc_wrap)
+  * [ignore_exceptions](#ignore_exceptions)
+  * [exception_backup](#exception_backup)
+  * [bulk_message_request_threshold](#bulk_message_request_threshold)
+  * [enable_ilm](#enable_ilm)
+  * [ilm_policy_id](#ilm_policy_id)
+  * [ilm_policy](#ilm_policy)
+  * [ilm_policies](#ilm_policies)
+  * [ilm_policy_overwrite](#ilm_policy_overwrite)
+  * [truncate_caches_interval](#truncate_caches_interval)
+  * [use_legacy_template](#use_legacy_template)
+  * [metadata section](#metadata-section)
+    * [include_chunk_id](#include_chunk_id)
+    * [chunk_id_key](#chunk_id_key)
 * [Configuration - Elasticsearch Input](#configuration---elasticsearch-input)
 * [Configuration - Elasticsearch Filter GenID](#configuration---elasticsearch-filter-genid)
 * [Configuration - Elasticsearch Output Data Stream](#configuration---elasticsearch-output-data-stream)
@@ -135,7 +135,7 @@ NOTE: Using Index Lifecycle management(ILM) feature needs to install elasticsear
 ## Installation
 
 ```sh
-$ gem install fluent-plugin-elasticsearch
+gem install fluent-plugin-elasticsearch
 ```
 
 ## Usage
@@ -201,7 +201,7 @@ You can specify Elasticsearch port by this parameter.
 ### cloud_id
 
 ```
-cloud_id test-dep:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyRiYZTA1Ng== 
+cloud_id test-dep:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyRiYZTA1Ng==
 ```
 
 You can specify Elasticsearch cloud_id by this parameter.
@@ -217,12 +217,12 @@ cloud_auth 'elastic:slkjdaooewkd87iqQ2O8EQYV'
 
 You can specify Elasticsearch cloud_auth by this parameter.
 
-
 ### emit_error_for_missing_id
 
 ```
 emit_error_for_missing_id true
 ```
+
 When  `write_operation` is configured to anything other then `index`, setting this value to `true` will
 cause the plugin to `emit_error_event` of any records which do not include an `_id` field.  The default (`false`)
 behavior is to silently drop the records.
@@ -370,6 +370,7 @@ time_key vtm
 ```
 
 Your input is:
+
 ```
 {
   "title": "developer",
@@ -378,6 +379,7 @@ Your input is:
 ```
 
 The output will be
+
 ```
 {
   "title": "developer",
@@ -432,6 +434,7 @@ index_name fallback
 ```
 
 If your input is:
+
 ```
 {
   "title": "developer",
@@ -470,6 +473,7 @@ But if you have a use case where data is also updated after indexing and `id_key
 This setting will search existing data by using elastic search's [id query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html) using `id_key` value (with logstash_prefix and logstash_prefix_separator index pattarn e.g. `logstash-*`). The index of found data is used for update/upsert. When no data is found, data is written to current logstash index as normally.
 
 This setting requires following other settings:
+
 ```
 logstash_format true
 id_key myId  # Some field on your data to identify the data uniquely
@@ -503,6 +507,7 @@ Suppose you have the following situation where you have 2 different match to con
 ```
 
 If your first (data1) input is:
+
 ```
 {
   "myId": "myuniqueId1",
@@ -511,6 +516,7 @@ If your first (data1) input is:
 ```
 
 and your second (data2) input is:
+
 ```
 {
   "myId": "myuniqueId1",
@@ -564,6 +570,7 @@ If [template_file](#template_file) and [template_name](#template_name) are set, 
 Specify this as true when an index with rollover capability needs to be created. It creates an index with the format <logstash-default-{now/d}-000001> where logstash denotes the index_prefix and default denotes the application_name which can be set.
 'deflector_alias' is a required field for rollover_index set to true.
 'index_prefix' and 'application_name' are optional and defaults to logstash and default respectively.
+
 ```
 rollover_index true # defaults to false
 ```
@@ -590,6 +597,7 @@ If [customize_template](#customize_template) is set, then this parameter will be
 ### deflector_alias
 
 Specify the deflector alias which would be assigned to the rollover index created. This is useful in case of using the Elasticsearch rollover API
+
 ```
 deflector_alias test-current
 ```
@@ -607,6 +615,7 @@ When specifying `logstash_format` as true, consider to use [logstash_prefix](#lo
 ### application_name
 
 Specify the application name for the rollover index to be created.
+
 ```
 application_name default # defaults to "default"
 ```
@@ -751,6 +760,7 @@ id_key _hash
 ```
 
 Example configuration for [fluent-plugin-genhashvalue](https://github.com/mtakemi/fluent-plugin-genhashvalue) (review the documentation of the plugin for more details)
+
 ```
 <filter logs.**>
   @type genhashvalue
@@ -799,6 +809,7 @@ parent_key a_parent # use "a_parent" field value to set _parent in elasticsearch
 ```
 
 If your input is
+
 ```
 { "name": "Johnny", "a_parent": "my_parent" }
 ```
@@ -881,6 +892,7 @@ with the specified tag:
 ```
 retry_tag 'retry_es'
 ```
+
 **NOTE:** `retry_tag` is optional. If you would rather use labels to reroute retries, add a label (e.g '@label @SOMELABEL') to your fluent
 elasticsearch plugin configuration. Retry records are, by default, submitted for retry to the ROOT label, which means
 records will flow through your fluentd pipeline from the beginning.  This may nor may not be a problem if the pipeline
@@ -908,9 +920,11 @@ Default value is `Fluent::ElasticsearchOutput::TimeParser.error` for backward co
 We will change default value to `.` separated tag.
 
 ### reconnect_on_error
+
 Indicates that the plugin should reset connection on any error (reconnect on next send).
 By default it will reconnect only on "host unreachable exceptions".
 We recommended to set this true in the presence of elasticsearch shield.
+
 ```
 reconnect_on_error true # defaults to false
 ```
@@ -961,10 +975,10 @@ http_backend typhoeus
 
 With `http_backend_excon_nonblock false`, elasticsearch plugin use excon with nonblock=false.
 If you use elasticsearch plugin with jRuby for https, you may need to consider to set `false` to avoid follwoing problems.
-- https://github.com/geemus/excon/issues/106
-- https://github.com/jruby/jruby-ossl/issues/19
+* <https://github.com/geemus/excon/issues/106>
+* <https://github.com/jruby/jruby-ossl/issues/19>
 
-But for all other case, it strongly reccomend to set `true` to avoid process hangin problem reported in https://github.com/uken/fluent-plugin-elasticsearch/issues/732
+But for all other case, it strongly reccomend to set `true` to avoid process hangin problem reported in <https://github.com/uken/fluent-plugin-elasticsearch/issues/732>
 
 Default value is `true`.
 
@@ -973,8 +987,10 @@ http_backend_excon_nonblock false
 ```
 
 ### compression_level
+
 You can add gzip compression of output data. In this case `default_compression`, `best_compression` or `best speed` option should be chosen.
 By default there is no compression, default value for this option is `no_compression`
+
 ```
 compression_level best_compression
 ```
@@ -994,11 +1010,13 @@ prefer_oj_serializer true
 ### Client/host certificate options
 
 Need to verify Elasticsearch's certificate?  You can use the following parameter to specify a CA instead of using an environment variable.
+
 ```
 ca_file /path/to/your/ca/cert
 ```
 
 Does your Elasticsearch cluster want to verify client connections?  You can specify the following parameters to use your client certificate, key, and key password for your connection.
+
 ```
 client_cert /path/to/your/client/cert
 client_key /path/to/your/private/key
@@ -1006,6 +1024,7 @@ client_key_pass password
 ```
 
 If you want to configure SSL/TLS version, you can specify ssl\_version parameter.
+
 ```
 ssl_version TLSv1_2 # or [SSLv23, TLSv1, TLSv1_1]
 ```
@@ -1027,10 +1046,9 @@ In Elasticsearch plugin v4.0.8 or later with Ruby 2.5 or later environment, `ssl
 
 From Elasticsearch plugin v4.0.4 to v4.0.7 with Ruby 2.5 or later environment, the value of `ssl_version` will be *used in `ssl_max_version` and `ssl_min_version`*.
 
-
 ### Proxy Support
 
-Starting with version 0.8.0, this gem uses excon, which supports proxy with environment variables - https://github.com/excon/excon#proxy-support
+Starting with version 0.8.0, this gem uses excon, which supports proxy with environment variables - <https://github.com/excon/excon#proxy-support>
 
 ### Buffer options
 
@@ -1071,7 +1089,7 @@ Note that the flattener does not deal with arrays at this time.
 
 ### Generate Hash ID
 
-By default, the fluentd elasticsearch plugin does not emit records with a _id field, leaving it to Elasticsearch to generate a unique _id as the record is indexed. When an Elasticsearch cluster is congested and begins to take longer to respond than the configured request_timeout, the fluentd elasticsearch plugin will re-send the same bulk request. Since Elasticsearch can't tell its actually the same request, all documents in the request are indexed again resulting in duplicate data. In certain scenarios, this can result in essentially and infinite loop generating multiple copies of the same data.
+By default, the fluentd elasticsearch plugin does not emit records with a _id field, leaving it to Elasticsearch to generate a unique_id as the record is indexed. When an Elasticsearch cluster is congested and begins to take longer to respond than the configured request_timeout, the fluentd elasticsearch plugin will re-send the same bulk request. Since Elasticsearch can't tell its actually the same request, all documents in the request are indexed again resulting in duplicate data. In certain scenarios, this can result in essentially and infinite loop generating multiple copies of the same data.
 
 The bundled elasticsearch_genid filter can generate a unique _hash key for each record, this key may be passed to the id_key parameter in the elasticsearch plugin to communicate to Elasticsearch the uniqueness of the requests so that duplicates will be rejected or simply replace the existing records.
 Here is a sample config:
@@ -1350,10 +1368,10 @@ Default value is `false`.
 A list of exception that will be ignored - when the exception occurs the chunk will be discarded and the buffer retry mechanism won't be called. It is possible also to specify classes at higher level in the hierarchy. For example
 
 ```
-ignore_exceptions ["Elasticsearch::Transport::Transport::ServerError"]
+ignore_exceptions ["Elastic::Transport::Transport::ServerError"]
 ```
 
-will match all subclasses of `ServerError` - `Elasticsearch::Transport::Transport::Errors::BadRequest`, `Elasticsearch::Transport::Transport::Errors::ServiceUnavailable`, etc.
+will match all subclasses of `ServerError` - `Elastic::Transport::Transport::Errors::BadRequest`, `Elastic::Transport::Transport::Errors::ServiceUnavailable`, etc.
 
 Default value is empty list (no exception is ignored).
 
@@ -1460,7 +1478,6 @@ Whether including `chunk_id` for not. Default value is `false`.
 </match>
 ```
 
-
 ### chunk_id_key
 
 Specify `chunk_id_key` to store `chunk_id` information into records. Default value is `chunk_id`.
@@ -1502,9 +1519,9 @@ The set of required permissions are the following:
 
 These permissions can be narrowed down by:
 
-- Setting a more specific pattern for indices under the `names` field
-- Removing the `manage_index_templates` cluster permission when not using the feature within your plugin configuration
-- Removing the `manage_ilm` cluster permission and the `manage` and `manage_ilm` indices privileges when not using ilm
+* Setting a more specific pattern for indices under the `names` field
+* Removing the `manage_index_templates` cluster permission when not using the feature within your plugin configuration
+* Removing the `manage_ilm` cluster permission and the `manage` and `manage_ilm` indices privileges when not using ilm
 features in the plugin configuration
 
 The list of privileges along with their description can be found in
@@ -1531,7 +1548,7 @@ This parameter is mandatory for `elasticsearch_data_stream`.
 
 ### data_stream_template_name
 
-You can specify an existing matching index template for the data stream. If not present, it creates a new matching index template. 
+You can specify an existing matching index template for the data stream. If not present, it creates a new matching index template.
 
 Default value is `data_stream_name`.
 
@@ -1544,7 +1561,6 @@ Default value is `data_stream_name`.
 There are some limitations about naming rule.
 
 In more detail, please refer to the [Path parameters](https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html#indices-create-data-stream-api-path-params).
-
 
 ### data_stream_ilm_policy
 

--- a/lib/fluent/plugin/elasticsearch_fallback_selector.rb
+++ b/lib/fluent/plugin/elasticsearch_fallback_selector.rb
@@ -1,7 +1,7 @@
-require 'elasticsearch/transport/transport/connections/selector'
+require 'elastic/transport/transport/connections/selector'
 
 class Fluent::Plugin::ElasticseatchFallbackSelector
-  include Elasticsearch::Transport::Transport::Connections::Selector::Base
+  include Elastic::Transport::Transport::Connections::Selector::Base
 
   def select(options={})
     connections.first

--- a/lib/fluent/plugin/elasticsearch_index_lifecycle_management.rb
+++ b/lib/fluent/plugin/elasticsearch_index_lifecycle_management.rb
@@ -21,7 +21,7 @@ module Fluent::Plugin::ElasticsearchIndexLifecycleManagement
       raise Fluent::ConfigError, "Index Lifecycle management is enabled in Fluentd, but not available in your Elasticsearch" unless ilm['available']
       raise Fluent::ConfigError, "Index Lifecycle management is enabled in Fluentd, but not enabled in your Elasticsearch" unless ilm['enabled']
 
-    rescue Elasticsearch::Transport::Transport::Error => e
+    rescue Elastic::Transport::Transport::Error => e
       raise Fluent::ConfigError, "Index Lifecycle management is enabled in Fluentd, but not installed on your Elasticsearch", error: e
     end
   end

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -28,12 +28,12 @@ module Fluent::ElasticsearchIndexTemplate
       client(host).indices.get_index_template(:name => name)
     end
     return true
-  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+  rescue Elastic::Transport::Transport::Errors::NotFound
     return false
   end
 
   def host_unreachable_exceptions
-    if Gem::Version.new(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if Gem::Version.new(::Elastic::Transport::VERSION) >= Gem::Version.new("7.14.0")
       # elasticsearch-ruby 7.14.0's elasticsearch-transport does not extends
       # Elasticsearch class on Transport.
       # This is why #host_unreachable_exceptions is not callable directly
@@ -47,7 +47,7 @@ module Fluent::ElasticsearchIndexTemplate
   def retry_operate(max_retries, fail_on_retry_exceed = true, catch_trasport_exceptions = true)
     return unless block_given?
     retries = 0
-    transport_errors = Elasticsearch::Transport::Transport::Errors.constants.map{ |c| Elasticsearch::Transport::Transport::Errors.const_get c } if catch_trasport_exceptions
+    transport_errors = Elastic::Transport::Transport::Errors.constants.map{ |c| Elastic::Transport::Transport::Errors.const_get c } if catch_trasport_exceptions
     begin
       yield
     rescue *host_unreachable_exceptions, *transport_errors, Timeout::Error => e
@@ -78,7 +78,7 @@ module Fluent::ElasticsearchIndexTemplate
 
   def indexcreation(index_name, host = nil)
     client(host).indices.create(:index => index_name)
-  rescue Elasticsearch::Transport::Transport::Error => e
+  rescue Elastic::Transport::Transport::Error => e
     if e.message =~ /"already exists"/ || e.message =~ /resource_already_exists_exception/
       log.debug("Index #{index_name} already exists")
     else

--- a/lib/fluent/plugin/elasticsearch_simple_sniffer.rb
+++ b/lib/fluent/plugin/elasticsearch_simple_sniffer.rb
@@ -1,6 +1,6 @@
 require 'elasticsearch'
 
-class Fluent::Plugin::ElasticsearchSimpleSniffer < Elasticsearch::Transport::Transport::Sniffer
+class Fluent::Plugin::ElasticsearchSimpleSniffer < Elastic::Transport::Transport::Sniffer
 
   def hosts
     @transport.logger.debug "In Fluent::Plugin::ElasticsearchSimpleSniffer hosts #{@transport.hosts}" if @transport.logger

--- a/lib/fluent/plugin/in_elasticsearch.rb
+++ b/lib/fluent/plugin/in_elasticsearch.rb
@@ -218,7 +218,7 @@ module Fluent::Plugin
 
         headers = { 'Content-Type' => "application/json" }.merge(@custom_headers)
 
-        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(
+        transport = Elastic::Transport::Transport::HTTP::Faraday.new(
           connection_options.merge(
             options: {
               reload_connections: local_reload_connections,

--- a/lib/fluent/plugin/oj_serializer.rb
+++ b/lib/fluent/plugin/oj_serializer.rb
@@ -4,7 +4,7 @@ module Fluent::Plugin
   module Serializer
 
     class Oj
-      include Elasticsearch::Transport::Transport::Serializer::Base
+      include Elastic::Transport::Transport::Serializer::Base
 
       # De-serialize a Hash from JSON string
       #

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -6,7 +6,7 @@ require 'set'
 begin
   require 'elasticsearch/xpack'
 rescue LoadError
-end
+end if Gem.loaded_specs["elasticsearch"].version < Gem::Version.new("8.0.0")
 require 'json'
 require 'uri'
 require 'base64'
@@ -413,11 +413,11 @@ EOC
         end
       end
 
-      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+      if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
         if compression
           raise Fluent::ConfigError, <<-EOC
             Cannot use compression with elasticsearch-transport plugin version < 7.2.0
-            Your elasticsearch-transport plugin version version is #{Elasticsearch::Transport::VERSION}.
+            Your elasticsearch-transport plugin version version is #{Elastic::Transport::VERSION}.
             Please consider to upgrade ES client.
           EOC
         end
@@ -613,7 +613,7 @@ EOC
                     .merge(gzip_headers)
         ssl_options = { verify: @ssl_verify, ca_file: @ca_file}.merge(@ssl_version_options)
 
-        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
+        transport = Elastic::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
                                                                               reload_connections: local_reload_connections,
                                                                               reload_on_failure: @reload_on_failure,

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -53,7 +53,7 @@ module Fluent::Plugin
                        end
         headers = { 'Content-Type' => @content_type.to_s, }.merge(gzip_headers)
         ssl_options = { verify: @ssl_verify, ca_file: @ca_file}.merge(@ssl_version_options)
-        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
+        transport = Elastic::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
                                                                               reload_connections: @reload_connections,
                                                                               reload_on_failure: @reload_on_failure,

--- a/test/plugin/test_elasticsearch_fallback_selector.rb
+++ b/test/plugin/test_elasticsearch_fallback_selector.rb
@@ -60,7 +60,7 @@ class ElasticsearchFallbackSelectorTest < Test::Unit::TestCase
       reload_after 10
       catch_transport_exception_on_retry false # For fallback testing
     ]
-    assert_raise(Elasticsearch::Transport::Transport::Errors::NotFound) do
+    assert_raise(Elastic::Transport::Transport::Errors::NotFound) do
       driver(config)
     end
     driver.run(default_tag: 'test') do

--- a/test/plugin/test_elasticsearch_index_lifecycle_management.rb
+++ b/test/plugin/test_elasticsearch_index_lifecycle_management.rb
@@ -10,8 +10,8 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
       require "elasticsearch/xpack"
     rescue LoadError
       omit "ILM testcase needs elasticsearch-xpack gem."
-    end
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+    end if Gem.loaded_specs["elasticsearch"].version < Gem::Version.new("8.0.0")
+    if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.4.0")
       omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
     end
     Fluent::Plugin::ElasticsearchIndexLifecycleManagement.module_eval(<<-CODE)

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -46,7 +46,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   def elasticsearch_transport_layer_decoupling?
-    Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    Gem::Version.create(::Elastic::Transport::VERSION) >= Gem::Version.new("7.14.0")
   end
 
   def default_type_name
@@ -273,7 +273,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   test 'configure compression' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_compression
@@ -284,7 +284,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   test 'check compression strategy' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_speed
@@ -295,7 +295,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   test 'check content-encoding header with compression' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_compression
@@ -324,7 +324,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   test 'check compression option is passed to transport' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_compression
@@ -485,17 +485,17 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         require "elasticsearch/xpack"
       rescue LoadError
         omit "ILM testcase needs elasticsearch-xpack gem."
-      end
+      end if Gem.loaded_specs["elasticsearch"].version < Gem::Version.new("8.0.0")
     end
 
     data("legacy_template" => [true, "_template"],
          "new_template"    => [false, "_index_template"])
     test 'valid configuration of index lifecycle management' do |data|
-      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+      if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.4.0")
         omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
       end
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -534,11 +534,11 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     data("legacy_template" => [true, "_template"],
          "new_template"    => [false, "_index_template"])
     test 'valid configuration of overwriting ilm_policy' do |data|
-      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+      if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.4.0")
         omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
       end
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -946,7 +946,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_already_present(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     config = %{
@@ -980,7 +980,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -1025,7 +1025,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create_with_rollover_index_and_template_related_placeholders(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -1094,7 +1094,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create_with_rollover_index_and_template_related_placeholders_with_truncating_caches(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -1172,8 +1172,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         require "elasticsearch/xpack"
       rescue LoadError
         omit "ILM testcase needs elasticsearch-xpack gem."
-      end
-      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+      end if Gem.loaded_specs["elasticsearch"].version < Gem::Version.new("8.0.0")
+      if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.4.0")
         omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
       end
     end
@@ -1182,7 +1182,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -1266,7 +1266,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_on_logstash_format(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -1359,7 +1359,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_ilm_policy_overwrite(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -1470,7 +1470,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_with_empty_index_date_pattern(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -1554,7 +1554,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_custom_ilm(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -1639,7 +1639,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_ilm_policies_and_placeholderstest_template_create_with_rollover_index_and_ilm_policies_and_placeholders(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -1731,7 +1731,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
            "new_template"    => [false, "_index_template"])
       def test_tag_placeholder(data)
         use_legacy_template_flag, endpoint = data
-        if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
           omit "elastisearch-ruby v7.8.0 or later is needed."
         end
         cwd = File.dirname(__FILE__)
@@ -1822,7 +1822,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
            "new_template"    => [false, "_index_template"])
       def test_tag_placeholder_with_multiple_policies(data)
         use_legacy_template_flag, endpoint = data
-        if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+        if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
           omit "elastisearch-ruby v7.8.0 or later is needed."
         end
         cwd = File.dirname(__FILE__)
@@ -1914,7 +1914,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_placeholders(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -2045,7 +2045,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_placeholders_and_index_separator(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -2138,7 +2138,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_template_create_with_rollover_index_and_default_ilm_and_custom_and_time_placeholders(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -2237,7 +2237,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_custom_template_create(data)
     use_legacy_template_flag, endpoint = data
 
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -2283,7 +2283,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_create_with_customize_template_related_placeholders(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -2337,7 +2337,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_installation_for_host_placeholder(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -2387,7 +2387,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_create(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -2449,7 +2449,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_create_and_deflector_alias(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -2512,7 +2512,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_create_with_logstash_format(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -2583,8 +2583,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
         require "elasticsearch/xpack"
       rescue LoadError
         omit "ILM testcase needs elasticsearch-xpack gem."
-      end
-      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+      end if Gem.loaded_specs["elasticsearch"].version < Gem::Version.new("8.0.0")
+      if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.4.0")
         omit "elastisearch-ruby v7.4.0 or later is needed."
       end
     end
@@ -2593,7 +2593,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_default_ilm(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -2680,7 +2680,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_default_ilm_and_ilm_policy_overwrite(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -2799,7 +2799,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_default_ilm_and_placeholders(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -2946,7 +2946,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
          "new_template"    => [false, "_index_template"])
     def test_custom_template_with_rollover_index_create_and_custom_ilm(data)
       use_legacy_template_flag, endpoint = data
-      if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+      if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
         omit "elastisearch-ruby v7.8.0 or later is needed."
       end
       cwd = File.dirname(__FILE__)
@@ -3027,7 +3027,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_overwrite(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3073,7 +3073,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_overwrite(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3120,7 +3120,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_custom_template_with_rollover_index_overwrite(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3210,7 +3210,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_create_for_host_placeholder(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3262,7 +3262,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_retry_install_fails(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3301,13 +3301,13 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_equal(4, connection_resets)
   end
 
-  transport_errors_handled_separately = [Elasticsearch::Transport::Transport::Errors::NotFound]
-  transport_errors = Elasticsearch::Transport::Transport::Errors.constants.map { |err| [err, Elasticsearch::Transport::Transport::Errors.const_get(err)]  }
+  transport_errors_handled_separately = [Elastic::Transport::Transport::Errors::NotFound]
+  transport_errors = Elastic::Transport::Transport::Errors.constants.map { |err| [err, Elastic::Transport::Transport::Errors.const_get(err)]  }
   transport_errors_hash = Hash[transport_errors.select { |err| !transport_errors_handled_separately.include?(err[1]) } ]
 
   data(transport_errors_hash)
   def test_template_retry_transport_errors(error)
-    endpoint, use_legacy_template_flag = if Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.create("7.8.0")
+    endpoint, use_legacy_template_flag = if Gem::Version.create(::Elastic::Transport::VERSION) >= Gem::Version.create("7.8.0")
                  ["_index_template".freeze, false]
                else
                  ["_template".freeze, true]
@@ -3347,7 +3347,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_template_retry_install_does_not_fail(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3389,7 +3389,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_create(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3447,7 +3447,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_overwrite(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3505,7 +3505,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_are_also_used(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3565,7 +3565,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
        "new_template"    => [false, "_index_template"])
   def test_templates_can_be_partially_created_if_error_occurs(data)
     use_legacy_template_flag, endpoint = data
-    if !use_legacy_template_flag && Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.8.0")
+    if !use_legacy_template_flag && Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.8.0")
       omit "elastisearch-ruby v7.8.0 or later is needed."
     end
     cwd = File.dirname(__FILE__)
@@ -3946,7 +3946,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
 
   def test_writes_to_default_index_with_compression
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %[
       compression_level default_compression
@@ -6157,7 +6157,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   def test_ignore_exception
-    driver.configure('ignore_exceptions ["Elasticsearch::Transport::Transport::Errors::ServiceUnavailable"]')
+    driver.configure('ignore_exceptions ["Elastic::Transport::Transport::Errors::ServiceUnavailable"]')
     stub_elastic_unavailable
     stub_elastic_info
 
@@ -6167,7 +6167,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   def test_ignore_exception_with_superclass
-    driver.configure('ignore_exceptions ["Elasticsearch::Transport::Transport::ServerError"]')
+    driver.configure('ignore_exceptions ["Elastic::Transport::Transport::ServerError"]')
     stub_elastic_unavailable
     stub_elastic_info
 

--- a/test/plugin/test_out_elasticsearch_data_stream.rb
+++ b/test/plugin/test_out_elasticsearch_data_stream.rb
@@ -87,15 +87,15 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
   end
 
   def stub_nonexistent_data_stream?(name="foo", url="http://localhost:9200")
-    stub_request(:get, "#{url}/_data_stream/#{name}").to_return(:status => [404, Elasticsearch::Transport::Transport::Errors::NotFound])
+    stub_request(:get, "#{url}/_data_stream/#{name}").to_return(:status => [404, Elastic::Transport::Transport::Errors::NotFound])
   end
 
   def stub_nonexistent_ilm?(name="foo_ilm_policy", url="http://localhost:9200")
-    stub_request(:get, "#{url}/_ilm/policy/#{name}").to_return(:status => [404, Elasticsearch::Transport::Transport::Errors::NotFound])
+    stub_request(:get, "#{url}/_ilm/policy/#{name}").to_return(:status => [404, Elastic::Transport::Transport::Errors::NotFound])
   end
 
   def stub_nonexistent_template?(name="foo_tpl", url="http://localhost:9200")
-    stub_request(:get, "#{url}/_index_template/#{name}").to_return(:status => [404, Elasticsearch::Transport::Transport::Errors::NotFound])
+    stub_request(:get, "#{url}/_index_template/#{name}").to_return(:status => [404, Elastic::Transport::Transport::Errors::NotFound])
   end
 
   def stub_nonexistent_template_retry?(name="foo_tpl", url="http://localhost:9200")
@@ -140,7 +140,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
   end
 
   def data_stream_supported?
-    Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.create("7.9.0")
+    Gem::Version.create(::Elastic::Transport::VERSION) >= Gem::Version.create("7.9.0")
   end
 
   # ref. https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html

--- a/test/plugin/test_out_elasticsearch_dynamic.rb
+++ b/test/plugin/test_out_elasticsearch_dynamic.rb
@@ -35,7 +35,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   end
 
   def elasticsearch_transport_layer_decoupling?
-    Gem::Version.create(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    Gem::Version.create(::Elastic::Transport::VERSION) >= Gem::Version.new("7.14.0")
   end
 
   def default_type_name
@@ -132,7 +132,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   end
 
   test 'configure compression' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_compression
@@ -143,7 +143,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   end
 
   test 'check compression strategy' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_speed
@@ -154,7 +154,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   end
 
   test 'check content-encoding header with compression' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_compression
@@ -183,7 +183,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   end
 
   test 'check compression option is passed to transport' do
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %{
       compression_level best_compression
@@ -402,7 +402,7 @@ class ElasticsearchOutputDynamic < Test::Unit::TestCase
   end
 
   def test_writes_to_default_index_with_compression
-    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+    omit "elastisearch-ruby v7.2.0 or later is needed." if Gem::Version.create(::Elastic::Transport::VERSION) < Gem::Version.create("7.2.0")
 
     config = %[
       compression_level default_compression


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

This is a draft pr with the support of es 8.0
It is not usable yet