### PR TITLE
Avoid long worrying log line at info level

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -142,7 +142,7 @@ module Fluent::Plugin
         response = client(host).indices.get_data_stream(params)
         return (not response.is_a?(TRANSPORT_CLASS::Transport::Errors::NotFound))
       rescue TRANSPORT_CLASS::Transport::Errors::NotFound => e
-        log.info "Specified data stream does not exist. Will be created: <#{e}>"
+        log.info "Specified data stream does not exist. Will be created: <#{datastream_name}>"
         return false
       end
     end


### PR DESCRIPTION
Currently there is an info level log line when checking if a datastream exists, but it includes the entire error even though it is caught and expected.

This results in long worrying looking log messages which are in fact not a problem (once you notice that they are info level) e.g. like this:
> [info]: #0 Specified data stream does not exist. Will be created: <[404] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [my.datastream.name]","resource.type":"index_or_alias","resource.id":"my.datastream.name","index_uuid":"_na_","index":"my.datastream.name"}],"type":"index_not_found_exception","reason":"no such index [my.datastream.name]","resource.type":"index_or_alias","resource.id":"my.datastream.name","index_uuid":"_na_","index":"my.datastream.name"},"status":404}>

We know what the error is going to be given it is being caught explicitly, so instead simplify and just log the name of the datastream which looks much nicer like this instead:
> [info]: #0 Specified data stream does not exist. Will be created: <my.datastream.name>

I don't think any of the below checklist are relevant but please let me know if you think they are.
Thanks!

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
