### PR TITLE
Handle newer es library

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,7 +15,6 @@ end
 
 require 'test/unit'
 require 'fluent/test'
-require 'minitest/pride'
 
 require 'webmock/test_unit'
 WebMock.disable_net_connect!

--- a/test/plugin/test_elasticsearch_fallback_selector.rb
+++ b/test/plugin/test_elasticsearch_fallback_selector.rb
@@ -15,7 +15,7 @@ class ElasticsearchFallbackSelectorTest < Test::Unit::TestCase
   def stub_elastic(url="http://localhost:9200/_bulk")
     stub_request(:post, url).with do |req|
       @index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
-    end
+    end.to_return({:status => 200, :body => "{}", :headers => { 'Content-Type' => 'json', 'x-elastic-product' => 'Elasticsearch' } })
   end
 
   def elasticsearch_version

--- a/test/plugin/test_elasticsearch_index_lifecycle_management.rb
+++ b/test/plugin/test_elasticsearch_index_lifecycle_management.rb
@@ -60,7 +60,7 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
 
   def test_xpack_info
     stub_request(:get, "http://localhost:9200/_xpack").
-      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json" })
+      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json", 'x-elastic-product' => 'Elasticsearch'  })
     stub_elastic_info
     expected = {"features"=>{"ilm"=>{"available"=>true, "enabled"=>true}}}
     if xpack_info.is_a?(Elasticsearch::API::Response)
@@ -72,32 +72,32 @@ class TestElasticsearchIndexLifecycleManagement < Test::Unit::TestCase
 
   def test_verify_ilm_working
     stub_request(:get, "http://localhost:9200/_xpack").
-      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json" })
+      to_return(:status => 200, :body => '{"features":{"ilm":{"available":true,"enabled":true}}}', :headers => {"Content-Type"=> "application/json", 'x-elastic-product' => 'Elasticsearch'  })
     stub_elastic_info
     assert_nothing_raised { verify_ilm_working }
   end
 
   def test_ilm_policy_doesnt_exists
     stub_request(:get, "http://localhost:9200/#{ilm_existence_endpoint("fluentd-policy")}").
-      to_return(:status => 404, :body => "", :headers => {})
+      to_return(:status => 404, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
     assert_false(ilm_policy_exists?("fluentd-policy"))
   end
 
   def test_ilm_policy_exists
     stub_request(:get, "http://localhost:9200/#{ilm_existence_endpoint("fluent-policy")}").
-      to_return(:status => 200, :body => "", :headers => {})
+      to_return(:status => 200, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
     assert_true(ilm_policy_exists?("fluent-policy"))
   end
 
   def test_create_ilm_policy
     stub_request(:get, "http://localhost:9200/#{ilm_creation_endpoint("fluent-policy")}").
-      to_return(:status => 404, :body => "", :headers => {})
+      to_return(:status => 404, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
     stub_request(:put, "http://localhost:9200/#{ilm_creation_endpoint("fluent-policy")}").
       with(:body => "{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"50gb\",\"max_age\":\"30d\"}}}}}}",
          :headers => {'Content-Type'=>'application/json'}).
-      to_return(:status => 200, :body => "", :headers => {})
+      to_return(:status => 200, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
     create_ilm_policy("fluent-policy")
 

--- a/test/plugin/test_in_elasticsearch.rb
+++ b/test/plugin/test_in_elasticsearch.rb
@@ -334,7 +334,7 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     stub_request(@http_method, "http://localhost:9200/fluentd/_search?scroll=1m&size=1000").
       with(body: "{\"sort\":[\"_doc\"]}").
       to_return(status: 200, body: sample_response.to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
 
     driver(CONFIG)
@@ -350,7 +350,7 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     stub_request(@http_method, "http://localhost:9200/#{index_name}/_search?scroll=1m&size=1000").
       with(body: "{\"sort\":[\"_doc\"]}").
       to_return(status: 200, body: sample_response(index_name).to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
 
     driver(CONFIG + %[index_name #{index_name}])
@@ -366,7 +366,7 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     stub_request(@http_method, "http://localhost:9200/#{index_name}/_search?scroll=1m&size=1000").
       with(body: "{\"sort\":[\"_doc\"]}").
       to_return(status: 200, body: sample_response(index_name).to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
 
     driver(CONFIG + %[parse_timestamp])
@@ -385,7 +385,7 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     stub_request(@http_method, "http://localhost:9200/#{index_name}/_search?scroll=1m&size=1000").
       with(body: "{\"sort\":[\"_doc\"]}").
       to_return(status: 200, body: sample_response(index_name).to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
 
     driver(CONFIG + %[parse_timestamp true
@@ -405,7 +405,7 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     stub_request(@http_method, "http://localhost:9200/fluentd/_search?scroll=1m&size=1000").
       with(body: "{\"sort\":[\"_doc\"]}").
       to_return(status: 200, body: sample_response.to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
 
     driver(CONFIG + %[docinfo true])
@@ -425,11 +425,11 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     stub_request(@http_method, "http://localhost:9200/fluentd/_search?scroll=1m&size=1000").
       with(body: "{\"sort\":[\"_doc\"],\"slice\":{\"id\":0,\"max\":2}}").
       to_return(status: 200, body: sample_response.to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     stub_request(@http_method, "http://localhost:9200/fluentd/_search?scroll=1m&size=1000").
       with(body: "{\"sort\":[\"_doc\"],\"slice\":{\"id\":1,\"max\":2}}").
       to_return(status: 200, body: sample_response.to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     stub_elastic_info
 
     driver(CONFIG + %[num_slices 2])
@@ -446,7 +446,7 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     stub_request(@http_method, "http://localhost:9200/fluentd/_search?scroll=1m&size=1").
       with(body: "{\"sort\":[\"_doc\"]}").
       to_return(status: 200, body: sample_scroll_response.to_s,
-                headers: {'Content-Type' => 'application/json'})
+                headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'})
     connection = 0
     scroll_request = stub_request(@http_method, "http://localhost:9200/_search/scroll?scroll=1m").
       with(
@@ -457,10 +457,10 @@ class ElasticsearchInputTest < Test::Unit::TestCase
     scroll_request.to_return(lambda do |req|
                                if connection <= 1
                                  {status: 200, body: sample_scroll_response_2.to_s,
-                                  headers: {'Content-Type' => 'application/json'}}
+                                  headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'}}
                                else
                                  {status: 200, body: sample_scroll_response_terminate.to_s,
-                                  headers: {'Content-Type' => 'application/json'}}
+                                  headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'}}
                                end
                              end)
     stub_request(:delete, "http://localhost:9200/_search/scroll/WomkoUKG0QPB679Ulo6TqQgh3pIGRUmrl9qXXGK3EeiQh9rbYNasTkspZQcJ01uz").

--- a/test/plugin/test_out_elasticsearch_data_stream.rb
+++ b/test/plugin/test_out_elasticsearch_data_stream.rb
@@ -92,40 +92,40 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
   NONEXISTENT_DATA_STREAM_EXCEPTION = {"error": {}, "status": 404}
 
   def stub_ilm_policy(name="foo_ilm_policy", url="http://localhost:9200")
-    stub_request(:put, "#{url}/#{ilm_endpoint}/policy/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+    stub_request(:put, "#{url}/#{ilm_endpoint}/policy/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_index_template(name="foo_tpl", url="http://localhost:9200")
-    stub_request(:put, "#{url}/_index_template/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+    stub_request(:put, "#{url}/_index_template/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_data_stream(name="foo", url="http://localhost:9200")
-    stub_request(:put, "#{url}/_data_stream/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+    stub_request(:put, "#{url}/_data_stream/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_existent_data_stream?(name="foo", url="http://localhost:9200")
-    stub_request(:get, "#{url}/_data_stream/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+    stub_request(:get, "#{url}/_data_stream/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_existent_ilm?(name="foo_ilm_policy", url="http://localhost:9200")
 
-    stub_request(:get, "#{url}/#{ilm_endpoint}/policy/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+    stub_request(:get, "#{url}/#{ilm_endpoint}/policy/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_existent_template?(name="foo_tpl", url="http://localhost:9200")
-    stub_request(:get, "#{url}/_index_template/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED])
+    stub_request(:get, "#{url}/_index_template/#{name}").to_return(:status => [200, RESPONSE_ACKNOWLEDGED], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_nonexistent_data_stream?(name="foo", url="http://localhost:9200")
-    stub_request(:get, "#{url}/_data_stream/#{name}").to_return(:status => [404, TRANSPORT_CLASS::Transport::Errors::NotFound])
+    stub_request(:get, "#{url}/_data_stream/#{name}").to_return(:status => [404, TRANSPORT_CLASS::Transport::Errors::NotFound], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_nonexistent_ilm?(name="foo_ilm_policy", url="http://localhost:9200")
-    stub_request(:get, "#{url}/#{ilm_endpoint}/policy/#{name}").to_return(:status => [404, TRANSPORT_CLASS::Transport::Errors::NotFound])
+    stub_request(:get, "#{url}/#{ilm_endpoint}/policy/#{name}").to_return(:status => [404, TRANSPORT_CLASS::Transport::Errors::NotFound], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def stub_nonexistent_template?(name="foo_tpl", url="http://localhost:9200")
-    stub_request(:get, "#{url}/_index_template/#{name}").to_return(:status => [404, TRANSPORT_CLASS::Transport::Errors::NotFound])
+    stub_request(:get, "#{url}/_index_template/#{name}").to_return(:status => [404, TRANSPORT_CLASS::Transport::Errors::NotFound], :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
 
@@ -141,7 +141,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
 
   def stub_nonexistent_template_retry?(name="foo_tpl", url="http://localhost:9200")
     stub_request(:get, "#{url}/_index_template/#{name}").
-      to_return({ status: 500, body: 'Internal Server Error' }, { status: 404, body: '{}' })
+      to_return({ status: 500, body: 'Internal Server Error' }, { status: 404, body: '{}', :headers => {'x-elastic-product' => 'Elasticsearch'} })
   end
 
   def stub_bulk_feed(datastream_name="foo", ilm_name="foo_ilm_policy", template_name="foo_tpl", url="http://localhost:9200")
@@ -150,19 +150,19 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
       # {"create": {}}\nhttp://localhost:9200/_ilm/policy/foo_ilm_bar
       # {"@timestamp": ...}
       push_bulk_request(req.body)
-    end
+    end.to_return({:status => 200, :body => "{}", :headers => { 'Content-Type' => 'json', 'x-elastic-product' => 'Elasticsearch' } })
     stub_request(:post, "#{url}/#{ilm_name}/_bulk").with do |req|
       # bulk data must be pair of OP and records
       # {"create": {}}\nhttp://localhost:9200/_ilm/policy/foo_ilm_bar
       # {"@timestamp": ...}
       push_bulk_request(req.body)
-    end
+    end.to_return({:status => 200, :body => "{}", :headers => { 'Content-Type' => 'json', 'x-elastic-product' => 'Elasticsearch' } })
     stub_request(:post, "#{url}/#{template_name}/_bulk").with do |req|
       # bulk data must be pair of OP and records
       # {"create": {}}\nhttp://localhost:9200/_ilm/policy/foo_ilm_bar
       # {"@timestamp": ...}
       push_bulk_request(req.body)
-    end
+    end.to_return({:status => 200, :body => "{}", :headers => { 'Content-Type' => 'json', 'x-elastic-product' => 'Elasticsearch' } })
   end
 
   def stub_elastic_info(url="http://localhost:9200/", version=elasticsearch_version, headers={})
@@ -189,7 +189,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
     stub_request(:post, url).with do |req|
       index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
       @index_command_counts[url] += index_cmds.size
-    end
+    end.to_return(:status => 200, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
   end
 
   def data_stream_supported?
@@ -588,7 +588,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
 
     stub_default
     stub_request(:post, "http://localhost:9200/foo/_bulk").
-      to_return(status: 200, body: "", headers: {})
+      to_return(status: 200, body: "", headers: {'x-elastic-product' => 'Elasticsearch'})
 
     instance = driver(config).instance
 
@@ -626,7 +626,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
 
     stub_default
     stub_request(:post, "http://localhost:9200/foo/_bulk").
-      to_return(status: 200, body: "", headers: {})
+      to_return(status: 200, body: "", headers: {'x-elastic-product' => 'Elasticsearch'})
 
     instance = driver(config).instance
 
@@ -849,7 +849,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
       stub_elastic_with_store_index_command_counts("http://#{host}:#{port}/foo_bar/_bulk")
       stub_elastic_info("http://#{host}:#{port}/")
       stub_request(:get, "http://#{host}:#{port}/_data_stream/foo_bar").
-        to_return(status: 200, body: "", headers: {})
+        to_return(status: 200, body: "", headers: {'x-elastic-product' => 'Elasticsearch'})
     end
 
     conf = config_element(
@@ -919,7 +919,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
 
     stub_default
     elastic_request = stub_request(:post, "http://localhost:9200/foo/_bulk").
-        to_return(:status => 200, :headers => {'Content-Type' => 'application/json'}, :body => compressed_body)
+        to_return(:status => 200, :headers => {'Content-Type' => 'application/json', 'x-elastic-product' => 'Elasticsearch'}, :body => compressed_body)
 
     driver(config)
     driver.run(default_tag: 'test') do
@@ -945,7 +945,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
     stub_data_stream
 
     stub_request(:put, "http://localhost:9200/#{ilm_endpoint}/policy/foo_ilm_policy").
-      to_return(:status => 200, :body => "", :headers => {})
+      to_return(:status => 200, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
 
     assert_nothing_raised {
       driver(config)
@@ -970,7 +970,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
     stub_data_stream
 
     stub_request(:put, "http://localhost:9200/#{ilm_endpoint}/policy/foo_ilm_policy").
-      to_return(:status => 200, :body => "", :headers => {})
+      to_return(:status => 200, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
 
     assert_nothing_raised {
       driver(config)
@@ -999,7 +999,7 @@ class ElasticsearchOutputDataStreamTest < Test::Unit::TestCase
     stub_nonexistent_template?("foo_template")
 
     stub_request(:put, "http://localhost:9200/#{ilm_endpoint}/policy/foo_ilm_policy").
-      to_return(:status => 200, :body => "", :headers => {})
+      to_return(:status => 200, :body => "", :headers => {'x-elastic-product' => 'Elasticsearch'})
 
     assert_nothing_raised {
       driver(config)


### PR DESCRIPTION
Fixes failed test cases when using newer Elasticsearch ruby library.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
