### PR TITLE
Remove outdated coveralls gem usage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: travis-ci
-

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'simplecov', require: false
-gem 'coveralls', ">= 0.8.0", require: false
 gem 'strptime', require: false if RUBY_ENGINE == "ruby" && RUBY_VERSION =~ /^2/
 gem "irb" if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.6"
 gem "elasticsearch-xpack" if ENV["USE_XPACK"]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,9 +5,6 @@ SimpleCov.start do
   end
 end
 
-require 'coveralls'
-Coveralls.wear!
-
 # needs to be after simplecov but before test/unit, because fluentd sets default
 # encoding to ASCII-8BIT, but coverall might load git data which could contain a
 # UTF-8 character


### PR DESCRIPTION
Remove coveralls usage due to outdated gem.

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
