### PR TITLE
Clarify README docs for template_name and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ The path to the file containing the template to install.
 
 ### templates
 
-Specify index templates (to be created on startup) in the form of a Ruby hash (accepts JSON dict). Can contain multiple templates.
+Specify index templates (to be created on startup) in the form of a hash (accepts JSON dict). Can contain multiple templates.
 
 ```
 templates { "template_name_1": "path_to_template_1_file", "template_name_2": "path_to_template_2_file"}

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ into same document with data1 as wanted and duplicated document is avoided.
 
 ### template_name
 
-The name of the template to define. If a template by the name given is already present, it will be left unchanged, unless [template_overwrite](#template_overwrite) is set, in which case the template will be updated.
+The name of the index template to create on fluentd startup. If a template by the name given is already present, it will be left unchanged, unless [template_overwrite](#template_overwrite) is set, in which case the template will be updated.
 
 This parameter along with template_file allow the plugin to behave similarly to Logstash (it installs a template at creation time) so that raw records are available. See [https://github.com/uken/fluent-plugin-elasticsearch/issues/33](https://github.com/uken/fluent-plugin-elasticsearch/issues/33).
 
@@ -541,7 +541,7 @@ The path to the file containing the template to install.
 
 ### templates
 
-Specify index templates in form of hash. Can contain multiple templates.
+Specify index templates (to be created on startup) in the form of a Ruby hash (accepts JSON dict). Can contain multiple templates.
 
 ```
 templates { "template_name_1": "path_to_template_1_file", "template_name_2": "path_to_template_2_file"}


### PR DESCRIPTION
Clarify when the index template is created and what 'hash' means (this was not at all obvious to me as a newcomber to Ruby - not all fluentd users will know Ruby)

I expect none of the below are really relevant as it is a readme-only change?

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
