### PR TITLE
Fix memory usage

### DIFF
--- a/lib/fluent/plugin/out_elasticsearch.rb
+++ b/lib/fluent/plugin/out_elasticsearch.rb
@@ -883,11 +883,11 @@ EOC
           if split_request?(bulk_message, info)
             bulk_message.each do |info, msgs|
               send_bulk(msgs, tag, chunk, bulk_message_count[info], extracted_values, info, unpackedMsgArr[info]) unless msgs.empty?
+            ensure
               unpackedMsgArr[info].clear
               msgs.clear
               # Clear bulk_message_count for this info.
               bulk_message_count[info] = 0;
-              next
             end
           end
 
@@ -907,7 +907,7 @@ EOC
 
       bulk_message.each do |info, msgs|
         send_bulk(msgs, tag, chunk, bulk_message_count[info], extracted_values, info, unpackedMsgArr[info]) unless msgs.empty?
-
+      ensure
         unpackedMsgArr[info].clear
         msgs.clear
       end


### PR DESCRIPTION
Fix https://github.com/uken/fluent-plugin-elasticsearch/issues/1051

This PR will fix memory usage when `send_bulk` method causes exception.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [x] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)

I measured memory usage with 

* Fluentd 1.15 + fluent-plugin-elasticsearch master brunch (Shown as “before” in the graph)
* Fluentd 1.15 + this fix (Shown as “after” in the graph)

![chart](https://github.com/user-attachments/assets/e167f6d3-721d-4896-978a-87a37f949aea)


This PR has stabilized memory usage.

(if you can try to this PR, you can use https://github.com/Watson1978/test-fluentd-elasticsearch to reproduce)