### PR TITLE
Fix Elasticsearch‐gem version constraints to avoid HTTP header errors

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday', '>= 2.0.0'
   s.add_runtime_dependency 'faraday-excon', '>= 2.0.0'
   s.add_runtime_dependency 'excon', '>= 0'
-  s.add_runtime_dependency 'elasticsearch'
+  s.add_runtime_dependency 'elasticsearch', '~> 8.0'
 
 
   s.add_development_dependency 'rake', '>= 0'


### PR DESCRIPTION
DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

After upgrading the elasticsearch Ruby gem to v9.0.1, Fluentd’s fluent-plugin-elasticsearch started raising:

Invalid media-type value on headers [Content-Type, Accept]

See: [uken/fluent-plugin-elasticsearch#1061](https://github.com/uken/fluent-plugin-elasticsearch/issues/1061)
https://github.com/elastic/elasticsearch-ruby/pull/2660

To restore compatibility:

For users on Elasticsearch-gem 8.x, continue shipping plugin v5.x

For users on Elasticsearch-gem 9.x, bump plugin to v6.x

This change pins the appropriate plugin version to each major gem series, preventing the header‐validation error.