### PR TITLE
do not overwrite @timestamp in data stream if it already exists in the record

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -248,7 +248,9 @@ module Fluent::Plugin
         end
 
         begin
-          record.merge!({"@timestamp" => Time.at(time).iso8601(@time_precision)})
+          unless record.has_key?("@timestamp")
+            record.merge!({"@timestamp" => Time.at(time).iso8601(@time_precision)})
+          end
           bulk_message = append_record_to_messages(CREATE_OP, {}, headers, record, bulk_message)
         rescue => e
           router.emit_error_event(tag, time, record, e)


### PR DESCRIPTION
closes #967 

If the log record already contains the field `@timestamp`, then the data stream output plugin should not overwrite the field.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
