### PR TITLE
Fix support for host/hosts placeholders for ipv6 addresses

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -3603,7 +3603,12 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   def test_hosts_list_with_existing_connection
     stub_elastic_info("https://john:password@host1:443/elastic/")
     stub_elastic_info("http://host2")
-    instance = driver.instance
+    config = %{
+      path     /default_path
+      user     default_user
+      password default_password
+    }
+    instance = driver(config).instance
 
     assert_equal 2, instance.get_connection_options("https://john:password@host1:443/elastic/,http://host2")[:hosts].length
     host1, host2 = instance.get_connection_options("https://john:password@host1:443/elastic/,http://host2")[:hosts]
@@ -3693,7 +3698,12 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     end
 
     def test_hosts_list_with_existing_connection
-      instance = driver.instance
+      config = %{
+        path     /default_path
+        user     default_user
+        password default_password
+      }
+      instance = driver(config).instance
 
       assert_equal 2, instance.get_connection_options("https://john:password@[2404:7a80:d440:3000:192a:a292:bd7f:ca19]:443/elastic/,http://host2")[:hosts].length
       host1, host2 = instance.get_connection_options("https://john:password@[2404:7a80:d440:3000:192a:a292:bd7f:ca19]:443/elastic/,http://host2")[:hosts]
@@ -3759,7 +3769,11 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   def test_single_existing_connection
-    instance = driver.instance
+    config = %{
+      user     john
+      password doe
+    }
+    instance = driver(config).instance
 
     assert_equal 1, instance.get_connection_options("logs.google.com")[:hosts].length
     host1 = instance.get_connection_options("logs.google.com")[:hosts][0]
@@ -3827,6 +3841,10 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     end
 
     def test_single_existing_connection
+      config = %{
+        user     john
+        password doe
+      }
       instance = driver(config).instance
 
       assert_equal 1, instance.get_connection_options("2404:7a80:d440:3000:192a:a292:bd7f:ca19")[:hosts].length

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -3592,6 +3592,28 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
     assert_equal '/default_path', host2[:path]
   end
 
+  def test_hosts_list_with_existing_connection
+    stub_elastic_info("https://john:password@host1:443/elastic/")
+    stub_elastic_info("http://host2")
+    instance = driver.instance
+
+    assert_equal 2, instance.get_connection_options("https://john:password@host1:443/elastic/,http://host2")[:hosts].length
+    host1, host2 = instance.get_connection_options("https://john:password@host1:443/elastic/,http://host2")[:hosts]
+
+    assert_equal 'host1', host1[:host]
+    assert_equal 443, host1[:port]
+    assert_equal 'https', host1[:scheme]
+    assert_equal 'john', host1[:user]
+    assert_equal 'password', host1[:password]
+    assert_equal '/elastic/', host1[:path]
+
+    assert_equal 'host2', host2[:host]
+    assert_equal 'http', host2[:scheme]
+    assert_equal 'default_user', host2[:user]
+    assert_equal 'default_password', host2[:password]
+    assert_equal '/default_path', host2[:path]
+  end
+
   def test_hosts_list_with_escape_placeholders
     config = %{
       hosts    https://%{j+hn}:%{passw@rd}@host1:443/elastic/,http://host2
@@ -3662,6 +3684,26 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       assert_equal '/default_path', host2[:path]
     end
 
+    def test_hosts_list_with_existing_connection
+      instance = driver.instance
+
+      assert_equal 2, instance.get_connection_options("https://john:password@[2404:7a80:d440:3000:192a:a292:bd7f:ca19]:443/elastic/,http://host2")[:hosts].length
+      host1, host2 = instance.get_connection_options("https://john:password@[2404:7a80:d440:3000:192a:a292:bd7f:ca19]:443/elastic/,http://host2")[:hosts]
+
+      assert_equal '[2404:7a80:d440:3000:192a:a292:bd7f:ca19]', host1[:host]
+      assert_equal 443, host1[:port]
+      assert_equal 'https', host1[:scheme]
+      assert_equal 'john', host1[:user]
+      assert_equal 'password', host1[:password]
+      assert_equal '/elastic/', host1[:path]
+
+      assert_equal 'host2', host2[:host]
+      assert_equal 'http', host2[:scheme]
+      assert_equal 'default_user', host2[:user]
+      assert_equal 'default_password', host2[:password]
+      assert_equal '/default_path', host2[:path]
+    end
+
     def test_hosts_list_with_escape_placeholders
       config = %{
         hosts    https://%{j+hn}:%{passw@rd}@[2404:7a80:d440:3000:192a:a292:bd7f:ca19]:443/elastic/,http://host2
@@ -3699,6 +3741,20 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
 
     assert_equal 1, instance.get_connection_options[:hosts].length
     host1 = instance.get_connection_options[:hosts][0]
+
+    assert_equal 'logs.google.com', host1[:host]
+    assert_equal 9200, host1[:port]
+    assert_equal 'http', host1[:scheme]
+    assert_equal 'john', host1[:user]
+    assert_equal 'doe', host1[:password]
+    assert_equal nil, host1[:path]
+  end
+
+  def test_single_existing_connection
+    instance = driver.instance
+
+    assert_equal 1, instance.get_connection_options("logs.google.com")[:hosts].length
+    host1 = instance.get_connection_options("logs.google.com")[:hosts][0]
 
     assert_equal 'logs.google.com', host1[:host]
     assert_equal 9200, host1[:port]
@@ -3760,6 +3816,30 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
       assert_equal 'john', host1[:user]
       assert_equal 'doe', host1[:password]
       assert_equal nil, host1[:path]
+    end
+
+    def test_single_existing_connection
+      instance = driver(config).instance
+
+      assert_equal 1, instance.get_connection_options("2404:7a80:d440:3000:192a:a292:bd7f:ca19")[:hosts].length
+      host1 = instance.get_connection_options("2404:7a80:d440:3000:192a:a292:bd7f:ca19")[:hosts][0]
+
+      assert_equal 1, instance.get_connection_options("[2404:7a80:d440:3000:192a:a292:bd7f:ca19]")[:hosts].length
+      host2 = instance.get_connection_options("[2404:7a80:d440:3000:192a:a292:bd7f:ca19]")[:hosts][0]
+
+      assert_equal '[2404:7a80:d440:3000:192a:a292:bd7f:ca19]', host1[:host]
+      assert_equal 9200, host1[:port]
+      assert_equal 'http', host1[:scheme]
+      assert_equal 'john', host1[:user]
+      assert_equal 'doe', host1[:password]
+      assert_equal nil, host1[:path]
+
+      assert_equal '[2404:7a80:d440:3000:192a:a292:bd7f:ca19]', host2[:host]
+      assert_equal 9200, host2[:port]
+      assert_equal 'http', host2[:scheme]
+      assert_equal 'john', host2[:user]
+      assert_equal 'doe', host2[:password]
+      assert_equal nil, host2[:path]
     end
 
     def test_single_host_params_and_defaults_with_escape_placeholders


### PR DESCRIPTION
This PR fixes support for host/hosts placeholders specifically for ipv6 addresses.
Before this fix, IPv6 addresses would not be parsed correctly after evaluating host/hosts for placeholders.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
