### PR TITLE
Adjust Content-Type and Accept for sending logs into ES9

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -147,7 +147,7 @@ EOC
     config_param :sniffer_class_name, :string, :default => nil
     config_param :selector_class_name, :string, :default => nil
     config_param :reload_after, :integer, :default => DEFAULT_RELOAD_AFTER
-    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson", :"#{ES9_CONTENT_TYPE}"], :default => :"application/json",
+    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson"], :default => :"application/json",
                  :deprecated => <<EOC
 elasticsearch gem v6.0.2 starts to use correct Content-Type. Please upgrade elasticserach gem and stop to use this option.
 see: https://github.com/elastic/elasticsearch-ruby/pull/514

--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -73,6 +73,7 @@ module Fluent::Plugin
     DEFAULT_RELOAD_AFTER = -1
     DEFAULT_TARGET_BULK_BYTES = -1
     DEFAULT_POLICY_ID = "logstash-policy"
+    ES9_CONTENT_TYPE = "application/vnd.elasticsearch+x-ndjson; compatible-with=9"
 
     config_param :host, :string,  :default => 'localhost'
     config_param :port, :integer, :default => 9200
@@ -146,7 +147,7 @@ EOC
     config_param :sniffer_class_name, :string, :default => nil
     config_param :selector_class_name, :string, :default => nil
     config_param :reload_after, :integer, :default => DEFAULT_RELOAD_AFTER
-    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson"], :default => :"application/json",
+    config_param :content_type, :enum, list: [:"application/json", :"application/x-ndjson", :"#{ES9_CONTENT_TYPE}"], :default => :"application/json",
                  :deprecated => <<EOC
 elasticsearch gem v6.0.2 starts to use correct Content-Type. Please upgrade elasticserach gem and stop to use this option.
 see: https://github.com/elastic/elasticsearch-ruby/pull/514
@@ -350,9 +351,21 @@ EOC
           log.warn "Detected ES 7.x: `_doc` will be used as the document `_type`."
           @type_name = '_doc'.freeze
         end
-        if @last_seen_major_version >= 8 && @type_name != DEFAULT_TYPE_NAME_ES_7x
-          log.debug "Detected ES 8.x or above: This parameter has no effect."
+        if @last_seen_major_version == 8 && @type_name != DEFAULT_TYPE_NAME_ES_7x
+          log.debug "Detected ES 8.x: This parameter has no effect."
           @type_name = nil
+        end
+        if @last_seen_major_version >= 9
+          if @type_name != DEFAULT_TYPE_NAME_ES_7x
+            log.debug "Detected ES 9.x or above: This parameter has no effect."
+            @type_name = nil
+          end
+          @accept_type = nil
+          if @content_type != ES9_CONTENT_TYPE
+            log.trace "Detected ES 9.x or above: Content-Type will be adjusted."
+            @content_type = ES9_CONTENT_TYPE
+            @accept_type = ES9_CONTENT_TYPE
+          end
         end
       end
 
@@ -614,6 +627,8 @@ EOC
                     .merge(@custom_headers)
                     .merge(@api_key_header)
                     .merge(gzip_headers)
+        headers.merge!('Accept' => @accept_type) if @accept_type
+
         ssl_options = { verify: @ssl_verify, ca_file: @ca_file}.merge(@ssl_version_options)
 
         transport = TRANSPORT_CLASS::Transport::HTTP::Faraday.new(connection_options.merge(

--- a/test/plugin/test_out_elasticsearch.rb
+++ b/test/plugin/test_out_elasticsearch.rb
@@ -90,7 +90,13 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   end
 
   def stub_elastic(url="http://localhost:9200/_bulk")
-    stub_request(:post, url).with do |req|
+    headers = if elasticsearch_miscellaneous_content_type?
+                { "Content-Type" => "application/vnd.elasticsearch+x-ndjson; compatible-with=9" }
+              else
+                {}
+              end
+
+    stub_request(:post, url).with({headers: headers}) do |req|
       @index_cmds = req.body.split("\n").map {|r| JSON.parse(r) }
     end.to_return({:status => 200, :body => "", :headers => { 'Content-Type' => 'json', 'x-elastic-product' => 'Elasticsearch' } })
   end
@@ -4016,6 +4022,7 @@ class ElasticsearchOutputTest < Test::Unit::TestCase
   data('Elasticsearch 6' => [6, Fluent::Plugin::ElasticsearchOutput::DEFAULT_TYPE_NAME],
        'Elasticsearch 7' => [7, Fluent::Plugin::ElasticsearchOutput::DEFAULT_TYPE_NAME_ES_7x],
        'Elasticsearch 8' => [8, nil],
+       'Elasticsearch 9' => [9, nil],
       )
   def test_writes_to_default_type(data)
     version, index_type = data


### PR DESCRIPTION
Trying to process #1061.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [x] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

Tested with the following configuration:

```aconf
  <source>
    @type dummy
    tag "test.local"
  </source>
  <match test.local>
    @type elasticsearch
    host "localhost"
    port 9200
    scheme https
    user "elastic"
    password xxxxxx
    verify_es_version_at_startup true
    default_elasticsearch_version 9
    ca_file "http_ca.crt"
    index_name "test-logs"
    logstash_format false
    include_timestamp true
    time_key "@timestamp"
  </match>
```
