### PR TITLE
releasing v5.4.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,12 @@
 
 ### [Unreleased]
 
+### 5.4.4
+- docs: Clarify README docs for template_name and templates (#1043)
+- `out_elasticsearch_data_stream`: Avoid long worrying log line at info level (#1044)
+- `out_elasticsearch_data_stream`: Support `id_key` and `remove_keys` (#1057)
+- `out_elasticsearch`: Fix memory leaks when exception was raised frequently (#1065)
+
 ### 5.4.3
 - add data_stream_template\_use\_index\_patterns\_wildcard in elasticsearch\_data\_stream (#1040)
 

--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = 'fluent-plugin-elasticsearch'
-  s.version       = '5.4.3'
+  s.version       = '5.4.4'
   s.authors       = ['diogo', 'pitr', 'Hiroshi Hatake']
   s.email         = ['pitr.vern@gmail.com', 'me@diogoterror.com', 'cosmo0920.wp@gmail.com']
   s.description   = %q{Elasticsearch output plugin for Fluent event collector}


### PR DESCRIPTION
DESCRIPTION HERE

* docs: Clarify README docs for template_name and templates (#1043)
*`out_elasticsearch_data_stream`: Avoid long worrying log line at info level (#1044)
* `out_elasticsearch_data_stream`: Support `id_key` and `remove_keys` (#1057)
* `out_elasticsearch`: Fix memory leaks when an exception was raised frequently (#1065)
