### PR TITLE
Allow duplicate keys in JSON parser

### DIFF
--- a/lib/fluent/plugin/elasticsearch_index_lifecycle_management.rb
+++ b/lib/fluent/plugin/elasticsearch_index_lifecycle_management.rb
@@ -76,6 +76,6 @@ module Fluent::Plugin::ElasticsearchIndexLifecycleManagement
 
   def default_policy_payload
     default_policy_path = File.join(__dir__, ILM_DEFAULT_POLICY_PATH)
-    JSON.parse(::IO.read(default_policy_path))
+    JSON.parse(::IO.read(default_policy_path), allow_duplicate_key: true)
   end
 end

--- a/lib/fluent/plugin/elasticsearch_index_template.rb
+++ b/lib/fluent/plugin/elasticsearch_index_template.rb
@@ -7,7 +7,7 @@ module Fluent::ElasticsearchIndexTemplate
       raise "If you specify a template_name you must specify a valid template file (checked '#{template_file}')!"
     end
     file_contents = IO.read(template_file).gsub(/\n/,'')
-    JSON.parse(file_contents)
+    JSON.parse(file_contents, allow_duplicate_key: true)
   end
 
   def get_custom_template(template_file, customize_template)
@@ -18,7 +18,7 @@ module Fluent::ElasticsearchIndexTemplate
     customize_template.each do |key, value|
       file_contents = file_contents.gsub(key,value.downcase)
     end
-    JSON.parse(file_contents)
+    JSON.parse(file_contents, allow_duplicate_key: true)
   end
 
   def template_exists?(name, host = nil)


### PR DESCRIPTION
The json gem emits a deprecation warning for duplicate keys in JSON objects and will raise `JSON::ParserError` in json 3.0 unless `allow_duplicate_key: true` is specified.

The plugin has historically accepted duplicate keys silently (last value wins).
To preserve this behavior uniformly regardless of the json gem version, this passes `allow_duplicate_key: true` to `JSON.parse`.

Note that `allow_duplicate_key` is silently ignored by json < 2.13, so this is safe with older json gem versions.

(check all that apply)
- [ ] tests added
- [x] tests passing
- [ ] README updated (if needed)
- [ ] README Table of Contents updated (if needed)
- [ ] History.md and `version` in gemspec are untouched
- [x] backward compatible
- [ ] feature works in `elasticsearch_dynamic` (not required but recommended)
