### PR TITLE
readme: Update thread_pool bulk to write

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ You can specify Elasticsearch port by this parameter.
 ### cloud_id
 
 ```
-cloud_id test-dep:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyRiYZTA1Ng== 
+cloud_id test-dep:ZXVyb3BlLXdlc3QxLmdjcC5jbG91ZC5lcy5pbyRiYZTA1Ng==
 ```
 
 You can specify Elasticsearch cloud_id by this parameter.
@@ -1179,11 +1179,11 @@ Advanced users can increase its capacity, but normal users should follow default
 
 If you want to increase it and forcibly retrying bulk request, please consider to change `unrecoverable_error_types` parameter from default value.
 
-Change default value of `thread_pool.bulk.queue_size` in elasticsearch.yml:
+Change default value of `thread_pool.write.queue_size` in elasticsearch.yml:
 e.g.)
 
 ```yaml
-thread_pool.bulk.queue_size: 1000
+thread_pool.write.queue_size: 1000
 ```
 
 Then, remove `es_rejected_execution_exception` from `unrecoverable_error_types` parameter:
@@ -1531,7 +1531,7 @@ This parameter is mandatory for `elasticsearch_data_stream`.
 
 ### data_stream_template_name
 
-You can specify an existing matching index template for the data stream. If not present, it creates a new matching index template. 
+You can specify an existing matching index template for the data stream. If not present, it creates a new matching index template.
 
 Default value is `data_stream_name`.
 


### PR DESCRIPTION
Could be confusing when consulting plugin documentation instead of elastic, as bulk was changed to write:
PR that changed this: https://github.com/elastic/elasticsearch/pull/41935
elastic docs: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/modules-threadpool.html#modules-threadpool

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
