### PR TITLE
add data_stream_template_use_index_patterns_wildcard in elasticsearch_data_stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,6 +1561,50 @@ Default value is `false`.
 
 **NOTE:** This parameter requests to install elasticsearch-xpack gem.
 
+### data_stream_template_use_index_patterns_wildcard
+
+Specify whether index patterns should include a wildcard (*) when creating an index template. This is particularly useful to prevent errors in scenarios where index templates are generated automatically, and multiple services with distinct suffixes are in use.
+
+Default value is `true`.
+
+Consider the following JSON error response when index patterns clash due to wildcard usage:
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "illegal_argument_exception",
+        "reason": "index template [eks-kube-apiserver] has index patterns [eks-kube-apiserver*] matching patterns from existing templates [eks-kube-apiserver-audit] with patterns (eks-kube-apiserver-audit => [eks-kube-apiserver-audit*]) that have the same priority [0], multiple index templates may not match during index creation, please use a different priority"
+      }
+    ],
+    "type": "illegal_argument_exception",
+    "reason": "index template [eks-kube-apiserver] has index patterns [eks-kube-apiserver*] matching patterns from existing templates [eks-kube-apiserver-audit] with patterns (eks-kube-apiserver-audit => [eks-kube-apiserver-audit*]) that have the same priority [0], multiple index templates may not match during index creation, please use a different priority"
+  },
+  "status": 400
+}
+```
+
+#### Usage Examples
+
+When `data_stream_template_use_index_patterns_wildcard` is set to `true` (default):
+
+```
+data_stream_name: foo
+data_stream_template_use_index_patterns_wildcard: true
+```
+
+In this case, the resulting index patterns will be: `["foo*"]`
+
+When `data_stream_template_use_index_patterns_wildcard` is set to `false`:
+
+```
+data_stream_name: foo
+data_stream_template_use_index_patterns_wildcard: false
+```
+
+The resulting index patterns will be: `["foo"]`
+
+
 ## Troubleshooting
 
 See [Troubleshooting document](README.Troubleshooting.md)

--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -13,6 +13,7 @@ module Fluent::Plugin
     config_param :data_stream_template_name, :string, :default => nil
     config_param :data_stream_ilm_policy, :string, :default => nil
     config_param :data_stream_ilm_policy_overwrite, :bool, :default => false
+    config_param :data_stream_template_use_index_patterns_wildcard, :bool, :default => true
 
     # Elasticsearch 7.9 or later always support new style of index template.
     config_set_default :use_legacy_template, false
@@ -112,8 +113,9 @@ module Fluent::Plugin
 
     def create_index_template(datastream_name, template_name, ilm_name, host = nil)
       return if data_stream_exist?(datastream_name, host) or template_exists?(template_name, host)
+      wildcard = @data_stream_template_use_index_patterns_wildcard ? '*' : ''
       body = {
-        "index_patterns" => ["#{datastream_name}*"],
+        "index_patterns" => ["#{datastream_name}#{wildcard}"],
         "data_stream" => {},
         "template" => {
           "settings" => {


### PR DESCRIPTION
Add `data_stream_template_use_index_patterns_wildcard` config param in `elasticsearch_data_stream`

Specify whether index patterns should include a wildcard (*) when creating an index template. This is particularly useful to prevent errors in scenarios where index templates are generated automatically, and multiple services with distinct suffixes are in use.

Default value is `true`.

Consider the following JSON error response when index patterns clash due to wildcard usage:
```json
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "index template [eks-kube-apiserver] has index patterns [eks-kube-apiserver*] matching patterns from existing templates [eks-kube-apiserver-audit] with patterns (eks-kube-apiserver-audit => [eks-kube-apiserver-audit*]) that have the same priority [0], multiple index templates may not match during index creation, please use a different priority"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "index template [eks-kube-apiserver] has index patterns [eks-kube-apiserver*] matching patterns from existing templates [eks-kube-apiserver-audit] with patterns (eks-kube-apiserver-audit => [eks-kube-apiserver-audit*]) that have the same priority [0], multiple index templates may not match during index creation, please use a different priority"
  },
  "status": 400
}
```

#### Usage Examples

When `data_stream_template_use_index_patterns_wildcard` is set to `true` (default):

```
data_stream_name: foo
data_stream_template_use_index_patterns_wildcard: true
```

In this case, the resulting index patterns will be: `["foo*"]`

When `data_stream_template_use_index_patterns_wildcard` is set to `false`:

```
data_stream_name: foo
data_stream_template_use_index_patterns_wildcard: false
```

The resulting index patterns will be: `["foo"]`

(check all that apply)
- [x] tests added
- [x] tests passing
- [x] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
