### PR TITLE
in_elasticsearch: Avoid to use deprecated endpoint for clear_scroll

### DIFF
--- a/lib/fluent/plugin/in_elasticsearch.rb
+++ b/lib/fluent/plugin/in_elasticsearch.rb
@@ -286,7 +286,11 @@ module Fluent::Plugin
       end
 
       router.emit_stream(@tag, es)
-      client.clear_scroll(scroll_id: scroll_id) if scroll_id
+      if Gem::Version.new(Elasticsearch::VERSION) >= Gem::Version.new("7.0.0")
+        client.clear_scroll(body: {scroll_id: scroll_id}) if scroll_id
+      else
+        client.clear_scroll(scroll_id: scroll_id) if scroll_id
+      end
     end
 
     def process_scroll_request(scroll_id)

--- a/test/plugin/test_in_elasticsearch.rb
+++ b/test/plugin/test_in_elasticsearch.rb
@@ -463,9 +463,14 @@ class ElasticsearchInputTest < Test::Unit::TestCase
                                   headers: {'Content-Type' => 'application/json', 'X-elastic-product' => 'Elasticsearch'}}
                                end
                              end)
-    stub_request(:delete, "http://localhost:9200/_search/scroll/WomkoUKG0QPB679Ulo6TqQgh3pIGRUmrl9qXXGK3EeiQh9rbYNasTkspZQcJ01uz").
+    if Gem::Version.new(Elasticsearch::VERSION) >= Gem::Version.new("7.0.0")
+      stub_request(:delete, "http://localhost:9200/_search/scroll").
+        with(body: "{\"scroll_id\":\"WomkoUKG0QPB679Ulo6TqQgh3pIGRUmrl9qXXGK3EeiQh9rbYNasTkspZQcJ01uz\"}").
       to_return(status: 200, body: "", headers: {})
-
+    else
+      stub_request(:delete, "http://localhost:9200/_search/scroll/WomkoUKG0QPB679Ulo6TqQgh3pIGRUmrl9qXXGK3EeiQh9rbYNasTkspZQcJ01uz").
+        to_return(status: 200, body: "", headers: {})
+    end
     driver(CONFIG + %[size 1])
     driver.run(expect_emits: 1, timeout: 10)
     expected = [


### PR DESCRIPTION
Closes https://github.com/uken/fluent-plugin-elasticsearch/pull/1038

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
