### PR TITLE
Increase errors metric on error response in data stream

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -265,6 +265,7 @@ module Fluent::Plugin
         response = client(host).bulk(params)
         if response['errors']
           log.error "Could not bulk insert to Data Stream: #{data_stream_name} #{response}"
+          @num_errors_metrics.inc
         end
       rescue => e
         raise RecoverableRequestFailure, "could not push logs to Elasticsearch cluster (#{data_stream_name}): #{e.message}"


### PR DESCRIPTION
If ES responds with an error (e.g., because of a type issue), this isn't visible in any metric (only an error log is generated). Because of this, monitoring solutions based on metrics scraping (like Prometheus) can't detect this issue. This patch increases num_errors metric if there are errors in response from ES in the data stream output.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
