### PR TITLE
Migrate to handle Elasticsearch 8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gem 'simplecov', require: false
 gem 'coveralls', ">= 0.8.0", require: false
 gem 'strptime', require: false if RUBY_ENGINE == "ruby" && RUBY_VERSION =~ /^2/
 gem "irb" if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.6"
-gem "elasticsearch-xpack"
+gem "elasticsearch-xpack" if ENV["USE_XPACK"]
 gem "oj"

--- a/lib/fluent/plugin/elasticsearch_compat.rb
+++ b/lib/fluent/plugin/elasticsearch_compat.rb
@@ -1,0 +1,27 @@
+begin
+  require 'elastic/transport'
+  ::TRANSPORT_CLASS = Elastic::Transport
+rescue LoadError
+end
+begin
+  require 'elasticsearch/transport'
+  ::TRANSPORT_CLASS = Elasticsearch::Transport
+rescue LoadError
+end
+if Gem::Version.new(Elasticsearch::VERSION) < Gem::Version.new("8.0.0")
+  begin
+    require 'elasticsearch/xpack'
+  rescue LoadError
+  end
+end
+
+begin
+  require 'elastic/transport/transport/connections/selector'
+  ::SELECTOR_CLASS = Elastic::Transport::Transport::Connections::Selector
+rescue LoadError
+end
+begin
+  require 'elasticsearch/transport/transport/connections/selector'
+  ::SELECTOR_CLASS = Elasticsearch::Transport::Transport::Connections::Selector
+rescue LoadError
+end

--- a/lib/fluent/plugin/elasticsearch_fallback_selector.rb
+++ b/lib/fluent/plugin/elasticsearch_fallback_selector.rb
@@ -1,7 +1,7 @@
-require 'elasticsearch/transport/transport/connections/selector'
+require_relative 'elasticsearch_compat'
 
 class Fluent::Plugin::ElasticseatchFallbackSelector
-  include Elasticsearch::Transport::Transport::Connections::Selector::Base
+  include SELECTOR_CLASS::Base
 
   def select(options={})
     connections.first

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -28,12 +28,16 @@ module Fluent::ElasticsearchIndexTemplate
       client(host).indices.get_index_template(:name => name)
     end
     return true
-  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+  rescue TRANSPORT_CLASS::Transport::Errors::NotFound
     return false
   end
 
   def host_unreachable_exceptions
-    if Gem::Version.new(::Elasticsearch::Transport::VERSION) >= Gem::Version.new("7.14.0")
+    if Gem::Version.new(::TRANSPORT_CLASS::VERSION) >= Gem::Version.new("8.0.0")
+      # elasticsearch-ruby 8.0.0's elastic-transport uses
+      # direct callable #host_unreachable_exceptions again.
+      client.transport.host_unreachable_exceptions
+    elsif Gem::Version.new(::TRANSPORT_CLASS::VERSION) >= Gem::Version.new("7.14.0")
       # elasticsearch-ruby 7.14.0's elasticsearch-transport does not extends
       # Elasticsearch class on Transport.
       # This is why #host_unreachable_exceptions is not callable directly
@@ -47,7 +51,7 @@ module Fluent::ElasticsearchIndexTemplate
   def retry_operate(max_retries, fail_on_retry_exceed = true, catch_trasport_exceptions = true)
     return unless block_given?
     retries = 0
-    transport_errors = Elasticsearch::Transport::Transport::Errors.constants.map{ |c| Elasticsearch::Transport::Transport::Errors.const_get c } if catch_trasport_exceptions
+    transport_errors = TRANSPORT_CLASS::Transport::Errors.constants.map{ |c| TRANSPORT_CLASS::Transport::Errors.const_get c } if catch_trasport_exceptions
     begin
       yield
     rescue *host_unreachable_exceptions, *transport_errors, Timeout::Error => e
@@ -78,7 +82,7 @@ module Fluent::ElasticsearchIndexTemplate
 
   def indexcreation(index_name, host = nil)
     client(host).indices.create(:index => index_name)
-  rescue Elasticsearch::Transport::Transport::Error => e
+  rescue TRANSPORT_CLASS::Transport::Error => e
     if e.message =~ /"already exists"/ || e.message =~ /resource_already_exists_exception/
       log.debug("Index #{index_name} already exists")
     else

--- a/lib/fluent/plugin/elasticsearch_simple_sniffer.rb
+++ b/lib/fluent/plugin/elasticsearch_simple_sniffer.rb
@@ -1,6 +1,7 @@
 require 'elasticsearch'
+require_relative 'elasticsearch_compat'
 
-class Fluent::Plugin::ElasticsearchSimpleSniffer < Elasticsearch::Transport::Transport::Sniffer
+class Fluent::Plugin::ElasticsearchSimpleSniffer < TRANSPORT_CLASS::Transport::Sniffer
 
   def hosts
     @transport.logger.debug "In Fluent::Plugin::ElasticsearchSimpleSniffer hosts #{@transport.hosts}" if @transport.logger

--- a/lib/fluent/plugin/in_elasticsearch.rb
+++ b/lib/fluent/plugin/in_elasticsearch.rb
@@ -3,6 +3,7 @@ require 'elasticsearch'
 require 'fluent/log-ext'
 require 'fluent/plugin/input'
 require_relative 'elasticsearch_constants'
+require_relative 'elasticsearch_compat'
 
 module Fluent::Plugin
   class ElasticsearchInput < Input
@@ -218,7 +219,7 @@ module Fluent::Plugin
 
         headers = { 'Content-Type' => "application/json" }.merge(@custom_headers)
 
-        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(
+        transport = TRANSPORT_CLASS::Transport::HTTP::Faraday.new(
           connection_options.merge(
             options: {
               reload_connections: local_reload_connections,

--- a/lib/fluent/plugin/oj_serializer.rb
+++ b/lib/fluent/plugin/oj_serializer.rb
@@ -1,10 +1,11 @@
 require 'oj'
+require_relative 'elasticsearch_compat'
 
 module Fluent::Plugin
   module Serializer
 
     class Oj
-      include Elasticsearch::Transport::Transport::Serializer::Base
+      include TRANSPORT_CLASS::Transport::Serializer::Base
 
       # De-serialize a Hash from JSON string
       #

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -3,10 +3,6 @@ require 'date'
 require 'excon'
 require 'elasticsearch'
 require 'set'
-begin
-  require 'elasticsearch/xpack'
-rescue LoadError
-end
 require 'json'
 require 'uri'
 require 'base64'
@@ -23,6 +19,7 @@ require 'fluent/time'
 require 'fluent/unique_id'
 require 'fluent/log-ext'
 require 'zlib'
+require_relative 'elasticsearch_compat'
 require_relative 'elasticsearch_constants'
 require_relative 'elasticsearch_error'
 require_relative 'elasticsearch_error_handler'
@@ -413,11 +410,11 @@ EOC
         end
       end
 
-      if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.2.0")
+      if Gem::Version.create(::TRANSPORT_CLASS::VERSION) < Gem::Version.create("7.2.0")
         if compression
           raise Fluent::ConfigError, <<-EOC
             Cannot use compression with elasticsearch-transport plugin version < 7.2.0
-            Your elasticsearch-transport plugin version version is #{Elasticsearch::Transport::VERSION}.
+            Your elasticsearch-transport plugin version version is #{TRANSPORT_CLASS::VERSION}.
             Please consider to upgrade ES client.
           EOC
         end
@@ -613,7 +610,7 @@ EOC
                     .merge(gzip_headers)
         ssl_options = { verify: @ssl_verify, ca_file: @ca_file}.merge(@ssl_version_options)
 
-        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
+        transport = TRANSPORT_CLASS::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
                                                                               reload_connections: local_reload_connections,
                                                                               reload_on_failure: @reload_on_failure,

--- a/lib/fluent/plugin/out_elasticsearch_dynamic.rb
+++ b/lib/fluent/plugin/out_elasticsearch_dynamic.rb
@@ -53,7 +53,7 @@ module Fluent::Plugin
                        end
         headers = { 'Content-Type' => @content_type.to_s, }.merge(gzip_headers)
         ssl_options = { verify: @ssl_verify, ca_file: @ca_file}.merge(@ssl_version_options)
-        transport = Elasticsearch::Transport::Transport::HTTP::Faraday.new(connection_options.merge(
+        transport = TRANSPORT_CLASS::Transport::HTTP::Faraday.new(connection_options.merge(
                                                                             options: {
                                                                               reload_connections: @reload_connections,
                                                                               reload_on_failure: @reload_on_failure,

--- a/test/plugin/test_elasticsearch_index_lifecycle_management.rb
+++ b/test/plugin/test_elasticsearch_index_lifecycle_management.rb
@@ -6,12 +6,14 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
   include Fluent::Plugin::ElasticsearchIndexLifecycleManagement
 
   def setup
-    begin
-      require "elasticsearch/xpack"
-    rescue LoadError
-      omit "ILM testcase needs elasticsearch-xpack gem."
+    if Gem::Version.new(Elasticsearch::VERSION) < Gem::Version.new("7.14.0")
+      begin
+        require "elasticsearch/xpack"
+      rescue LoadError
+        omit "ILM testcase needs elasticsearch-xpack gem."
+      end
     end
-    if Gem::Version.create(::Elasticsearch::Transport::VERSION) < Gem::Version.create("7.4.0")
+    if Gem::Version.create(::TRANSPORT_CLASS::VERSION) < Gem::Version.create("7.4.0")
       omit "elastisearch-ruby v7.4.0 or later is needed for ILM."
     end
     Fluent::Plugin::ElasticsearchIndexLifecycleManagement.module_eval(<<-CODE)
@@ -27,50 +29,78 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
     CODE
   end
 
-  def stub_elastic_info(url="http://localhost:9200/", version="7.9.0")
+  def elasticsearch_version
+    if Gem::Version.new(TRANSPORT_CLASS::VERSION) >= Gem::Version.new("8.0.0")
+      TRANSPORT_CLASS::VERSION
+    else
+      '6.4.2'.freeze
+    end
+  end
+
+  def ilm_existence_endpoint(policy_id)
+    if Gem::Version.new(TRANSPORT_CLASS::VERSION) >= Gem::Version.new("8.0.0")
+      "_enrich/policy/#{policy_id}"
+    else
+      "_ilm/policy/%7B:policy_id=%3E%22#{policy_id}%22%7D"
+    end
+  end
+
+  def ilm_creation_endpoint(policy_id)
+    if Gem::Version.new(TRANSPORT_CLASS::VERSION) >= Gem::Version.new("8.0.0")
+      "_enrich/policy/#{policy_id}"
+    else
+      "_ilm/policy/#{policy_id}"
+    end
+  end
+
+  def stub_elastic_info(url="http://localhost:9200/", version=elasticsearch_version)
     body ="{\"version\":{\"number\":\"#{version}\", \"build_flavor\":\"default\"},\"tagline\" : \"You Know, for Search\"}"
-    stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json' } })
+    stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json', 'x-elastic-product' => 'Elasticsearch' } })
   end
 
   def test_xpack_info
     stub_request(:get, "http://localhost:9200/_xpack").
-      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json" })
     stub_elastic_info
     expected = {"features"=>{"ilm"=>{"available"=>true, "enabled"=>true}}}
-    assert_equal(expected, xpack_info)
+    if xpack_info.is_a?(Elasticsearch::API::Response)
+      assert_equal(expected, xpack_info.body)
+    else
+      assert_equal(expected, xpack_info)
+    end
   end
 
   def test_verify_ilm_working
     stub_request(:get, "http://localhost:9200/_xpack").
-      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json"})
+      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json" })
     stub_elastic_info
     assert_nothing_raised { verify_ilm_working }
   end
 
   def test_ilm_policy_doesnt_exists
-    stub_request(:get, "http://localhost:9200/_ilm/policy/%7B:policy_id=%3E%22fluentd-policy%22%7D").
+    stub_request(:get, "http://localhost:9200/#{ilm_existence_endpoint("fluentd-policy")}").
       to_return(:status => 404, :body => "", :headers => {})
     stub_elastic_info
-    assert_false(ilm_policy_exists?(policy_id: "fluentd-policy"))
+    assert_false(ilm_policy_exists?("fluentd-policy"))
   end
 
   def test_ilm_policy_exists
-    stub_request(:get, "http://localhost:9200/_ilm/policy/%7B:policy_id=%3E%22fluent-policy%22%7D").
+    stub_request(:get, "http://localhost:9200/#{ilm_existence_endpoint("fluent-policy")}").
       to_return(:status => 200, :body => "", :headers => {})
     stub_elastic_info
-    assert_true(ilm_policy_exists?(policy_id: "fluent-policy"))
+    assert_true(ilm_policy_exists?("fluent-policy"))
   end
 
   def test_create_ilm_policy
-    stub_request(:get, "http://localhost:9200/_ilm/policy/fluent-policy").
+    stub_request(:get, "http://localhost:9200/#{ilm_creation_endpoint("fluent-policy")}").
       to_return(:status => 404, :body => "", :headers => {})
-    stub_request(:put, "http://localhost:9200/_ilm/policy/fluent-policy").
+    stub_request(:put, "http://localhost:9200/#{ilm_creation_endpoint("fluent-policy")}").
       with(:body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}",
          :headers => {'Content-Type'=>'application/json'}).
       to_return(:status => 200, :body => "", :headers => {})
     stub_elastic_info
     create_ilm_policy("fluent-policy")
 
-    assert_requested(:put, "http://localhost:9200/_ilm/policy/fluent-policy", times: 1)
+    assert_requested(:put, "http://localhost:9200/#{ilm_creation_endpoint("fluent-policy")}", times: 1)
   end
 end

--- a/test/plugin/test_in_elasticsearch.rb
+++ b/test/plugin/test_in_elasticsearch.rb
@@ -31,9 +31,17 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     @driver ||= Fluent::Test::Driver::Input.new(Fluent::Plugin::ElasticsearchInput).configure(conf)
   end
 
-  def stub_elastic_info(url="http://localhost:9200/", version="7.9.0")
+  def elasticsearch_version
+    if Gem::Version.new(TRANSPORT_CLASS::VERSION) >= Gem::Version.new("7.14.0")
+      TRANSPORT_CLASS::VERSION
+    else
+      '7.9.0'.freeze
+    end
+  end
+
+  def stub_elastic_info(url="http://localhost:9200/", version=elasticsearch_version)
     body ="{\"version\":{\"number\":\"#{version}\", \"build_flavor\":\"default\"},\"tagline\" : \"You Know, for Search\"}"
-    stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json' } })
+    stub_request(:get, url).to_return({:status => 200, :body => body, :headers => { 'Content-Type' => 'json', 'x-elastic-product' => 'Elasticsearch' } })
   end
 
   def sample_response(index_name="fluentd")


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

Closes #944 

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
