### PR TITLE
Support long scroll id for clear scroll

### DIFF
--- a/lib/fluent/plugin/in_elasticsearch.rb
+++ b/lib/fluent/plugin/in_elasticsearch.rb
@@ -286,7 +286,7 @@ module Fluent::Plugin
       end
 
       router.emit_stream(@tag, es)
-      client.clear_scroll(scroll_id: scroll_id) if scroll_id
+      client.clear_scroll(:body => { :scroll_id => scroll_id } ) if scroll_id
     end
 
     def process_scroll_request(scroll_id)


### PR DESCRIPTION
- put the scroll id into the body as new es api instead of marking it in the url

Fix the issue with long scroll id: 

Configure elastic with a lot of data and I want to use elasticsearch stream input, then it doesnt work with scrolling and have this error:
error_class=Elasticsearch::Transport::Transport::Errors::BadRequest error="[400] {\"error\":{\"root_cause\":[{\"type\":\"too_long_frame_exception\",\"reason\":\"An HTTP line is larger than 4096 bytes.\"}],\"type\":\"too_long_frame_exception\",\"reason\":\"An HTTP line is larger than 4096 bytes.\"},\"status\":400}"","worker_id":0} #<Thread:0x000000000411a798@in_elasticsearch_thread_1000 /opt/td-agent/lib/ruby/gems/2.7.0/gems/fluentd-1.14.6/lib/fluent/plugin_helper/thread.rb:70 run> terminated with exception (report_on_exception is true):
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ x] README updated (if needed)
- [ x] README Table of Contents updated (if needed)
- [ x] History.md and `version` in gemspec are untouched
- [ x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
