### PR TITLE
test: fix hash expression incompatibility for Ruby 3.4

### DIFF
--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -5005,7 +5005,8 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
           driver.feed(time.to_i, sample_record.merge({"pipeline_id" => pipeline_id}))
         end
       }
-      assert_equal("could not push logs to Elasticsearch cluster ({:host=>\"myhost-1\", :port=>9200, :scheme=>\"http\"}): [503] ", exception.message)
+      params = {:host=> "myhost-1", :port=>9200, :scheme=>"http"}
+      assert_equal("could not push logs to Elasticsearch cluster (#{params}): [503] ", exception.message)
     end
   end
 


### PR DESCRIPTION
Since Ruby 3.4, evaluated Hash notation was changed.

Before:

  :symbol => value

After:

  symbol: value

To keep compatibility, embed evaluated hash.

It fixes the following error:

```
  Failure:
  test_writes_to_extracted_host_with_placeholder_replaced_in_exception_message(ElasticsearchOutputTest::HostnamePlaceholders)
  /work/fluent/plugins/fluent-plugin-elasticsearch.work/test/plugin/test_out_elasticsearch.rb:5008:in
  'ElasticsearchOutputTest::HostnamePlaceholders#test_writes_to_extracted_host_with_placeholder_replaced_in_exception_message'
  <"could not push logs to Elasticsearch
  cluster ({:host=>\"myhost-1\", :port=>9200, :scheme=>\"http\"}):
  [503] "> expected but was <"could not push logs to Elasticsearch
  cluster ({host: \"myhost-1\", port: 9200, scheme: \"http\"}): [503]
  ">
```

(check all that apply)
- [- ] tests added
- [x] tests passing
- [- ] README updated (if needed)
- [-] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [-] feature works in `elasticsearch_dynamic` (not required but recommended)
