### PR TITLE
Handle unsupported version error

### DIFF
--- a/lib/fluent/plugin/elasticsearch_compat.rb
+++ b/lib/fluent/plugin/elasticsearch_compat.rb
@@ -25,3 +25,6 @@ begin
   ::SELECTOR_CLASS = Elasticsearch::Transport::Transport::Connections::Selector
 rescue LoadError
 end
+unless defined?(Elasticsearch::UnsupportedProductError)
+  class Elasticsearch::UnsupportedProductError < StandardError; end
+end

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -492,7 +492,11 @@ EOC
     end
 
     def detect_es_major_version
-      @_es_info ||= client.info
+      begin
+        @_es_info ||= client.info
+      rescue Elasticsearch::UnsupportedProductError => e
+        raise Fluent::ConfigError, "Using Elasticsearch client #{client_library_version} is not compatible for your Elasticsearch server. Please check your using elasticsearch gem version and Elasticsearch server."
+      end
       begin
         unless version = @_es_info.dig("version", "number")
           version = @default_elasticsearch_version


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>

Closes #951 

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [x] feature works in `elasticsearch_dynamic` (not required but recommended)
