### PR TITLE
gemspec: fix elasticsearch dependency to v8

### DIFF
--- a/fluent-plugin-elasticsearch.gemspec
+++ b/fluent-plugin-elasticsearch.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'faraday', '>= 2.0.0'
   s.add_runtime_dependency 'faraday-excon', '>= 2.0.0'
   s.add_runtime_dependency 'excon', '>= 0'
-  s.add_runtime_dependency 'elasticsearch'
+  s.add_runtime_dependency 'elasticsearch', '~> 8.0'
 
 
   s.add_development_dependency 'rake', '>= 0'


### PR DESCRIPTION
* Related to #1061

It is assumed that ES8 is currently widely used.
For such users, it doesn't work correctly if installing v9.

This fix will allow users to be able to use ES8 by default.
Users who want to use ES9 will need to manually update the gem.

DESCRIPTION HERE

(check all that apply)
- [ ] tests added
- [ ] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [ ] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
