### PR TITLE
Add id_key and remove_keys to elasticsearch datastream driver

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch_data_stream.rb
+++ b/lib/fluent/plugin/out_elasticsearch_data_stream.rb
@@ -14,8 +14,6 @@ module Fluent::Plugin
     config_param :data_stream_ilm_policy, :string, :default => nil
     config_param :data_stream_ilm_policy_overwrite, :bool, :default => false
     config_param :data_stream_template_use_index_patterns_wildcard, :bool, :default => true
-    config_param :remove_keys, :string, :default => nil
-    config_param :id_key, :string, :default => nil
 
     # Elasticsearch 7.9 or later always support new style of index template.
     config_set_default :use_legacy_template, false


### PR DESCRIPTION
Fix https://github.com/uken/fluent-plugin-elasticsearch/issues/1045

Add id_key and remove_keys field in elasticsearch datastream.

(check all that apply)
- [x] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

