### PR TITLE
Add compression_level support to elasticsearch_data_stream

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -257,12 +257,18 @@ module Fluent::Plugin
         end
       end
 
+      prepared_data = if compression
+        gzip(bulk_message)
+      else
+        bulk_message
+      end
+
       params = {
         index: data_stream_name,
-        body: bulk_message
+        body: prepared_data
       }
       begin
-        response = client(host).bulk(params)
+        response = client(host, compression).bulk(params)
         if response['errors']
           log.error "Could not bulk insert to Data Stream: #{data_stream_name} #{response}"
           @num_errors_metrics.inc


### PR DESCRIPTION
This PR adds support for request compression when using the data stream plugin. Prior to this PR `compression_level` is silently ignored when using `elasticsearch_data_stream`. 

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
