### PR TITLE
data_stream: Honor hosts parameter

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -219,7 +219,11 @@ module Fluent::Plugin
       data_stream_ilm_name = @data_stream_ilm_name
       host = nil
       if @use_placeholder
-        host = extract_placeholders(@host, chunk)
+        host = if @hosts
+                 extract_placeholders(@hosts, chunk)
+               else
+                 extract_placeholders(@host, chunk)
+               end
         data_stream_name = extract_placeholders(@data_stream_name, chunk)
         data_stream_template_name = extract_placeholders(@data_stream_template_name, chunk)
         data_stream_ilm_name = extract_placeholders(@data_stream_ilm_name, chunk)


### PR DESCRIPTION
This PR is based on OpenSearch repo's PR.

DESCRIPTION HERE

(check all that apply)
- [x] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
